### PR TITLE
[AI] Lazily initialize sessions in `HybridModelSession`

### DIFF
--- a/FirebaseAI/Sources/TaskLocals.swift
+++ b/FirebaseAI/Sources/TaskLocals.swift
@@ -1,0 +1,26 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// A container for task-local values used within the Firebase AI Logic SDK.
+///
+/// See https://developer.apple.com/documentation/swift/tasklocal for more details about
+/// `TaskLocal` values in Swift.
+enum TaskLocals {
+  /// A task-local value indicating whether the current request is a hybrid request.
+  ///
+  /// This is used to pass context down the call stack without modifying function signatures.
+  @TaskLocal static var isHybridRequest = false
+}

--- a/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
@@ -13,20 +13,32 @@
 // limitations under the License.
 
 #if compiler(>=6.2.3)
-  final class HybridModelSession: _ModelSession {
-    private let primary: any _ModelSession
-    private let secondary: any _ModelSession
+  private import FirebaseCoreInternal
 
-    init(primary: any _ModelSession, secondary: any _ModelSession) {
-      self.primary = primary
-      self.secondary = secondary
+  final class HybridModelSession: _ModelSession {
+    private let primaryModel: any LanguageModel
+    private let secondaryModel: any LanguageModel
+    private let tools: [any ToolRepresentable]?
+    private let instructions: String?
+
+    private let lock: UnfairLock<(primary: (any _ModelSession)?, secondary: (any _ModelSession)?)>
+
+    init(primaryModel: any LanguageModel, secondaryModel: any LanguageModel,
+         tools: [any ToolRepresentable]?, instructions: String?) {
+      self.primaryModel = primaryModel
+      self.secondaryModel = secondaryModel
+      self.tools = tools
+      self.instructions = instructions
+      lock = UnfairLock((primary: nil, secondary: nil))
     }
 
     /// Returns `true` if the session has history (i.e., it has already had one or more chat turns).
     ///
     /// > Important: This property is for **internal use only** and may change at any time.
     var _hasHistory: Bool {
-      return primary._hasHistory || secondary._hasHistory
+      return lock.withLock { state in
+        state.primary?._hasHistory == true || state.secondary?._hasHistory == true
+      }
     }
 
     /// Sends a prompt to the model and returns a ``_ModelSessionResponse``.
@@ -44,8 +56,12 @@
       async throws -> _ModelSessionResponse {
       // If the secondary session contains history then a previous fallback occurred.
       // Stick with the secondary session to maintain conversation consistency.
-      if secondary._hasHistory {
-        return try await secondary._respond(
+      let useSecondary = lock.withLock { state in
+        state.secondary?._hasHistory == true
+      }
+      if useSecondary {
+        let secondarySession = try getSecondarySession()
+        return try await secondarySession._respond(
           to: prompt,
           schema: schema,
           includeSchemaInPrompt: includeSchemaInPrompt,
@@ -55,7 +71,8 @@
 
       do {
         // First try the primary session.
-        return try await primary._respond(
+        let primarySession = try getPrimarySession()
+        return try await primarySession._respond(
           to: prompt,
           schema: schema,
           includeSchemaInPrompt: includeSchemaInPrompt,
@@ -63,12 +80,16 @@
         )
       } catch {
         // Do not fallback to second session if the primary session contains history.
-        if primary._hasHistory {
+        let primaryHasHistory = lock.withLock { state in
+          state.primary?._hasHistory == true
+        }
+        if primaryHasHistory {
           throw error
         }
 
         // Fallback to the second session if the first fails or is unavailable.
-        return try await secondary._respond(
+        let secondarySession = try getSecondarySession()
+        return try await secondarySession._respond(
           to: prompt,
           schema: schema,
           includeSchemaInPrompt: includeSchemaInPrompt,
@@ -92,49 +113,85 @@
       -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
       // If the secondary session contains history then a previous fallback occurred.
       // Stick with the secondary session to maintain conversation consistency.
-      if secondary._hasHistory {
-        return secondary._streamResponse(
-          to: prompt,
-          schema: schema,
-          includeSchemaInPrompt: includeSchemaInPrompt,
-          options: options
-        )
+      let useSecondary = lock.withLock { state in
+        state.secondary?._hasHistory == true
       }
-
-      return AsyncThrowingStream { continuation in
-        let task = Task {
-          // First try the primary session.
-          let stream = primary._streamResponse(
+      if useSecondary {
+        do {
+          let secondarySession = try getSecondarySession()
+          return secondarySession._streamResponse(
             to: prompt,
             schema: schema,
             includeSchemaInPrompt: includeSchemaInPrompt,
             options: options
           )
+        } catch {
+          return AsyncThrowingStream { continuation in
+            continuation.finish(throwing: error)
+          }
+        }
+      }
 
-          var didYield = false
+      return AsyncThrowingStream { continuation in
+        let task = Task {
           do {
-            for try await snapshot in stream {
-              didYield = true
-              continuation.yield(snapshot)
-            }
-            continuation.finish()
-          } catch {
-            // Do not fallback to second session if the primary session contains history or has
-            // already yielded data.
-            if didYield || primary._hasHistory {
-              continuation.finish(throwing: error)
-              return
-            }
-
-            // Fallback to the second session if the first fails or is unavailable.
-            let stream = secondary._streamResponse(
+            // First try the primary session.
+            let primarySession = try self.getPrimarySession()
+            let stream = primarySession._streamResponse(
               to: prompt,
               schema: schema,
               includeSchemaInPrompt: includeSchemaInPrompt,
               options: options
             )
 
+            var didYield = false
             do {
+              for try await snapshot in stream {
+                didYield = true
+                continuation.yield(snapshot)
+              }
+              continuation.finish()
+            } catch {
+              // Do not fallback to second session if the primary session contains history or has
+              // already yielded data.
+              let primaryHasHistory = self.lock.withLock { state in
+                state.primary?._hasHistory == true
+              }
+              if didYield || primaryHasHistory {
+                continuation.finish(throwing: error)
+                return
+              }
+
+              // Fallback to the second session if the first fails or is unavailable.
+              let secondarySession = try self.getSecondarySession()
+              let stream = secondarySession._streamResponse(
+                to: prompt,
+                schema: schema,
+                includeSchemaInPrompt: includeSchemaInPrompt,
+                options: options
+              )
+
+              do {
+                for try await snapshot in stream {
+                  continuation.yield(snapshot)
+                }
+                continuation.finish()
+              } catch {
+                continuation.finish(throwing: error)
+              }
+            }
+          } catch {
+            // Failure to create primary session.
+            // Fallback to the second session if the first fails or is unavailable.
+            do {
+              let secondarySession = try self.getSecondarySession()
+              let stream = secondarySession._streamResponse(
+                to: prompt,
+                schema: schema,
+                includeSchemaInPrompt: includeSchemaInPrompt,
+                options: options
+              )
+
               for try await snapshot in stream {
                 continuation.yield(snapshot)
               }
@@ -145,6 +202,28 @@
           }
         }
         continuation.onTermination = { _ in task.cancel() }
+      }
+    }
+
+    private func getPrimarySession() throws -> any _ModelSession {
+      try lock.withLock { state in
+        if let session = state.primary {
+          return session
+        }
+        let session = try primaryModel._startSession(tools: tools, instructions: instructions)
+        state.primary = session
+        return session
+      }
+    }
+
+    private func getSecondarySession() throws -> any _ModelSession {
+      try lock.withLock { state in
+        if let session = state.secondary {
+          return session
+        }
+        let session = try secondaryModel._startSession(tools: tools, instructions: instructions)
+        state.secondary = session
+        return session
       }
     }
   }

--- a/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
@@ -21,7 +21,8 @@
     private let tools: [any ToolRepresentable]?
     private let instructions: String?
 
-    private let lock: UnfairLock<(primary: (any _ModelSession)?, secondary: (any _ModelSession)?)>
+    typealias SessionState = (primary: (any _ModelSession)?, secondary: (any _ModelSession)?)
+    private let lock: UnfairLock<SessionState>
 
     init(primaryModel: any LanguageModel, secondaryModel: any LanguageModel,
          tools: [any ToolRepresentable]?, instructions: String?) {
@@ -30,6 +31,11 @@
       self.tools = tools
       self.instructions = instructions
       lock = UnfairLock((primary: nil, secondary: nil))
+    }
+
+    enum SessionModel {
+      case primaryModel
+      case secondaryModel
     }
 
     /// Returns `true` if the session has history (i.e., it has already had one or more chat turns).
@@ -61,7 +67,7 @@
           state.secondary?._hasHistory == true
         }
         if useSecondary {
-          let secondarySession = try getSecondarySession()
+          let secondarySession = try getSession(for: .secondaryModel)
           return try await secondarySession._respond(
             to: prompt,
             schema: schema,
@@ -72,7 +78,7 @@
 
         do {
           // First try the primary session.
-          let primarySession = try getPrimarySession()
+          let primarySession = try getSession(for: .primaryModel)
           return try await primarySession._respond(
             to: prompt,
             schema: schema,
@@ -89,7 +95,7 @@
           }
 
           // Fallback to the second session if the first fails or is unavailable.
-          let secondarySession = try getSecondarySession()
+          let secondarySession = try getSession(for: .secondaryModel)
           return try await secondarySession._respond(
             to: prompt,
             schema: schema,
@@ -121,7 +127,7 @@
         }
         if useSecondary {
           do {
-            let secondarySession = try getSecondarySession()
+            let secondarySession = try getSession(for: .secondaryModel)
             return secondarySession._streamResponse(
               to: prompt,
               schema: schema,
@@ -139,7 +145,7 @@
           let task = Task {
             do {
               // First try the primary session.
-              let primarySession = try self.getPrimarySession()
+              let primarySession = try self.getSession(for: .primaryModel)
               let stream = primarySession._streamResponse(
                 to: prompt,
                 schema: schema,
@@ -166,7 +172,7 @@
                 }
 
                 // Fallback to the second session if the first fails or is unavailable.
-                let secondarySession = try self.getSecondarySession()
+                let secondarySession = try self.getSession(for: .secondaryModel)
                 let stream = secondarySession._streamResponse(
                   to: prompt,
                   schema: schema,
@@ -187,7 +193,7 @@
               // Failure to create primary session.
               // Fallback to the second session if the first fails or is unavailable.
               do {
-                let secondarySession = try self.getSecondarySession()
+                let secondarySession = try self.getSession(for: .secondaryModel)
                 let stream = secondarySession._streamResponse(
                   to: prompt,
                   schema: schema,
@@ -209,24 +215,29 @@
       }
     }
 
-    private func getPrimarySession() throws -> any _ModelSession {
-      try lock.withLock { state in
-        if let session = state.primary {
-          return session
-        }
-        let session = try primaryModel._startSession(tools: tools, instructions: instructions)
-        state.primary = session
-        return session
-      }
-    }
+    private func getSession(for model: SessionModel) throws -> any _ModelSession {
+      let languageModel = (model == .primaryModel) ? primaryModel : secondaryModel
 
-    private func getSecondarySession() throws -> any _ModelSession {
-      try lock.withLock { state in
-        if let session = state.secondary {
-          return session
+      // 1. Check if it exists under lock.
+      let existing = lock.withLock { state in
+        (model == .primaryModel) ? state.primary : state.secondary
+      }
+      if let existing {
+        return existing
+      }
+
+      // 2. Create it outside the lock.
+      let session = try languageModel._startSession(tools: tools, instructions: instructions)
+
+      // 3. Try to store it under lock.
+      return lock.withLock { state in
+        if model == .primaryModel {
+          if let existing = state.primary { return existing }
+          state.primary = session
+        } else {
+          if let existing = state.secondary { return existing }
+          state.secondary = session
         }
-        let session = try secondaryModel._startSession(tools: tools, instructions: instructions)
-        state.secondary = session
         return session
       }
     }

--- a/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
@@ -86,6 +86,10 @@
             options: options
           )
         } catch {
+          if Task.isCancelled || error is CancellationError {
+            throw error
+          }
+
           // Do not fallback to second session if the primary session contains history.
           let primaryHasHistory = lock.withLock { state in
             state.primary?._hasHistory == true
@@ -161,6 +165,11 @@
                 }
                 continuation.finish()
               } catch {
+                if Task.isCancelled || error is CancellationError {
+                  continuation.finish(throwing: error)
+                  return
+                }
+
                 // Do not fallback to second session if the primary session contains history or has
                 // already yielded data.
                 let primaryHasHistory = self.lock.withLock { state in
@@ -190,6 +199,11 @@
                 }
               }
             } catch {
+              if Task.isCancelled || error is CancellationError {
+                continuation.finish(throwing: error)
+                return
+              }
+
               // Failure to create primary session.
               // Fallback to the second session if the first fails or is unavailable.
               do {

--- a/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
@@ -54,47 +54,49 @@
     func _respond(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
                   includeSchemaInPrompt: Bool, options: any GenerationOptionsRepresentable)
       async throws -> _ModelSessionResponse {
-      // If the secondary session contains history then a previous fallback occurred.
-      // Stick with the secondary session to maintain conversation consistency.
-      let useSecondary = lock.withLock { state in
-        state.secondary?._hasHistory == true
-      }
-      if useSecondary {
-        let secondarySession = try getSecondarySession()
-        return try await secondarySession._respond(
-          to: prompt,
-          schema: schema,
-          includeSchemaInPrompt: includeSchemaInPrompt,
-          options: options
-        )
-      }
-
-      do {
-        // First try the primary session.
-        let primarySession = try getPrimarySession()
-        return try await primarySession._respond(
-          to: prompt,
-          schema: schema,
-          includeSchemaInPrompt: includeSchemaInPrompt,
-          options: options
-        )
-      } catch {
-        // Do not fallback to second session if the primary session contains history.
-        let primaryHasHistory = lock.withLock { state in
-          state.primary?._hasHistory == true
+      return try await TaskLocals.$isHybridRequest.withValue(true) {
+        // If the secondary session contains history then a previous fallback occurred.
+        // Stick with the secondary session to maintain conversation consistency.
+        let useSecondary = lock.withLock { state in
+          state.secondary?._hasHistory == true
         }
-        if primaryHasHistory {
-          throw error
+        if useSecondary {
+          let secondarySession = try getSecondarySession()
+          return try await secondarySession._respond(
+            to: prompt,
+            schema: schema,
+            includeSchemaInPrompt: includeSchemaInPrompt,
+            options: options
+          )
         }
 
-        // Fallback to the second session if the first fails or is unavailable.
-        let secondarySession = try getSecondarySession()
-        return try await secondarySession._respond(
-          to: prompt,
-          schema: schema,
-          includeSchemaInPrompt: includeSchemaInPrompt,
-          options: options
-        )
+        do {
+          // First try the primary session.
+          let primarySession = try getPrimarySession()
+          return try await primarySession._respond(
+            to: prompt,
+            schema: schema,
+            includeSchemaInPrompt: includeSchemaInPrompt,
+            options: options
+          )
+        } catch {
+          // Do not fallback to second session if the primary session contains history.
+          let primaryHasHistory = lock.withLock { state in
+            state.primary?._hasHistory == true
+          }
+          if primaryHasHistory {
+            throw error
+          }
+
+          // Fallback to the second session if the first fails or is unavailable.
+          let secondarySession = try getSecondarySession()
+          return try await secondarySession._respond(
+            to: prompt,
+            schema: schema,
+            includeSchemaInPrompt: includeSchemaInPrompt,
+            options: options
+          )
+        }
       }
     }
 
@@ -111,67 +113,88 @@
                          includeSchemaInPrompt: Bool,
                          options: any GenerationOptionsRepresentable)
       -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
-      // If the secondary session contains history then a previous fallback occurred.
-      // Stick with the secondary session to maintain conversation consistency.
-      let useSecondary = lock.withLock { state in
-        state.secondary?._hasHistory == true
-      }
-      if useSecondary {
-        do {
-          let secondarySession = try getSecondarySession()
-          return secondarySession._streamResponse(
-            to: prompt,
-            schema: schema,
-            includeSchemaInPrompt: includeSchemaInPrompt,
-            options: options
-          )
-        } catch {
-          return AsyncThrowingStream { continuation in
-            continuation.finish(throwing: error)
-          }
+      return TaskLocals.$isHybridRequest.withValue(true) {
+        // If the secondary session contains history then a previous fallback occurred.
+        // Stick with the secondary session to maintain conversation consistency.
+        let useSecondary = lock.withLock { state in
+          state.secondary?._hasHistory == true
         }
-      }
-
-      return AsyncThrowingStream { continuation in
-        let task = Task {
+        if useSecondary {
           do {
-            // First try the primary session.
-            let primarySession = try self.getPrimarySession()
-            let stream = primarySession._streamResponse(
+            let secondarySession = try getSecondarySession()
+            return secondarySession._streamResponse(
               to: prompt,
               schema: schema,
               includeSchemaInPrompt: includeSchemaInPrompt,
               options: options
             )
+          } catch {
+            return AsyncThrowingStream { continuation in
+              continuation.finish(throwing: error)
+            }
+          }
+        }
 
-            var didYield = false
+        return AsyncThrowingStream { continuation in
+          let task = Task {
             do {
-              for try await snapshot in stream {
-                didYield = true
-                continuation.yield(snapshot)
-              }
-              continuation.finish()
-            } catch {
-              // Do not fallback to second session if the primary session contains history or has
-              // already yielded data.
-              let primaryHasHistory = self.lock.withLock { state in
-                state.primary?._hasHistory == true
-              }
-              if didYield || primaryHasHistory {
-                continuation.finish(throwing: error)
-                return
-              }
-
-              // Fallback to the second session if the first fails or is unavailable.
-              let secondarySession = try self.getSecondarySession()
-              let stream = secondarySession._streamResponse(
+              // First try the primary session.
+              let primarySession = try self.getPrimarySession()
+              let stream = primarySession._streamResponse(
                 to: prompt,
                 schema: schema,
                 includeSchemaInPrompt: includeSchemaInPrompt,
                 options: options
               )
 
+              var didYield = false
               do {
+                for try await snapshot in stream {
+                  didYield = true
+                  continuation.yield(snapshot)
+                }
+                continuation.finish()
+              } catch {
+                // Do not fallback to second session if the primary session contains history or has
+                // already yielded data.
+                let primaryHasHistory = self.lock.withLock { state in
+                  state.primary?._hasHistory == true
+                }
+                if didYield || primaryHasHistory {
+                  continuation.finish(throwing: error)
+                  return
+                }
+
+                // Fallback to the second session if the first fails or is unavailable.
+                let secondarySession = try self.getSecondarySession()
+                let stream = secondarySession._streamResponse(
+                  to: prompt,
+                  schema: schema,
+                  includeSchemaInPrompt: includeSchemaInPrompt,
+                  options: options
+                )
+
+                do {
+                  for try await snapshot in stream {
+                    continuation.yield(snapshot)
+                  }
+                  continuation.finish()
+                } catch {
+                  continuation.finish(throwing: error)
+                }
+              }
+            } catch {
+              // Failure to create primary session.
+              // Fallback to the second session if the first fails or is unavailable.
+              do {
+                let secondarySession = try self.getSecondarySession()
+                let stream = secondarySession._streamResponse(
+                  to: prompt,
+                  schema: schema,
+                  includeSchemaInPrompt: includeSchemaInPrompt,
+                  options: options
+                )
+
                 for try await snapshot in stream {
                   continuation.yield(snapshot)
                 }
@@ -180,28 +203,9 @@
                 continuation.finish(throwing: error)
               }
             }
-          } catch {
-            // Failure to create primary session.
-            // Fallback to the second session if the first fails or is unavailable.
-            do {
-              let secondarySession = try self.getSecondarySession()
-              let stream = secondarySession._streamResponse(
-                to: prompt,
-                schema: schema,
-                includeSchemaInPrompt: includeSchemaInPrompt,
-                options: options
-              )
-
-              for try await snapshot in stream {
-                continuation.yield(snapshot)
-              }
-              continuation.finish()
-            } catch {
-              continuation.finish(throwing: error)
-            }
           }
+          continuation.onTermination = { _ in task.cancel() }
         }
-        continuation.onTermination = { _ in task.cancel() }
       }
     }
 

--- a/FirebaseAI/Sources/Types/Public/HybridModel.swift
+++ b/FirebaseAI/Sources/Types/Public/HybridModel.swift
@@ -46,41 +46,12 @@
     /// > Important: This method is for **internal use only** and may change at any time.
     public func _startSession(tools: [any ToolRepresentable]?,
                               instructions: String?) throws -> any _ModelSession {
-      var primarySession: (any _ModelSession)?
-      var primaryError: Error?
-      var secondarySession: (any _ModelSession)?
-      var secondaryError: Error?
-
-      do {
-        primarySession = try primary._startSession(tools: tools, instructions: instructions)
-      } catch {
-        primaryError = error
-      }
-
-      do {
-        secondarySession = try secondary._startSession(tools: tools, instructions: instructions)
-      } catch {
-        secondaryError = error
-      }
-
-      if let primarySession, let secondarySession {
-        return HybridModelSession(primary: primarySession, secondary: secondarySession)
-      } else if let primarySession {
-        return primarySession
-      } else if let secondarySession {
-        return secondarySession
-      } else {
-        let context = GenerativeModelSession.GenerationError.Context(
-          debugDescription: """
-          Failed to start session for model "\(primary._modelName)" with error: \
-          \(primaryError?.localizedDescription ?? "unknown error");
-          Failed to start session for model "\(secondary._modelName)" with error: \
-          \(secondaryError?.localizedDescription ?? "unknown error")
-          """
-        )
-
-        throw GenerativeModelSession.GenerationError.assetsUnavailable(context)
-      }
+      return HybridModelSession(
+        primaryModel: primary,
+        secondaryModel: secondary,
+        tools: tools,
+        instructions: instructions
+      )
     }
   }
 #endif // compiler(>=6.2.3)

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
@@ -208,6 +208,41 @@
       #expect(response.rawResponse.modelVersion == validModel._modelName)
     }
 
+    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
+    @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    func streamResponseText_fallbackOnFoundationModelsError(_ config: InstanceConfig) async throws {
+      let firebaseAI = FirebaseAI.componentInstance(config)
+      let systemModel = FirebaseAI.SystemLanguageModel.default
+      let geminiModel = firebaseAI.geminiModel(name: ModelNames.gemini2_5_FlashLite)
+      let session = firebaseAI.generativeModelSession(
+        model: HybridModel(primary: systemModel, secondary: geminiModel)
+      )
+      let prompt = "In one sentence, why is the sky blue?"
+
+      let stream = session.streamResponse(to: prompt)
+
+      var receivedTexts = [String]()
+      var isComplete = false
+      for try await snapshot in stream {
+        let partial = snapshot.content
+        receivedTexts.append(partial)
+        isComplete = snapshot.rawContent.isComplete
+      }
+      #expect(isComplete)
+
+      let response = try await stream.collect()
+      let content = response.content
+      #expect(!content.isEmpty)
+
+      if await foundationModelsIsAvailable() {
+        #expect(response.rawResponse.modelVersion == systemModel._modelName)
+      } else {
+        #expect(response.rawResponse.modelVersion == geminiModel._modelName)
+      }
+    }
+
     /// Returns `true` if `FoundationModels.SystemLanguageModel` is available.
     ///
     /// This is a workaround for `SystemLanguageModel.isAvailable`, which returns `true` if *any*

--- a/FirebaseAI/Tests/Unit/HybridModelTests.swift
+++ b/FirebaseAI/Tests/Unit/HybridModelTests.swift
@@ -52,6 +52,7 @@
         return try await respondHandler()
       }
 
+      @available(macOS 12.0, watchOS 8.0, *)
       func _streamResponse(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
                            includeSchemaInPrompt: Bool,
                            options: any GenerationOptionsRepresentable)
@@ -227,7 +228,13 @@
       XCTAssertEqual(tracker2.count, 0)
     }
 
+    @available(macOS 12.0, watchOS 8.0, *)
     func testStreamResponse_bothSucceed() async throws {
+      // Skip this test on platforms that do not support streaming with `_streamResponse)`. This is
+      // a workaround for XCTest ignoring the `@available` attributes. See
+      // https://stackoverflow.com/q/59645536 for more details.
+      try XCTSkipStreamingUnsupported()
+
       let session1 = MockSession(
         streamHandler: {
           AsyncThrowingStream { continuation in
@@ -283,7 +290,13 @@
       XCTAssertEqual(receivedTexts, ["primary"])
     }
 
+    @available(macOS 12.0, watchOS 8.0, *)
     func testStreamResponse_primaryFails_secondarySucceeds() async throws {
+      // Skip this test on platforms that do not support streaming with `_streamResponse)`. This is
+      // a workaround for XCTest ignoring the `@available` attributes. See
+      // https://stackoverflow.com/q/59645536 for more details.
+      try XCTSkipStreamingUnsupported()
+
       let session2 = MockSession(
         streamHandler: {
           AsyncThrowingStream { continuation in

--- a/FirebaseAI/Tests/Unit/HybridModelTests.swift
+++ b/FirebaseAI/Tests/Unit/HybridModelTests.swift
@@ -31,12 +31,18 @@
     struct MockSession: _ModelSession {
       var _hasHistory: Bool = false
       let respondHandler: @Sendable () async throws -> _ModelSessionResponse
+      let streamHandler: @Sendable () -> AsyncThrowingStream<_ModelSessionResponse, any Error>
 
       init(_hasHistory: Bool = false,
            respondHandler: @escaping @Sendable () async throws
-             -> _ModelSessionResponse = { fatalError("Not implemented") }) {
+             -> _ModelSessionResponse = { fatalError("Not implemented") },
+           streamHandler: @escaping @Sendable ()
+             -> AsyncThrowingStream<_ModelSessionResponse, any Error> = {
+               fatalError("Not implemented")
+             }) {
         self._hasHistory = _hasHistory
         self.respondHandler = respondHandler
+        self.streamHandler = streamHandler
       }
 
       func _respond(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
@@ -50,19 +56,27 @@
                            includeSchemaInPrompt: Bool,
                            options: any GenerationOptionsRepresentable)
         -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
-        fatalError("Not implemented")
+        return streamHandler()
       }
     }
 
     func testStartSession_bothSucceed() async throws {
-      let session1 = MockSession(respondHandler: { _ModelSessionResponse(
-        rawContent: FirebaseAI.GeneratedContent(kind: .string("primary"), isComplete: true),
-        rawResponse: GenerateContentResponse(candidates: [])
-      ) })
-      let session2 = MockSession(respondHandler: { _ModelSessionResponse(
-        rawContent: FirebaseAI.GeneratedContent(kind: .string("secondary"), isComplete: true),
-        rawResponse: GenerateContentResponse(candidates: [])
-      ) })
+      let session1 = MockSession(
+        respondHandler: {
+          _ModelSessionResponse(
+            rawContent: FirebaseAI.GeneratedContent(kind: .string("primary"), isComplete: true),
+            rawResponse: GenerateContentResponse(candidates: [])
+          )
+        }
+      )
+      let session2 = MockSession(
+        respondHandler: {
+          _ModelSessionResponse(
+            rawContent: FirebaseAI.GeneratedContent(kind: .string("secondary"), isComplete: true),
+            rawResponse: GenerateContentResponse(candidates: [])
+          )
+        }
+      )
       let model1 = MockModel(_modelName: "model1") { session1 }
       let model2 = MockModel(_modelName: "model2") { session2 }
       let hybridModel = HybridModel(primary: model1, secondary: model2)
@@ -85,10 +99,14 @@
     }
 
     func testStartSession_primaryFails_secondarySucceeds() async throws {
-      let session2 = MockSession(respondHandler: { _ModelSessionResponse(
-        rawContent: FirebaseAI.GeneratedContent(kind: .string("secondary"), isComplete: true),
-        rawResponse: GenerateContentResponse(candidates: [])
-      ) })
+      let session2 = MockSession(
+        respondHandler: {
+          _ModelSessionResponse(
+            rawContent: FirebaseAI.GeneratedContent(kind: .string("secondary"), isComplete: true),
+            rawResponse: GenerateContentResponse(candidates: [])
+          )
+        }
+      )
       let model1 = MockModel(_modelName: "model1") { throw NSError(domain: "test", code: 1) }
       let model2 = MockModel(_modelName: "model2") { session2 }
       let hybridModel = HybridModel(primary: model1, secondary: model2)
@@ -111,10 +129,14 @@
     }
 
     func testStartSession_primarySucceeds_secondaryFails() async throws {
-      let session1 = MockSession(respondHandler: { _ModelSessionResponse(
-        rawContent: FirebaseAI.GeneratedContent(kind: .string("primary"), isComplete: true),
-        rawResponse: GenerateContentResponse(candidates: [])
-      ) })
+      let session1 = MockSession(
+        respondHandler: {
+          _ModelSessionResponse(
+            rawContent: FirebaseAI.GeneratedContent(kind: .string("primary"), isComplete: true),
+            rawResponse: GenerateContentResponse(candidates: [])
+          )
+        }
+      )
       let model1 = MockModel(_modelName: "model1") { session1 }
       let model2 = MockModel(_modelName: "model2") { throw NSError(domain: "test", code: 2) }
       let hybridModel = HybridModel(primary: model1, secondary: model2)
@@ -159,17 +181,12 @@
         )
         XCTFail("Expected error but succeeded")
       } catch {
-        // Verify that the error is what we expect.
-        // In the new implementation, the error will be from the fallback logic.
-        // If primary fails and has no history, it falls back to secondary.
-        // If secondary fails, its error is thrown.
-        // So the error will be from secondary model creation or response.
         let nsError = error as NSError
         XCTAssertEqual(nsError.code, 2) // Error from model2
       }
     }
 
-    func testStartSession_lazyInitialization() throws {
+    func testStartSession_lazyInitialization() async throws {
       final class CallTracker: @unchecked Sendable {
         var count = 0
       }
@@ -177,7 +194,14 @@
       let tracker2 = CallTracker()
       let model1 = MockModel(_modelName: "model1") {
         tracker1.count += 1
-        return MockSession()
+        return MockSession(
+          respondHandler: {
+            _ModelSessionResponse(
+              rawContent: FirebaseAI.GeneratedContent(kind: .string("primary"), isComplete: true),
+              rawResponse: GenerateContentResponse(candidates: [])
+            )
+          }
+        )
       }
       let model2 = MockModel(_modelName: "model2") {
         tracker2.count += 1
@@ -190,6 +214,125 @@
       XCTAssertTrue(session is HybridModelSession)
       XCTAssertEqual(tracker1.count, 0)
       XCTAssertEqual(tracker2.count, 0)
+
+      // Verify that calling respond creates the primary session lazily.
+      _ = try await session._respond(
+        to: [],
+        schema: nil,
+        includeSchemaInPrompt: false,
+        options: ResponseGenerationOptions.default
+      )
+
+      XCTAssertEqual(tracker1.count, 1)
+      XCTAssertEqual(tracker2.count, 0)
+    }
+
+    func testStreamResponse_bothSucceed() async throws {
+      let session1 = MockSession(
+        streamHandler: {
+          AsyncThrowingStream { continuation in
+            continuation.yield(
+              _ModelSessionResponse(
+                rawContent: FirebaseAI.GeneratedContent(kind: .string("primary"), isComplete: true),
+                rawResponse: GenerateContentResponse(candidates: [])
+              )
+            )
+            continuation.finish()
+          }
+        }
+      )
+      let session2 = MockSession(
+        streamHandler: {
+          AsyncThrowingStream { continuation in
+            continuation.yield(
+              _ModelSessionResponse(
+                rawContent: FirebaseAI.GeneratedContent(
+                  kind: .string("secondary"),
+                  isComplete: true
+                ),
+                rawResponse: GenerateContentResponse(candidates: [])
+              )
+            )
+            continuation.finish()
+          }
+        }
+      )
+      let model1 = MockModel(_modelName: "model1") { session1 }
+      let model2 = MockModel(_modelName: "model2") { session2 }
+      let hybridModel = HybridModel(primary: model1, secondary: model2)
+
+      let session = try hybridModel._startSession(tools: nil, instructions: nil)
+
+      XCTAssertTrue(session is HybridModelSession)
+
+      let stream = session._streamResponse(
+        to: [],
+        schema: nil,
+        includeSchemaInPrompt: false,
+        options: ResponseGenerationOptions.default
+      )
+
+      var receivedTexts = [String]()
+      for try await response in stream {
+        guard case let .string(text) = response.rawContent.kind else {
+          return XCTFail("Unexpected content kind")
+        }
+        receivedTexts.append(text)
+      }
+
+      XCTAssertEqual(receivedTexts, ["primary"])
+    }
+
+    func testStreamResponse_primaryFails_secondarySucceeds() async throws {
+      let session2 = MockSession(
+        streamHandler: {
+          AsyncThrowingStream { continuation in
+            continuation.yield(
+              _ModelSessionResponse(
+                rawContent: FirebaseAI.GeneratedContent(
+                  kind: .string("secondary"),
+                  isComplete: true
+                ),
+                rawResponse: GenerateContentResponse(candidates: [])
+              )
+            )
+            continuation.finish()
+          }
+        }
+      )
+      let model1 = MockModel(_modelName: "model1") {
+        let session = MockSession(
+          streamHandler: {
+            AsyncThrowingStream { continuation in
+              continuation.finish(throwing: NSError(domain: "test", code: 1))
+            }
+          }
+        )
+        return session
+      }
+      let model2 = MockModel(_modelName: "model2") { session2 }
+      let hybridModel = HybridModel(primary: model1, secondary: model2)
+
+      let session = try hybridModel._startSession(tools: nil, instructions: nil)
+
+      XCTAssertTrue(session is HybridModelSession)
+
+      let stream = session._streamResponse(
+        to: [],
+        schema: nil,
+        includeSchemaInPrompt: false,
+        options: ResponseGenerationOptions.default
+      )
+
+      var receivedTexts = [String]()
+      for try await response in stream {
+        guard case let .string(text) = response.rawContent.kind else {
+          return XCTFail("Unexpected content kind")
+        }
+        receivedTexts.append(text)
+      }
+
+      XCTAssertEqual(receivedTexts, ["secondary"])
     }
   }
 #endif // compiler(>=6.2.3)

--- a/FirebaseAI/Tests/Unit/HybridModelTests.swift
+++ b/FirebaseAI/Tests/Unit/HybridModelTests.swift
@@ -30,12 +30,20 @@
 
     struct MockSession: _ModelSession {
       var _hasHistory: Bool = false
+      let respondHandler: @Sendable () async throws -> _ModelSessionResponse
+
+      init(_hasHistory: Bool = false,
+           respondHandler: @escaping @Sendable () async throws
+             -> _ModelSessionResponse = { fatalError("Not implemented") }) {
+        self._hasHistory = _hasHistory
+        self.respondHandler = respondHandler
+      }
 
       func _respond(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
                     includeSchemaInPrompt: Bool,
                     options: any GenerationOptionsRepresentable)
         async throws -> _ModelSessionResponse {
-        fatalError("Not implemented")
+        return try await respondHandler()
       }
 
       func _streamResponse(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
@@ -46,9 +54,15 @@
       }
     }
 
-    func testStartSession_bothSucceed() throws {
-      let session1 = MockSession()
-      let session2 = MockSession()
+    func testStartSession_bothSucceed() async throws {
+      let session1 = MockSession(respondHandler: { _ModelSessionResponse(
+        rawContent: FirebaseAI.GeneratedContent(kind: .string("primary"), isComplete: true),
+        rawResponse: GenerateContentResponse(candidates: [])
+      ) })
+      let session2 = MockSession(respondHandler: { _ModelSessionResponse(
+        rawContent: FirebaseAI.GeneratedContent(kind: .string("secondary"), isComplete: true),
+        rawResponse: GenerateContentResponse(candidates: [])
+      ) })
       let model1 = MockModel(_modelName: "model1") { session1 }
       let model2 = MockModel(_modelName: "model2") { session2 }
       let hybridModel = HybridModel(primary: model1, secondary: model2)
@@ -56,31 +70,73 @@
       let session = try hybridModel._startSession(tools: nil, instructions: nil)
 
       XCTAssertTrue(session is HybridModelSession)
+
+      // Verify that calling respond uses the primary session.
+      let response = try await session._respond(
+        to: [],
+        schema: nil,
+        includeSchemaInPrompt: false,
+        options: ResponseGenerationOptions.default
+      )
+      guard case let .string(text) = response.rawContent.kind else {
+        return XCTFail("Unexpected content kind")
+      }
+      XCTAssertEqual(text, "primary")
     }
 
-    func testStartSession_primaryFails_secondarySucceeds() throws {
-      let session2 = MockSession()
+    func testStartSession_primaryFails_secondarySucceeds() async throws {
+      let session2 = MockSession(respondHandler: { _ModelSessionResponse(
+        rawContent: FirebaseAI.GeneratedContent(kind: .string("secondary"), isComplete: true),
+        rawResponse: GenerateContentResponse(candidates: [])
+      ) })
       let model1 = MockModel(_modelName: "model1") { throw NSError(domain: "test", code: 1) }
       let model2 = MockModel(_modelName: "model2") { session2 }
       let hybridModel = HybridModel(primary: model1, secondary: model2)
 
       let session = try hybridModel._startSession(tools: nil, instructions: nil)
 
-      XCTAssertTrue(session is MockSession)
+      XCTAssertTrue(session is HybridModelSession)
+
+      // Verify that calling respond falls back to the secondary session.
+      let response = try await session._respond(
+        to: [],
+        schema: nil,
+        includeSchemaInPrompt: false,
+        options: ResponseGenerationOptions.default
+      )
+      guard case let .string(text) = response.rawContent.kind else {
+        return XCTFail("Unexpected content kind")
+      }
+      XCTAssertEqual(text, "secondary")
     }
 
-    func testStartSession_primarySucceeds_secondaryFails() throws {
-      let session1 = MockSession()
+    func testStartSession_primarySucceeds_secondaryFails() async throws {
+      let session1 = MockSession(respondHandler: { _ModelSessionResponse(
+        rawContent: FirebaseAI.GeneratedContent(kind: .string("primary"), isComplete: true),
+        rawResponse: GenerateContentResponse(candidates: [])
+      ) })
       let model1 = MockModel(_modelName: "model1") { session1 }
       let model2 = MockModel(_modelName: "model2") { throw NSError(domain: "test", code: 2) }
       let hybridModel = HybridModel(primary: model1, secondary: model2)
 
       let session = try hybridModel._startSession(tools: nil, instructions: nil)
 
-      XCTAssertTrue(session is MockSession)
+      XCTAssertTrue(session is HybridModelSession)
+
+      // Verify that calling respond uses the primary session.
+      let response = try await session._respond(
+        to: [],
+        schema: nil,
+        includeSchemaInPrompt: false,
+        options: ResponseGenerationOptions.default
+      )
+      guard case let .string(text) = response.rawContent.kind else {
+        return XCTFail("Unexpected content kind")
+      }
+      XCTAssertEqual(text, "primary")
     }
 
-    func testStartSession_bothFail() throws {
+    func testStartSession_bothFail() async throws {
       let model1 = MockModel(_modelName: "model1") {
         throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Error 1"])
       }
@@ -89,14 +145,51 @@
       }
       let hybridModel = HybridModel(primary: model1, secondary: model2)
 
-      XCTAssertThrowsError(try hybridModel._startSession(tools: nil, instructions: nil)) { error in
-        guard case let GenerativeModelSession.GenerationError.assetsUnavailable(context)
-          = error else {
-          return XCTFail("Unexpected error type: \(error)")
-        }
-        XCTAssertTrue(context.debugDescription.contains("Error 1"))
-        XCTAssertTrue(context.debugDescription.contains("Error 2"))
+      let session = try hybridModel._startSession(tools: nil, instructions: nil)
+
+      XCTAssertTrue(session is HybridModelSession)
+
+      // Verify that calling respond throws an error.
+      do {
+        _ = try await session._respond(
+          to: [],
+          schema: nil,
+          includeSchemaInPrompt: false,
+          options: ResponseGenerationOptions.default
+        )
+        XCTFail("Expected error but succeeded")
+      } catch {
+        // Verify that the error is what we expect.
+        // In the new implementation, the error will be from the fallback logic.
+        // If primary fails and has no history, it falls back to secondary.
+        // If secondary fails, its error is thrown.
+        // So the error will be from secondary model creation or response.
+        let nsError = error as NSError
+        XCTAssertEqual(nsError.code, 2) // Error from model2
       }
+    }
+
+    func testStartSession_lazyInitialization() throws {
+      final class CallTracker: @unchecked Sendable {
+        var count = 0
+      }
+      let tracker1 = CallTracker()
+      let tracker2 = CallTracker()
+      let model1 = MockModel(_modelName: "model1") {
+        tracker1.count += 1
+        return MockSession()
+      }
+      let model2 = MockModel(_modelName: "model2") {
+        tracker2.count += 1
+        return MockSession()
+      }
+      let hybridModel = HybridModel(primary: model1, secondary: model2)
+
+      let session = try hybridModel._startSession(tools: nil, instructions: nil)
+
+      XCTAssertTrue(session is HybridModelSession)
+      XCTAssertEqual(tracker1.count, 0)
+      XCTAssertEqual(tracker2.count, 0)
     }
   }
 #endif // compiler(>=6.2.3)

--- a/FirebaseAI/Tests/Unit/TestUtilities/XCTUtil.swift
+++ b/FirebaseAI/Tests/Unit/TestUtilities/XCTUtil.swift
@@ -70,3 +70,9 @@ func XCTSkipFoundationModelsUnsupported() throws {
     throw XCTSkip("Foundation Models requires iOS/macOS/visionOS 26+.")
   }
 }
+
+func XCTSkipStreamingUnsupported() throws {
+  guard #available(macOS 12.0, watchOS 8.0, *) else {
+    throw XCTSkip("Streaming requires macOS 12+ or watchOS 8+.")
+  }
+}


### PR DESCRIPTION
Updated `HybridModelSession` to lazily initialize sessions from the underlying models. This avoids unnecessarily starting on-device sessions if a Gemini model is the primary model and it succeeds. 

#no-changelog