### PR TITLE
chore: update changelogs for 12.13.0 release

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.13.0
 - [fixed] Fix race in FIRCLSContextMarkAndCheckIfCrashed. (#15384)
 - [fixed] Fix unfound file warnings from `swift build`. (#16012)
 - [fixed] Fix calling frame not being included in the stack trace for record(error:). (#16106)

--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.13.0
 - [feature] Added support for session resumption in the Live API via the `resumeSession` method on
   [`LiveSession`](https://firebase.google.com/docs/reference/swift/firebaseai/api/reference/Classes/LiveSession).
   (#15904)
@@ -31,7 +31,7 @@
 - [changed] **Breaking Change**: `GenerativeModelSession.GenerationError` is now
   marked `@nonexhaustive` to support additional cases in a non-breaking manner.
   If switching on `GenerativeModelSession.GenerationError`, you must add an
-  [`@unknown default:`](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0192-non-exhaustive-enums.md#unknown)
+  [`@unknown default:`](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0192-non-exhaustive-enums.md# 12.13.0
   case to your `switch` statement. (#16011)
 - [deprecated] All Imagen models are deprecated and will shut down as early as June 2026.
   As a replacement, you can [migrate your apps to use Gemini Image models (the "Nano Banana" models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration).

--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -31,7 +31,7 @@
 - [changed] **Breaking Change**: `GenerativeModelSession.GenerationError` is now
   marked `@nonexhaustive` to support additional cases in a non-breaking manner.
   If switching on `GenerativeModelSession.GenerationError`, you must add an
-  [`@unknown default:`](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0192-non-exhaustive-enums.md# 12.13.0
+  [`@unknown default:`](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0192-non-exhaustive-enums.md#unknown)
   case to your `switch` statement. (#16011)
 - [deprecated] All Imagen models are deprecated and will shut down as early as June 2026.
   As a replacement, you can [migrate your apps to use Gemini Image models (the "Nano Banana" models)](https://firebase.google.com/docs/ai-logic/imagen-models-migration).

--- a/FirebaseFunctions/CHANGELOG.md
+++ b/FirebaseFunctions/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.13.0
 - [fixed] Fixed a release-build crash in `HTTPSCallable.call()` when using
   Xcode 26.4 (Swift 6.3) that was caused by a Swift regression in `async let`
   teardown. (#15974)

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.13.0
 - [fixed] Fixed NSURLSession delegate instrumentation for NSProxy delegates. (#14478)
 - [fixed] Address crash by deferring class disposal in FPRObjectSwizzler. (#14473)
 - [fixed] Prevent race condition crashes in FPRScreenTraceTracker by replacing NSMapTable with

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.13.0
 - [fixed] Remote Config Realtime updates now trigger when a parameter's experiment
   or variant assignment changes, ensuring more accurate A/B test analytics and
   consistent user experiences.

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.13.0
 - [feature] Added search stage support for `languageCode`, `offset`, `limit`, and `retrievalDepth`.
 - [feature] Added support for Pipeline expressions `arraySlice`, `arrayFilter`, `arrayTransform` and `arrayTransformWithIndex`. (#16001)
 


### PR DESCRIPTION
This PR updates the changelogs for the `12.13.0` release such that all the currently pending `# Unreleased` changes have been moved into a `12.13.0` sub header.