### PR TITLE
[AI] Add `visionOS 26.0` to `@available` annotations

### DIFF
--- a/FirebaseAI/Sources/Extensions/Internal/ConvertibleFromGeneratedContent+Firebase.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/ConvertibleFromGeneratedContent+Firebase.swift
@@ -15,7 +15,7 @@
 #if compiler(>=6.2.3) && canImport(FoundationModels)
   import FoundationModels
 
-  @available(iOS 26.0, macOS 26.0, *)
+  @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   public extension FoundationModels.ConvertibleFromGeneratedContent {

--- a/FirebaseAI/Sources/FirebaseAI.swift
+++ b/FirebaseAI/Sources/FirebaseAI.swift
@@ -169,7 +169,7 @@ public final class FirebaseAI: Sendable {
       ///   - tools: A list of tools that extend the capabilities of the model. These tools must be
       ///     instances conforming to `FoundationModels.Tool` for automatic function calling.
       ///   - instructions: System instructions that direct the model's behavior.
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       public func generativeModelSession(model: any LanguageModelProvider,

--- a/FirebaseAI/Sources/GenerativeModelSession.swift
+++ b/FirebaseAI/Sources/GenerativeModelSession.swift
@@ -117,7 +117,7 @@
       /// generation configuration.
       /// - Returns: A `Response` containing the generated content as `GeneratedContent`.
       /// - Throws: A `GenerationError` if the model fails to generate a response.
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       @discardableResult
@@ -153,7 +153,7 @@
       /// - Returns: A `Response` containing the generated content as the specified `Generable`
       /// type.
       /// - Throws: A `GenerationError` if the model fails to generate a response.
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       @discardableResult
@@ -183,7 +183,7 @@
       /// - Parameter options: An optional `GenerationConfig` to override the model's default
       /// generation configuration.
       /// - Returns: A `ResponseStream` that yields snapshots of the generated content.
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       func streamResponse(to prompt: PartsRepresentable...,
@@ -215,7 +215,7 @@
       /// - Parameter options: An optional `GenerationConfig` to override the model's default
       /// generation configuration.
       /// - Returns: A `ResponseStream` that yields snapshots of the generated content.
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       public func streamResponse<Content>(to prompt: PartsRepresentable...,

--- a/FirebaseAI/Sources/Protocols/Internal/ConvertibleToGeneratedContent.swift
+++ b/FirebaseAI/Sources/Protocols/Internal/ConvertibleToGeneratedContent.swift
@@ -30,7 +30,7 @@
   }
 
   #if canImport(FoundationModels)
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     extension FirebaseAI.ConvertibleToGeneratedContent

--- a/FirebaseAI/Sources/Protocols/Public/GenerationOptionsRepresentable.swift
+++ b/FirebaseAI/Sources/Protocols/Public/GenerationOptionsRepresentable.swift
@@ -44,7 +44,7 @@
   }
 
   #if canImport(FoundationModels)
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     extension FoundationModels.GenerationOptions: GenerationOptionsRepresentable {
@@ -81,7 +81,7 @@
       ///
       /// - Parameter generationOptions: Generation options for the on-device `SystemLanguageModel`
       ///   provided by the Foundation Models framework.
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       static func foundationModels(_ generationOptions: FoundationModels.GenerationOptions)
@@ -95,7 +95,7 @@
       ///   - gemini: Generation options for Gemini models.
       ///   - foundationModels: Generation options for the on-device `SystemLanguageModel` provided
       ///     by the Foundation Models framework.
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       static func hybrid(gemini: GenerationConfig,

--- a/FirebaseAI/Sources/Protocols/Public/ToolRepresentable.swift
+++ b/FirebaseAI/Sources/Protocols/Public/ToolRepresentable.swift
@@ -22,7 +22,7 @@ public protocol ToolRepresentable: Sendable {
 
 #if compiler(>=6.2.3)
   #if canImport(FoundationModels)
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     public extension FoundationModels.Tool

--- a/FirebaseAI/Sources/Tool.swift
+++ b/FirebaseAI/Sources/Tool.swift
@@ -68,7 +68,7 @@ public struct FunctionDeclaration: Sendable {
 
   #if compiler(>=6.2.3)
     #if canImport(FoundationModels)
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       init<T: FoundationModels.Tool>(foundationModelsTool: T) {
@@ -260,7 +260,7 @@ public extension ToolRepresentable where Self == FirebaseAILogic.Tool {
 
   #if compiler(>=6.2.3)
     #if canImport(FoundationModels)
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       static func autoFunctionDeclaration(_ tool: any FoundationModels.Tool) -> Tool {
@@ -341,7 +341,7 @@ public extension ToolRepresentable where Self == FirebaseAILogic.Tool {
   }
 
   #if canImport(FoundationModels)
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     extension FunctionDeclaration {

--- a/FirebaseAI/Sources/Types/Public/GenerationOptions.swift
+++ b/FirebaseAI/Sources/Types/Public/GenerationOptions.swift
@@ -65,14 +65,14 @@
         }
 
         #if canImport(FoundationModels)
-          @available(iOS 26.0, macOS 26.0, *)
+          @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
           @available(tvOS, unavailable)
           @available(watchOS, unavailable)
           init(_ samplingMode: FoundationModels.GenerationOptions.SamplingMode) {
             kind = .foundationModelsSamplingMode(samplingMode)
           }
 
-          @available(iOS 26.0, macOS 26.0, *)
+          @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
           @available(tvOS, unavailable)
           @available(watchOS, unavailable)
           var samplingMode: FoundationModels.GenerationOptions.SamplingMode {
@@ -153,7 +153,7 @@
         /// `FoundationModels.GenerationOptions`.
         ///
         /// - Parameter options: The `FoundationModels.GenerationOptions` to wrap.
-        @available(iOS 26.0, macOS 26.0, *)
+        @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
         @available(tvOS, unavailable)
         @available(watchOS, unavailable)
         public init(_ options: FoundationModels.GenerationOptions) {
@@ -163,7 +163,7 @@
           maximumResponseTokens = options.maximumResponseTokens
         }
 
-        @available(iOS 26.0, macOS 26.0, *)
+        @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
         @available(tvOS, unavailable)
         @available(watchOS, unavailable)
         func toFoundationModels() -> FoundationModels.GenerationOptions {
@@ -197,13 +197,13 @@
   }
 
   #if canImport(FoundationModels)
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     extension FoundationModels.GenerationOptions: FirebaseAI.GenerationOptions
       .GenerationOptionsProtocol {}
 
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     extension FoundationModels.GenerationOptions.SamplingMode: FirebaseAI.GenerationOptions

--- a/FirebaseAI/Sources/Types/Public/StructuredOutput/GeneratedContent.swift
+++ b/FirebaseAI/Sources/Types/Public/StructuredOutput/GeneratedContent.swift
@@ -19,7 +19,7 @@
   #endif // canImport(FoundationModels)
 
   #if canImport(FoundationModels)
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     extension FoundationModels.GeneratedContent: FirebaseAI.GeneratedContent
@@ -38,7 +38,7 @@
       public let kind: Kind
 
       #if canImport(FoundationModels)
-        @available(iOS 26.0, macOS 26.0, *)
+        @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
         @available(tvOS, unavailable)
         @available(watchOS, unavailable)
         var generatedContent: FoundationModels.GeneratedContent {
@@ -91,7 +91,7 @@
       }
 
       #if canImport(FoundationModels)
-        @available(iOS 26.0, macOS 26.0, *)
+        @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
         @available(tvOS, unavailable)
         @available(watchOS, unavailable)
         init(kind: FoundationModels.GeneratedContent.Kind, id: FirebaseAI.GenerationID? = nil,
@@ -126,7 +126,7 @@
         /// The JSON string representation of the generated content.
         ///
         /// **Public Preview**: This API is a public preview and may be subject to change.
-        @available(iOS 26.0, macOS 26.0, *)
+        @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
         @available(tvOS, unavailable)
         @available(watchOS, unavailable)
         public var jsonString: String {
@@ -146,7 +146,7 @@
         ///   - type: The type to decode the content into.
         /// - Returns: The decoded value.
         /// - Throws: An error if decoding fails.
-        @available(iOS 26.0, macOS 26.0, *)
+        @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
         @available(tvOS, unavailable)
         @available(watchOS, unavailable)
         public func value<Value>(_ type: Value.Type = Value.self) throws -> Value
@@ -165,7 +165,7 @@
         ///   - property: The name of the property to decode.
         /// - Returns: The decoded value.
         /// - Throws: An error if decoding fails or the property does not exist.
-        @available(iOS 26.0, macOS 26.0, *)
+        @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
         @available(tvOS, unavailable)
         @available(watchOS, unavailable)
         public func value<Value>(_ type: Value.Type = Value.self,
@@ -185,7 +185,7 @@
         ///   - property: The name of the property to decode.
         /// - Returns: The decoded value, or `nil` if the property does not exist or is null.
         /// - Throws: An error if decoding fails.
-        @available(iOS 26.0, macOS 26.0, *)
+        @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
         @available(tvOS, unavailable)
         @available(watchOS, unavailable)
         public func value<Value>(_ type: Value?.Type = Value?.self,
@@ -229,7 +229,7 @@
   }
 
   #if canImport(FoundationModels)
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     extension FirebaseAI.GeneratedContent: Equatable {
@@ -240,7 +240,7 @@
       }
     }
 
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     extension FirebaseAI.GeneratedContent: CustomDebugStringConvertible {
@@ -249,12 +249,12 @@
       }
     }
 
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     extension FirebaseAI.GeneratedContent.Kind: Equatable {}
 
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     extension FoundationModels.GeneratedContent.Kind {
@@ -288,7 +288,7 @@
       }
     }
 
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     extension FirebaseAI.GeneratedContent.Kind {

--- a/FirebaseAI/Sources/Types/Public/StructuredOutput/GenerationID.swift
+++ b/FirebaseAI/Sources/Types/Public/StructuredOutput/GenerationID.swift
@@ -49,7 +49,7 @@ public extension FirebaseAI {
     }
 
     #if canImport(FoundationModels)
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       var generationID: FoundationModels.GenerationID? {
@@ -64,7 +64,7 @@ public extension FirebaseAI {
 }
 
 #if canImport(FoundationModels)
-  @available(iOS 26.0, macOS 26.0, *)
+  @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   extension FoundationModels.GenerationID: FirebaseAI.GenerationID.GenerationIDProtocol {}

--- a/FirebaseAI/Sources/Types/Public/StructuredOutput/GenerationSchema.swift
+++ b/FirebaseAI/Sources/Types/Public/StructuredOutput/GenerationSchema.swift
@@ -32,7 +32,7 @@ public extension FirebaseAI {
     private let _generationSchema: (any GenerationSchemaProtocol)?
 
     #if canImport(FoundationModels)
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       var generationSchema: FoundationModels.GenerationSchema {
@@ -45,7 +45,7 @@ public extension FirebaseAI {
         return generationSchema
       }
 
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       init(_ generationSchema: FoundationModels.GenerationSchema) {

--- a/FirebaseAI/Sources/Types/Public/SystemLanguageModel.swift
+++ b/FirebaseAI/Sources/Types/Public/SystemLanguageModel.swift
@@ -31,7 +31,7 @@
       private let _systemLanguageModel: (any SystemLanguageModelProtocol)?
 
       #if canImport(FoundationModels)
-        @available(iOS 26.0, macOS 26.0, *)
+        @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
         @available(tvOS, unavailable)
         @available(watchOS, unavailable)
         var systemLanguageModel: FoundationModels.SystemLanguageModel {
@@ -115,7 +115,7 @@
         public static let contentTagging = UseCase(kind: .contentTagging)
 
         #if canImport(FoundationModels)
-          @available(iOS 26.0, macOS 26.0, *)
+          @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
           @available(tvOS, unavailable)
           @available(watchOS, unavailable)
           func toFoundationModels() -> FoundationModels.SystemLanguageModel.UseCase {
@@ -161,7 +161,7 @@
       )
 
       #if canImport(FoundationModels)
-        @available(iOS 26.0, macOS 26.0, *)
+        @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
         @available(tvOS, unavailable)
         @available(watchOS, unavailable)
         func toFoundationModels() -> FoundationModels.SystemLanguageModel.Guardrails {
@@ -272,7 +272,7 @@
       /// such as providing a `SystemLanguageModel.Adapter`.
       ///
       /// - Parameter systemLanguageModel: The `FoundationModels.SystemLanguageModel` to wrap.
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       convenience init(_ systemLanguageModel: FoundationModels.SystemLanguageModel) {
@@ -314,7 +314,7 @@
   }
 
   #if canImport(FoundationModels)
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     extension FoundationModels.SystemLanguageModel: FirebaseAI.SystemLanguageModel

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
@@ -57,7 +57,7 @@
     }
 
     @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     func respondGenerable_fallbackOnGeminiModelError(_ config: InstanceConfig) async throws {
@@ -132,7 +132,7 @@
     }
 
     @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     func streamResponseGenerable_fallbackOnGeminiModelError(_ config: InstanceConfig) async throws {

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionTests.swift
@@ -48,7 +48,7 @@
 
     #if canImport(FoundationModels)
       @Generable(description: "Basic profile information about a cat")
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       struct CatProfile {
@@ -63,7 +63,7 @@
       }
 
       @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       func respondGeneratedContent(_ config: InstanceConfig) async throws {
@@ -91,7 +91,7 @@
       }
 
       @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       func respondGenerable(_ config: InstanceConfig) async throws {
@@ -122,7 +122,7 @@
       }
 
       @Generable
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       enum Difficulty {
@@ -132,7 +132,7 @@
       }
 
       @Generable
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       enum SuggestedCourse {
@@ -142,7 +142,7 @@
       }
 
       @Generable(description: "A recipe for a delicious dish")
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       struct Recipe {
@@ -169,7 +169,7 @@
       }
 
       @Generable(description: "A list of recipes")
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       struct RecipeList {
@@ -178,7 +178,7 @@
       }
 
       @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       func respondGenerableRecipe(_ config: InstanceConfig) async throws {
@@ -206,7 +206,7 @@
       }
 
       @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       func respondGenerableRecipeList(_ config: InstanceConfig) async throws {
@@ -242,7 +242,7 @@
       }
     #endif // canImport(FoundationModels)
 
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     struct GetTemperature: FoundationModels.Tool {
@@ -272,7 +272,7 @@
     }
 
     @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     func respondTextWithAutomaticFunctionCalling(_ config: InstanceConfig) async throws {
@@ -306,7 +306,7 @@
     }
 
     @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
-    @available(iOS 26.0, macOS 26.0, *)
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     func respondGenerableWithAutomaticFunctionCalling(_ config: InstanceConfig) async throws {
@@ -403,7 +403,7 @@
 
     #if canImport(FoundationModels)
       @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       func streamResponseGeneratedContent(_ config: InstanceConfig) async throws {
@@ -458,7 +458,7 @@
       }
 
       @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       func streamResponseGenerable(_ config: InstanceConfig) async throws {
@@ -532,7 +532,7 @@
       }
 
       @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       func streamResponseTextWithAutomaticFunctionCalling(_ config: InstanceConfig) async throws {

--- a/FirebaseAI/Tests/Unit/GenerativeModelSessionTests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelSessionTests.swift
@@ -18,7 +18,7 @@
 
   @testable import FirebaseAILogic
 
-  @available(iOS 26.0, macOS 26.0, *)
+  @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
   final class GenerativeModelSessionTests: XCTestCase {

--- a/FirebaseAI/Tests/Unit/Types/GenerationOptionsTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GenerationOptionsTests.swift
@@ -22,7 +22,7 @@
 
   final class GenerationOptionsTests: XCTestCase {
     #if canImport(FoundationModels)
-      @available(iOS 26.0, macOS 26.0, *)
+      @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
       func testConversionToFoundationModels() throws {


### PR DESCRIPTION
Updated all `@available(iOS 26.0, macOS 26.0, *)` annotations to `@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)`. This is unnecessary since `visionOS 26.0` is covered by `iOS 26.0` (and diverges from the Foundation Models definitions) but this should reduce the time wasted by Gemini Code Assist asking to add `visionOS 26.0` in all reviews.

#no-changelog