### PR TITLE
fix(firestore): add `noexcept` specifiers to move, swap, hash operations

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [feature] Added support for Pipeline expressions `arraySlice`, `arrayFilter`, `arrayTransform` and `arrayTransformWithIndex`. (#16001)
+- [fixed] Add missing `noexcept` specifiers to move, hash, swap operations [#16117].
 
 # 12.12.0
 - [feature] Added support for the `parent` Pipeline expression. (#16010)

--- a/Firestore/core/src/api/settings.h
+++ b/Firestore/core/src/api/settings.h
@@ -49,10 +49,10 @@ class Settings {
 
   Settings() = default;
   Settings(const Settings& other);
-  Settings(Settings&& other) = default;
+  Settings(Settings&& other) noexcept = default;
 
   Settings& operator=(const Settings& other);
-  Settings& operator=(Settings&& other) = default;
+  Settings& operator=(Settings&& other) noexcept = default;
 
   void set_host(const std::string& value) {
     host_ = value;

--- a/Firestore/core/src/core/pipeline_util.h
+++ b/Firestore/core/src/core/pipeline_util.h
@@ -202,7 +202,7 @@ namespace std {
 template <>
 struct hash<firebase::firestore::core::QueryOrPipeline> {
   size_t operator()(
-      const firebase::firestore::core::QueryOrPipeline& query) const {
+      const firebase::firestore::core::QueryOrPipeline& query) const noexcept {
     return query.Hash();
   }
 };
@@ -210,7 +210,7 @@ struct hash<firebase::firestore::core::QueryOrPipeline> {
 template <>
 struct hash<firebase::firestore::core::TargetOrPipeline> {
   size_t operator()(
-      const firebase::firestore::core::TargetOrPipeline& target) const {
+      const firebase::firestore::core::TargetOrPipeline& target) const noexcept {
     return target.Hash();
   }
 };

--- a/Firestore/core/src/core/pipeline_util.h
+++ b/Firestore/core/src/core/pipeline_util.h
@@ -209,8 +209,8 @@ struct hash<firebase::firestore::core::QueryOrPipeline> {
 
 template <>
 struct hash<firebase::firestore::core::TargetOrPipeline> {
-  size_t operator()(
-      const firebase::firestore::core::TargetOrPipeline& target) const noexcept {
+  size_t operator()(const firebase::firestore::core::TargetOrPipeline& target)
+      const noexcept {
     return target.Hash();
   }
 };

--- a/Firestore/core/src/core/query.h
+++ b/Firestore/core/src/core/query.h
@@ -329,7 +329,7 @@ namespace std {
 
 template <>
 struct hash<firebase::firestore::core::Query> {
-  size_t operator()(const firebase::firestore::core::Query& query) const {
+  size_t operator()(const firebase::firestore::core::Query& query) const noexcept {
     return query.Hash();
   }
 };

--- a/Firestore/core/src/core/query.h
+++ b/Firestore/core/src/core/query.h
@@ -329,7 +329,8 @@ namespace std {
 
 template <>
 struct hash<firebase::firestore::core::Query> {
-  size_t operator()(const firebase::firestore::core::Query& query) const noexcept {
+  size_t operator()(
+      const firebase::firestore::core::Query& query) const noexcept {
     return query.Hash();
   }
 };

--- a/Firestore/core/src/core/target.h
+++ b/Firestore/core/src/core/target.h
@@ -242,7 +242,8 @@ namespace std {
 
 template <>
 struct hash<firebase::firestore::core::Target> {
-  size_t operator()(const firebase::firestore::core::Target& target) const noexcept {
+  size_t operator()(
+      const firebase::firestore::core::Target& target) const noexcept {
     return target.Hash();
   }
 };

--- a/Firestore/core/src/core/target.h
+++ b/Firestore/core/src/core/target.h
@@ -242,7 +242,7 @@ namespace std {
 
 template <>
 struct hash<firebase::firestore::core::Target> {
-  size_t operator()(const firebase::firestore::core::Target& target) const {
+  size_t operator()(const firebase::firestore::core::Target& target) const noexcept {
     return target.Hash();
   }
 };

--- a/Firestore/core/src/immutable/sorted_map.h
+++ b/Firestore/core/src/immutable/sorted_map.h
@@ -85,7 +85,6 @@ class SortedMap : public SortedMapBase {
   }
 
   SortedMap(SortedMap&& other) noexcept : tag_{other.tag_} {
-    throw 32;
     switch (tag_) {
       case Tag::Array:
         new (&array_) array_type{std::move(other.array_)};

--- a/Firestore/core/src/immutable/sorted_map.h
+++ b/Firestore/core/src/immutable/sorted_map.h
@@ -85,6 +85,7 @@ class SortedMap : public SortedMapBase {
   }
 
   SortedMap(SortedMap&& other) noexcept : tag_{other.tag_} {
+    throw 32;
     switch (tag_) {
       case Tag::Array:
         new (&array_) array_type{std::move(other.array_)};

--- a/Firestore/core/src/model/document_key.cc
+++ b/Firestore/core/src/model/document_key.cc
@@ -121,7 +121,7 @@ absl::optional<std::string> DocumentKey::GetCollectionGroup() const {
   return path()[size - 2];
 }
 
-size_t DocumentKeyHash::operator()(const DocumentKey& key) const {
+size_t DocumentKeyHash::operator()(const DocumentKey& key) const noexcept {
   return util::Hash(key.path());
 }
 

--- a/Firestore/core/src/model/document_key.h
+++ b/Firestore/core/src/model/document_key.h
@@ -110,7 +110,7 @@ inline bool operator>=(const DocumentKey& lhs, const DocumentKey& rhs) {
 }
 
 struct DocumentKeyHash {
-  size_t operator()(const DocumentKey& key) const;
+  size_t operator()(const DocumentKey& key) const noexcept;
 };
 
 }  // namespace model

--- a/Firestore/core/src/model/overlay.cc
+++ b/Firestore/core/src/model/overlay.cc
@@ -35,7 +35,7 @@ std::ostream& operator<<(std::ostream& os, const Overlay& result) {
   return os << result.ToString();
 }
 
-std::size_t Overlay::Hash() const {
+std::size_t Overlay::Hash() const noexcept {
   if (mutation_.is_valid()) {
     return util::Hash(largest_batch_id_, mutation_);
   } else {
@@ -48,7 +48,7 @@ std::string Overlay::ToString() const {
                       ", mutation=", util::ToString(mutation_), ")");
 }
 
-std::size_t OverlayHash::operator()(const Overlay& overlay) const {
+std::size_t OverlayHash::operator()(const Overlay& overlay) const noexcept {
   return overlay.Hash();
 }
 

--- a/Firestore/core/src/model/overlay.h
+++ b/Firestore/core/src/model/overlay.h
@@ -55,7 +55,7 @@ class Overlay {
     return mutation_.key();
   }
 
-  std::size_t Hash() const;
+  std::size_t Hash() const noexcept;
 
   std::string ToString() const;
 
@@ -76,7 +76,7 @@ inline bool operator!=(const Overlay& lhs, const Overlay& rhs) {
 std::ostream& operator<<(std::ostream&, const Overlay&);
 
 struct OverlayHash {
-  std::size_t operator()(const Overlay&) const;
+  std::size_t operator()(const Overlay&) const noexcept;
 };
 
 }  // namespace model

--- a/Firestore/core/src/remote/bloom_filter.h
+++ b/Firestore/core/src/remote/bloom_filter.h
@@ -34,7 +34,7 @@ class BloomFilter final {
   BloomFilter(const BloomFilter&) = default;
   BloomFilter(BloomFilter&&) noexcept = default;
   BloomFilter& operator=(const BloomFilter&) = default;
-  BloomFilter& operator=(BloomFilter&&) = default;
+  BloomFilter& operator=(BloomFilter&&) noexcept = default;
 
   /**
    * Creates a BloomFilter object or returns a status.

--- a/Firestore/core/src/remote/bloom_filter.h
+++ b/Firestore/core/src/remote/bloom_filter.h
@@ -32,7 +32,7 @@ class BloomFilter final {
 
   // Copyable & movable.
   BloomFilter(const BloomFilter&) = default;
-  BloomFilter(BloomFilter&&) = default;
+  BloomFilter(BloomFilter&&) noexcept = default;
   BloomFilter& operator=(const BloomFilter&) = default;
   BloomFilter& operator=(BloomFilter&&) = default;
 

--- a/Firestore/core/src/util/random_access_queue.h
+++ b/Firestore/core/src/util/random_access_queue.h
@@ -56,7 +56,7 @@ class RandomAccessQueue {
     PushBackAll(other);
   }
 
-  RandomAccessQueue(RandomAccessQueue&& other) = default;
+  RandomAccessQueue(RandomAccessQueue&& other) noexcept = default;
 
   RandomAccessQueue& operator=(const RandomAccessQueue& other) {
     queue_.clear();
@@ -65,7 +65,7 @@ class RandomAccessQueue {
     return *this;
   }
 
-  RandomAccessQueue& operator=(RandomAccessQueue&& other) = default;
+  RandomAccessQueue& operator=(RandomAccessQueue&& other) noexcept = default;
 
   /**
    * Adds an element to the back of this queue, if it is not already present.

--- a/Firestore/core/test/unit/remote/bloom_filter_test.cc
+++ b/Firestore/core/test/unit/remote/bloom_filter_test.cc
@@ -37,6 +37,9 @@ using util::Path;
 using util::Status;
 using util::StatusOr;
 
+static_assert(std::is_nothrow_move_constructible<BloomFilter>::value, "BloomFilter must be nothrow move constructible");
+static_assert(std::is_nothrow_move_assignable<BloomFilter>::value, "BloomFilter must be nothrow move assignable");
+
 TEST(BloomFilterUnitTest, CanInstantiateEmptyBloomFilter) {
   BloomFilter bloom_filter(ByteString{}, 0, 0);
   EXPECT_EQ(bloom_filter.bit_count(), 0);

--- a/Firestore/core/test/unit/remote/bloom_filter_test.cc
+++ b/Firestore/core/test/unit/remote/bloom_filter_test.cc
@@ -37,8 +37,10 @@ using util::Path;
 using util::Status;
 using util::StatusOr;
 
-static_assert(std::is_nothrow_move_constructible<BloomFilter>::value, "BloomFilter must be nothrow move constructible");
-static_assert(std::is_nothrow_move_assignable<BloomFilter>::value, "BloomFilter must be nothrow move assignable");
+static_assert(std::is_nothrow_move_constructible<BloomFilter>::value,
+              "BloomFilter must be nothrow move constructible");
+static_assert(std::is_nothrow_move_assignable<BloomFilter>::value,
+              "BloomFilter must be nothrow move assignable");
 
 TEST(BloomFilterUnitTest, CanInstantiateEmptyBloomFilter) {
   BloomFilter bloom_filter(ByteString{}, 0, 0);


### PR DESCRIPTION
[b/269108721](b/269108721)

Adds `noexcept` specifiers to move, swap, and hash operations throughout the SDK.

According the C++ Core Guidelines, move, swap, and hash operations should be `noexcept`.
If move operations are throwable, many std lib containers that use these objects will fall back to using copy semantics, degrading performance.

I used grep to attempt to locate all instances of these operations that did not have the `noexcept` specifiers.

Command:
```
rg --pcre2 -n -g '*.{h,cc}' '\b(?:friend\s+)?(?:void|size_t|std::size_t|auto)\s+(?:swap|hash|operator\s*\(\))\s*\(' | rg -v 'noexcept'
```

Notes:
- Default move constructors are nothrow. I added `noexcept` anyway to be more explicit.
- Some of the hash operations **are** throwable. For example, some hash functions call functions like `absl::StrCat` which can throw `std::bad_alloc` if memory can't be allocated (OOM). If we label these hash operations as `noexcept`, and then a `std::bad_alloc` is thrown, then `std::terminate` will be called [1]. **This is ok, since OOM conditions are already fatal and cause apps to crash.**

[1] _Whenever an exception is thrown and the search for a handler encounters the outermost block of a non-throwing function, the function std::terminate is called_ https://en.cppreference.com/cpp/language/noexcept_spec