### PR TITLE
[AI] Add hybrid and Foundation Models debug logging

### DIFF
--- a/FirebaseAI/Sources/AILog.swift
+++ b/FirebaseAI/Sources/AILog.swift
@@ -91,6 +91,7 @@ enum AILog {
     case invalidToolOutputType = 4007
     case hybridPrimarySessionInitializationFailed = 4008
     case hybridPrimaryModelRequestFailed = 4009
+    case hybridPrimaryModelStreamingRequestFailed = 4010
 
     // SDK Debugging
     case loadRequestStreamResponseLine = 5000

--- a/FirebaseAI/Sources/AILog.swift
+++ b/FirebaseAI/Sources/AILog.swift
@@ -89,7 +89,8 @@ enum AILog {
     case duplicateLiveSessionSetupComplete = 4005
     case malformedURL = 4006
     case invalidToolOutputType = 4007
-    case hybridPrimaryModelFailed = 4008
+    case hybridPrimarySessionInitializationFailed = 4008
+    case hybridPrimaryModelRequestFailed = 4009
 
     // SDK Debugging
     case loadRequestStreamResponseLine = 5000

--- a/FirebaseAI/Sources/AILog.swift
+++ b/FirebaseAI/Sources/AILog.swift
@@ -89,9 +89,12 @@ enum AILog {
     case duplicateLiveSessionSetupComplete = 4005
     case malformedURL = 4006
     case invalidToolOutputType = 4007
+    case hybridPrimaryModelFailed = 4008
 
     // SDK Debugging
     case loadRequestStreamResponseLine = 5000
+    case foundationModelsResponseTranscript = 5001
+    case foundationModelsStreamResponseTranscript = 5002
   }
 
   /// Subsystem that should be used for all Loggers.

--- a/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
@@ -66,6 +66,15 @@
         )
       }
 
+      #if DEBUG
+        if AILog.additionalLoggingEnabled() {
+          AILog.debug(
+            code: .foundationModelsResponseTranscript,
+            "Foundation Models Transcript: \(response.transcriptEntries)"
+          )
+        }
+      #endif // DEBUG
+
       return makeResponse(from: response.rawContent, schema: schema)
     }
 
@@ -114,6 +123,19 @@
 
               continuation.yield(response)
             }
+
+            #if DEBUG
+              if AILog.additionalLoggingEnabled() {
+                // Streaming has completed but we call `collect()` to get a
+                // `LanguageModelSession.Response`, which contains `transcriptEntries`.
+                let response = try await stream.collect()
+                AILog.debug(
+                  code: .foundationModelsStreamResponseTranscript,
+                  "Foundation Models Transcript: \(response.transcriptEntries)"
+                )
+              }
+            #endif // DEBUG
+
             continuation.finish()
           } catch {
             continuation.finish(throwing: error)

--- a/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
@@ -122,7 +122,7 @@
 
           // Fallback to the second session if the first fails or is unavailable.
           AILog.notice(code: .hybridPrimaryModelRequestFailed, """
-          Primary model "\(primaryModel._modelName)" failed with error: \(error); falling back to
+          Primary model "\(primaryModel._modelName)" failed with error: \(error); falling back to \
           secondary model "\(secondaryModel._modelName)".
           """)
           let secondarySession = try getSession(for: .secondaryModel)
@@ -208,8 +208,8 @@
 
                 // Fallback to the second session if the first fails or is unavailable.
                 AILog.notice(code: .hybridPrimaryModelStreamingRequestFailed, """
-                Primary model "\(primaryModel._modelName)" failed with error: \(error); falling back
-                to secondary model "\(secondaryModel._modelName)".
+                Primary model "\(primaryModel._modelName)" failed with error: \(error); falling \
+                back to secondary model "\(secondaryModel._modelName)".
                 """)
                 let secondarySession = try self.getSession(for: .secondaryModel)
                 let stream = secondarySession._streamResponse(

--- a/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
@@ -76,9 +76,31 @@
           )
         }
 
+        let primarySession: any _ModelSession
         do {
-          // First try the primary session.
-          let primarySession = try getSession(for: .primaryModel)
+          // First try to get the primary session.
+          primarySession = try getSession(for: .primaryModel)
+        } catch {
+          if Task.isCancelled || error is CancellationError {
+            throw error
+          }
+
+          // Fallback to the second session if the first fails or is unavailable.
+          AILog.notice(code: .hybridPrimarySessionInitializationFailed, """
+          Primary model "\(primaryModel._modelName)" failed to initialize session with error: \
+          \(error); falling back to secondary model "\(secondaryModel._modelName)".
+          """)
+          let secondarySession = try getSession(for: .secondaryModel)
+          return try await secondarySession._respond(
+            to: prompt,
+            schema: schema,
+            includeSchemaInPrompt: includeSchemaInPrompt,
+            options: options
+          )
+        }
+
+        do {
+          // Then try the request on the primary session.
           return try await primarySession._respond(
             to: prompt,
             schema: schema,
@@ -99,7 +121,7 @@
           }
 
           // Fallback to the second session if the first fails or is unavailable.
-          AILog.notice(code: .hybridPrimaryModelFailed, """
+          AILog.notice(code: .hybridPrimaryModelRequestFailed, """
           Primary model "\(primaryModel._modelName)" failed with error: \(error); falling back to
           secondary model "\(secondaryModel._modelName)".
           """)
@@ -185,7 +207,7 @@
                 }
 
                 // Fallback to the second session if the first fails or is unavailable.
-                AILog.notice(code: .hybridPrimaryModelFailed, """
+                AILog.notice(code: .hybridPrimaryModelRequestFailed, """
                 Primary model "\(primaryModel._modelName)" failed with error: \(error); falling back
                 to secondary model "\(secondaryModel._modelName)".
                 """)
@@ -214,6 +236,10 @@
 
               // Failure to create primary session.
               // Fallback to the second session if the first fails or is unavailable.
+              AILog.notice(code: .hybridPrimarySessionInitializationFailed, """
+              Primary model "\(primaryModel._modelName)" failed to initialize session with error: \
+              \(error); falling back to secondary model "\(secondaryModel._modelName)".
+              """)
               do {
                 let secondarySession = try self.getSession(for: .secondaryModel)
                 let stream = secondarySession._streamResponse(

--- a/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
@@ -99,6 +99,10 @@
           }
 
           // Fallback to the second session if the first fails or is unavailable.
+          AILog.notice(code: .hybridPrimaryModelFailed, """
+          Primary model "\(primaryModel._modelName)" failed with error: \(error); falling back to
+          secondary model "\(secondaryModel._modelName)".
+          """)
           let secondarySession = try getSession(for: .secondaryModel)
           return try await secondarySession._respond(
             to: prompt,
@@ -181,6 +185,10 @@
                 }
 
                 // Fallback to the second session if the first fails or is unavailable.
+                AILog.notice(code: .hybridPrimaryModelFailed, """
+                Primary model "\(primaryModel._modelName)" failed with error: \(error); falling back
+                to secondary model "\(secondaryModel._modelName)".
+                """)
                 let secondarySession = try self.getSession(for: .secondaryModel)
                 let stream = secondarySession._streamResponse(
                   to: prompt,

--- a/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
+++ b/FirebaseAI/Sources/Types/Internal/HybridModelSession.swift
@@ -207,7 +207,7 @@
                 }
 
                 // Fallback to the second session if the first fails or is unavailable.
-                AILog.notice(code: .hybridPrimaryModelRequestFailed, """
+                AILog.notice(code: .hybridPrimaryModelStreamingRequestFailed, """
                 Primary model "\(primaryModel._modelName)" failed with error: \(error); falling back
                 to secondary model "\(secondaryModel._modelName)".
                 """)


### PR DESCRIPTION
- Added log messages at level "notice" when the primary model in a hybrid configuration fails and falls back to the secondary model.
- Added log messages at level "debug", in `DEBUG` builds, for the transcript of each `LanguageModelSession.Response` when using Foundation Models.

These should help provide better visibility into the hybrid behaviour during development, alongside `modelVersion` in https://github.com/firebase/firebase-ios-sdk/pull/16132 that can be used in production environments as well.

#no-changelog