### PR TITLE
[AI] Add `GenerateContentResponse.modelVersion` to public API

### DIFF
--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -71,7 +71,13 @@ public struct GenerateContentResponse: Sendable {
 
   let responseID: String?
 
-  let modelVersion: String?
+  static let unknownModelVersion = "unknown-model-version"
+
+  /// Returns the model version used to generate the response.
+  ///
+  /// - Note: If the model version is not specified by the backend, this returns
+  ///   "unknown-model-version".
+  public let modelVersion: String
 
   /// The response's content as text, if it exists.
   ///
@@ -150,11 +156,13 @@ public struct GenerateContentResponse: Sendable {
   /// Initializer for SwiftUI previews or tests.
   public init(candidates: [Candidate], promptFeedback: PromptFeedback? = nil,
               usageMetadata: UsageMetadata? = nil) {
-    self.candidates = candidates
-    self.promptFeedback = promptFeedback
-    self.usageMetadata = usageMetadata
-    responseID = nil
-    modelVersion = nil
+    self = .init(
+      candidates: candidates,
+      promptFeedback: promptFeedback,
+      usageMetadata: usageMetadata,
+      responseID: nil,
+      modelVersion: nil
+    )
   }
 
   init(candidates: [Candidate], promptFeedback: PromptFeedback? = nil,
@@ -164,7 +172,7 @@ public struct GenerateContentResponse: Sendable {
     self.promptFeedback = promptFeedback
     self.usageMetadata = usageMetadata
     self.responseID = responseID
-    self.modelVersion = modelVersion
+    self.modelVersion = modelVersion ?? GenerateContentResponse.unknownModelVersion
   }
 
   func text(isThought: Bool) -> String? {
@@ -553,7 +561,10 @@ extension GenerateContentResponse: Decodable {
     promptFeedback = try container.decodeIfPresent(PromptFeedback.self, forKey: .promptFeedback)
     usageMetadata = try container.decodeIfPresent(UsageMetadata.self, forKey: .usageMetadata)
     responseID = try container.decodeIfPresent(String.self, forKey: .responseID)
-    modelVersion = try container.decodeIfPresent(String.self, forKey: .modelVersion)
+    modelVersion = try container.decodeIfPresent(
+      String.self,
+      forKey: .modelVersion
+    ) ?? GenerateContentResponse.unknownModelVersion
   }
 }
 

--- a/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
@@ -268,6 +268,33 @@ final class GenerateContentResponseTests: XCTestCase {
     XCTAssertEqual(candidate.finishReason, .stop)
   }
 
+  func testDecodeGenerateContentResponse_withModelVersion() throws {
+    let json = """
+    {
+      "candidates": [],
+      "modelVersion": "gemini-2.5-flash"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try jsonDecoder.decode(GenerateContentResponse.self, from: jsonData)
+
+    XCTAssertEqual(response.modelVersion, "gemini-2.5-flash")
+  }
+
+  func testDecodeGenerateContentResponse_withoutModelVersion() throws {
+    let json = """
+    {
+      "candidates": []
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try jsonDecoder.decode(GenerateContentResponse.self, from: jsonData)
+
+    XCTAssertEqual(response.modelVersion, GenerateContentResponse.unknownModelVersion)
+  }
+
   // MARK: - Candidate.isEmpty
 
   func testCandidateIsEmpty_allEmpty_isTrue() throws {


### PR DESCRIPTION
Made the `modelVersion` property in `GenerateContentResponse` public and non-Optional. To handle unexpected cases where the field is not returned by the backend, this defaults to `"unknown-model-version"` if `nil`.

Note: This property is already integration tested in https://github.com/firebase/firebase-ios-sdk/blob/1727d908dd2a71fe4573bda15b6251fbd8c36ff8/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift#L56.

#no-changelog