### PR TITLE
[CI] Remove `OS=${xcode_version}` from `watchos_flags` in build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -179,15 +179,9 @@ else
   ios_flags=(
     -destination "platform=iOS Simulator,name=${iphone_simulator_name}"
   )
-  if [[ "$xcode_major" -ge 26 ]]; then
-    watchos_flags=(
-      -destination "platform=watchOS Simulator,OS=${xcode_version},name=Apple Watch Series 11 (42mm)"
-    )
-  else
-    watchos_flags=(
-      -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (42mm)'
-    )
-  fi
+  watchos_flags=(
+    -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (42mm)'
+  )
 fi
 
 ios_device_flags=(


### PR DESCRIPTION
Removed `OS=${xcode_version}` from `watchos_flags` when using Xcode 26.x since Xcode 26.4.1 exists but watchOS 26.4.1 does not. This will hopefully address the CI failures in https://github.com/firebase/firebase-ios-sdk/pull/16111.

#no-changelog