### PR TITLE
[AI] Remove `GenerativeModelSession` public initializer

### DIFF
--- a/FirebaseAI/Sources/GenerativeModelSession.swift
+++ b/FirebaseAI/Sources/GenerativeModelSession.swift
@@ -73,8 +73,8 @@
     ///     native Gemini ``FirebaseAILogic/Tool``s, such as ``ToolRepresentable/googleSearch(_:)``,
     ///     or instances conforming to ``ToolRepresentable`` for automatic function calling.
     ///   - instructions: System instructions that direct the model's behavior.
-    public init(model: any LanguageModel, tools: [any ToolRepresentable]? = nil,
-                instructions: String? = nil) {
+    init(model: any LanguageModel, tools: [any ToolRepresentable]? = nil,
+         instructions: String? = nil) {
       sessionManager = SessionManager(model: model, tools: tools)
       self.instructions = instructions
     }

--- a/FirebaseAI/Sources/Protocols/Public/LanguageModelProvider.swift
+++ b/FirebaseAI/Sources/Protocols/Public/LanguageModelProvider.swift
@@ -57,9 +57,11 @@
     /// [documentation](https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel/init(usecase:guardrails:)).
     ///
     /// - Parameters:
-    ///   - useCase: The ``UseCase`` that the model is tuned for; defaults to ``UseCase/general``.
-    ///   - guardrails: The ``Guardrails`` that configure how the model handles potentially harmful
-    ///     content; defaults to ``Guardrails/default``.
+    ///   - useCase: The ``FirebaseAI/SystemLanguageModel/UseCase`` that the model is tuned for;
+    ///     defaults to ``FirebaseAI/SystemLanguageModel/UseCase/general``.
+    ///   - guardrails: The ``FirebaseAI/SystemLanguageModel/Guardrails`` that configure how the
+    ///     model handles potentially harmful content; defaults to
+    ///     ``FirebaseAI/SystemLanguageModel/Guardrails/default``.
     static func systemModel(useCase: FirebaseAI.SystemLanguageModel.UseCase = .general,
                             guardrails: FirebaseAI.SystemLanguageModel.Guardrails = .default)
       -> FirebaseAI.SystemLanguageModel {

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
@@ -95,7 +95,7 @@
       let firebaseAI = FirebaseAI.componentInstance(config)
       let invalidModel = firebaseAI.geminiModel(name: "invalid-model-name-1")
       let validModel = firebaseAI.geminiModel(name: ModelNames.gemini2_5_FlashLite)
-      let session = GenerativeModelSession(
+      let session = firebaseAI.generativeModelSession(
         model: HybridModel(primary: invalidModel, secondary: validModel)
       )
       let prompt = "Generate a cute rescue cat"
@@ -120,7 +120,7 @@
       let firebaseAI = FirebaseAI.componentInstance(config)
       let invalidModel = firebaseAI.geminiModel(name: "invalid-model-name")
       let validModel = firebaseAI.geminiModel(name: ModelNames.gemini2_5_FlashLite)
-      let session = GenerativeModelSession(
+      let session = firebaseAI.generativeModelSession(
         model: HybridModel(primary: invalidModel, secondary: validModel)
       )
       let prompt = "In one sentence, why is the sky blue?"

--- a/FirebaseAI/Tests/Unit/GenerativeModelSessionAPITests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelSessionAPITests.swift
@@ -30,11 +30,10 @@ import XCTest
       // Initialize a session with a `GeminiModel`
       let geminiModel = ai.geminiModel(name: "gemini-flash-latest")
       _ = ai.generativeModelSession(model: geminiModel)
-      _ = GenerativeModelSession(model: geminiModel)
 
       // Initialize a session with a `SystemLanguageModel` as a `LanguageModel`
       let systemModel = FirebaseAI.SystemLanguageModel.default
-      _ = GenerativeModelSession(model: systemModel)
+      _ = ai.generativeModelSession(model: systemModel)
 
       // Initialize a session with a `SystemLanguageModel` as a `LanguageModelProvider`
       _ = ai.generativeModelSession(model: .systemModel())
@@ -57,11 +56,12 @@ import XCTest
 
       // Initialize a session with a `HybridModel` of cloud models
       let gemmaModel = ai.geminiModel(name: "gemma-4-31b-it")
-      let hybridModel = HybridModel(primary: gemmaModel, secondary: geminiModel)
-      _ = GenerativeModelSession(model: hybridModel)
+      let cloudHybridModel = HybridModel(primary: gemmaModel, secondary: geminiModel)
+      _ = ai.generativeModelSession(model: cloudHybridModel)
 
       // Initialize a session with a `HybridModel` of cloud and on-device models
-      _ = HybridModel(primary: systemModel, secondary: geminiModel)
+      let hybridModel = HybridModel(primary: systemModel, secondary: geminiModel)
+      _ = ai.generativeModelSession(model: hybridModel)
     }
   }
 #endif // compiler(>=6.2.3)


### PR DESCRIPTION
Removed the `GenerativeModelSession` public initializer to avoid a hard to debug compilation error (`Failed to produce diagnostic for expression; please submit a bug report (https://swift.org/contributing/#reporting-bugs)`) when accidentally using a non-existent static method, e.g., `GenerativeModelSession(model: .geminiModel(name: "gemini-flash-latest"))` where `.geminiModel()` isn't a method on `any LanguageModel`.

This constructor was made public for convenience but the potential for confusion outweighs this. Developers must now use `generativeModelSession(model:tools:instructions:)` on a `FirebaseAI` instance. The `GenerativeModelSession` initializer was never made public in a release so this is a non-breaking change.

#no-changelog