### PR TITLE
chore: fix AI logic changelog entries

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -5,6 +5,8 @@
 - [feature] Added support for context window compression in the Live API via
   [`ContextWindowCompressionConfig`](https://firebase.google.com/docs/reference/swift/firebaseai/api/reference/Structs/ContextWindowCompressionConfig).
   (#15904)
+- [feature] **Breaking Change**: Added a new Live API payload field for `LiveSessionResumptionUpdate` to
+  support the new session resumption feature. (#15904)
 - [feature] Adds support for configuring image generation properties,
   such as aspect ratio and image size, through the new `ImageConfig` struct
   and its integration with `GenerationConfig`. (#15923)

--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -2,7 +2,7 @@
 - [feature] Added support for session resumption in the Live API via the `resumeSession` method on
   [`LiveSession`](https://firebase.google.com/docs/reference/swift/firebaseai/api/reference/Classes/LiveSession).
   (#15904)
-- [feature] Added support for context window compression in the Liva API via
+- [feature] Added support for context window compression in the Live API via
   [`ContextWindowCompressionConfig`](https://firebase.google.com/docs/reference/swift/firebaseai/api/reference/Structs/ContextWindowCompressionConfig).
   (#15904)
 - [feature] Adds support for configuring image generation properties,


### PR DESCRIPTION
This PR fixes a typo in one of the AI logic changelog entries, as well as adds an additional entry to call out the breaking change introduced in #15904