### PR TITLE
[AI] Add `hybrid` tag in `x-goog-api-client` header

### DIFF
--- a/FirebaseAI/Sources/GenerativeAIService.swift
+++ b/FirebaseAI/Sources/GenerativeAIService.swift
@@ -181,8 +181,12 @@ struct GenerativeAIService {
     if let bundleID = Bundle.main.bundleIdentifier {
       urlRequest.setValue(bundleID, forHTTPHeaderField: "x-ios-bundle-identifier")
     }
+    var apiClientHeaders = [GenerativeAIService.languageTag, GenerativeAIService.firebaseVersionTag]
+    if TaskLocals.isHybridRequest {
+      apiClientHeaders.append("hybrid")
+    }
     urlRequest.setValue(
-      "\(GenerativeAIService.languageTag) \(GenerativeAIService.firebaseVersionTag)",
+      apiClientHeaders.joined(separator: " "),
       forHTTPHeaderField: "x-goog-api-client"
     )
     urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/FirebaseAI/Sources/TaskLocals.swift
+++ b/FirebaseAI/Sources/TaskLocals.swift
@@ -1,0 +1,26 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// A container for task-local values used within the Firebase AI Logic SDK.
+///
+/// See https://developer.apple.com/documentation/swift/tasklocal for more details about
+// `TaskLocal` values in Swift.
+enum TaskLocals {
+  /// A task-local value indicating whether the current request is a hybrid request.
+  ///
+  /// This is used to pass context down the call stack without modifying function signatures.
+  @TaskLocal static var isHybridRequest = false
+}

--- a/FirebaseAI/Sources/TaskLocals.swift
+++ b/FirebaseAI/Sources/TaskLocals.swift
@@ -17,7 +17,7 @@ import Foundation
 /// A container for task-local values used within the Firebase AI Logic SDK.
 ///
 /// See https://developer.apple.com/documentation/swift/tasklocal for more details about
-// `TaskLocal` values in Swift.
+/// `TaskLocal` values in Swift.
 enum TaskLocals {
   /// A task-local value indicating whether the current request is a hybrid request.
   ///

--- a/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
@@ -42,38 +42,40 @@
     func _respond(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
                   includeSchemaInPrompt: Bool, options: any GenerationOptionsRepresentable)
       async throws -> _ModelSessionResponse {
-      // If the secondary session contains history then a previous fallback occurred.
-      // Stick with the secondary session to maintain conversation consistency.
-      if secondary._hasHistory {
-        return try await secondary._respond(
-          to: prompt,
-          schema: schema,
-          includeSchemaInPrompt: includeSchemaInPrompt,
-          options: options
-        )
-      }
-
-      do {
-        // First try the primary session.
-        return try await primary._respond(
-          to: prompt,
-          schema: schema,
-          includeSchemaInPrompt: includeSchemaInPrompt,
-          options: options
-        )
-      } catch {
-        // Do not fallback to second session if the primary session contains history.
-        if primary._hasHistory {
-          throw error
+      return try await TaskLocals.$isHybridRequest.withValue(true) {
+        // If the secondary session contains history then a previous fallback occurred.
+        // Stick with the secondary session to maintain conversation consistency.
+        if secondary._hasHistory {
+          return try await secondary._respond(
+            to: prompt,
+            schema: schema,
+            includeSchemaInPrompt: includeSchemaInPrompt,
+            options: options
+          )
         }
 
-        // Fallback to the second session if the first fails or is unavailable.
-        return try await secondary._respond(
-          to: prompt,
-          schema: schema,
-          includeSchemaInPrompt: includeSchemaInPrompt,
-          options: options
-        )
+        do {
+          // First try the primary session.
+          return try await primary._respond(
+            to: prompt,
+            schema: schema,
+            includeSchemaInPrompt: includeSchemaInPrompt,
+            options: options
+          )
+        } catch {
+          // Do not fallback to second session if the primary session contains history.
+          if primary._hasHistory {
+            throw error
+          }
+
+          // Fallback to the second session if the first fails or is unavailable.
+          return try await secondary._respond(
+            to: prompt,
+            schema: schema,
+            includeSchemaInPrompt: includeSchemaInPrompt,
+            options: options
+          )
+        }
       }
     }
 
@@ -90,61 +92,63 @@
                          includeSchemaInPrompt: Bool,
                          options: any GenerationOptionsRepresentable)
       -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
-      // If the secondary session contains history then a previous fallback occurred.
-      // Stick with the secondary session to maintain conversation consistency.
-      if secondary._hasHistory {
-        return secondary._streamResponse(
-          to: prompt,
-          schema: schema,
-          includeSchemaInPrompt: includeSchemaInPrompt,
-          options: options
-        )
-      }
-
-      return AsyncThrowingStream { continuation in
-        let task = Task {
-          // First try the primary session.
-          let stream = primary._streamResponse(
+      return TaskLocals.$isHybridRequest.withValue(true) {
+        // If the secondary session contains history then a previous fallback occurred.
+        // Stick with the secondary session to maintain conversation consistency.
+        if secondary._hasHistory {
+          return secondary._streamResponse(
             to: prompt,
             schema: schema,
             includeSchemaInPrompt: includeSchemaInPrompt,
             options: options
           )
+        }
 
-          var didYield = false
-          do {
-            for try await snapshot in stream {
-              didYield = true
-              continuation.yield(snapshot)
-            }
-            continuation.finish()
-          } catch {
-            // Do not fallback to second session if the primary session contains history or has
-            // already yielded data.
-            if didYield || primary._hasHistory {
-              continuation.finish(throwing: error)
-              return
-            }
-
-            // Fallback to the second session if the first fails or is unavailable.
-            let stream = secondary._streamResponse(
+        return AsyncThrowingStream { continuation in
+          let task = Task {
+            // First try the primary session.
+            let stream = primary._streamResponse(
               to: prompt,
               schema: schema,
               includeSchemaInPrompt: includeSchemaInPrompt,
               options: options
             )
 
+            var didYield = false
             do {
               for try await snapshot in stream {
+                didYield = true
                 continuation.yield(snapshot)
               }
               continuation.finish()
             } catch {
-              continuation.finish(throwing: error)
+              // Do not fallback to second session if the primary session contains history or has
+              // already yielded data.
+              if didYield || primary._hasHistory {
+                continuation.finish(throwing: error)
+                return
+              }
+
+              // Fallback to the second session if the first fails or is unavailable.
+              let stream = secondary._streamResponse(
+                to: prompt,
+                schema: schema,
+                includeSchemaInPrompt: includeSchemaInPrompt,
+                options: options
+              )
+
+              do {
+                for try await snapshot in stream {
+                  continuation.yield(snapshot)
+                }
+                continuation.finish()
+              } catch {
+                continuation.finish(throwing: error)
+              }
             }
           }
+          continuation.onTermination = { _ in task.cancel() }
         }
-        continuation.onTermination = { _ in task.cancel() }
       }
     }
   }

--- a/FirebaseAI/Tests/Unit/GenerativeModelSessionTests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelSessionTests.swift
@@ -556,6 +556,67 @@
       XCTAssertEqual(functionResponse.response, ["result": .string(CurrentTimeTool.currentTime)])
     }
 
+    func testRespondTo_hybridHeader() async throws {
+      let model1 = try mockGeminiModel(modelName: "test-model-1")
+      let model2 = try mockGeminiModel(modelName: "test-model-2")
+      let session = GenerativeModelSession(model: HybridModel(primary: model1, secondary: model2))
+
+      let bundle = BundleTestUtil.bundle()
+      let fileURL = try XCTUnwrap(bundle.url(
+        forResource: "unary-success-thinking-reply-thought-summary",
+        withExtension: "json",
+        subdirectory: googleAISubdirectory
+      ))
+
+      MockURLProtocol.requestHandler = { request in
+        let apiClientHeader = try XCTUnwrap(request.value(forHTTPHeaderField: "x-goog-api-client"))
+        let apiClientTags = apiClientHeader.components(separatedBy: " ")
+
+        XCTAssertTrue(apiClientTags.contains("hybrid"), "Header was: \(apiClientTags)")
+
+        let requestURL = try XCTUnwrap(request.url)
+        let response = try XCTUnwrap(HTTPURLResponse(
+          url: requestURL,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        ))
+        return (response, fileURL.lines)
+      }
+
+      _ = try await session.respond(to: testPrompt)
+    }
+
+    func testRespondTo_noHybridHeader() async throws {
+      let model = try mockGeminiModel()
+      let session = GenerativeModelSession(model: model)
+
+      let bundle = BundleTestUtil.bundle()
+      let fileURL = try XCTUnwrap(bundle.url(
+        forResource: "unary-success-thinking-reply-thought-summary",
+        withExtension: "json",
+        subdirectory: googleAISubdirectory
+      ))
+
+      MockURLProtocol.requestHandler = { request in
+        let apiClientHeader = try XCTUnwrap(request.value(forHTTPHeaderField: "x-goog-api-client"))
+        let apiClientTags = apiClientHeader.components(separatedBy: " ")
+
+        XCTAssertFalse(apiClientTags.contains("hybrid"), "Header was: \(apiClientTags)")
+
+        let requestURL = try XCTUnwrap(request.url)
+        let response = try XCTUnwrap(HTTPURLResponse(
+          url: requestURL,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        ))
+        return (response, fileURL.lines)
+      }
+
+      _ = try await session.respond(to: testPrompt)
+    }
+
     // MARK: - Helper Utilities
 
     func mockGeminiModel(modelName: String? = nil, modelResourceName: String? = nil,


### PR DESCRIPTION
Added a `hybrid` tag in the `x-goog-api-client` header for requests that originate from the `HybridModelSession` class. This uses a [`TaskLocal`](https://developer.apple.com/documentation/swift/tasklocal) value to pass this request information from `HybridModelSession` to `GenerativeAIService` through `Task` context while avoiding major internal refactoring.

#no-changelog