### PR TITLE
[Crashlytics] Refactor non-fatal error logging to use `FIRCLSNonFatalError` model

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Refactor how data is recorded for non-fatal errors.
+
 # 12.13.0
 - [fixed] Fix race in FIRCLSContextMarkAndCheckIfCrashed. (#15384)
 - [fixed] Fix unfound file warnings from `swift build`. (#16012)

--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,6 +1,3 @@
-# Unreleased
-- Refactor how data is recorded for non-fatal errors.
-
 # 12.13.0
 - [fixed] Fix race in FIRCLSContextMarkAndCheckIfCrashed. (#15384)
 - [fixed] Fix unfound file warnings from `swift build`. (#16012)

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -32,6 +32,7 @@
 #include "Crashlytics/Crashlytics/Helpers/FIRCLSUtility.h"
 #import "Crashlytics/Crashlytics/Models/FIRCLSExecutionIdentifierModel.h"
 #import "Crashlytics/Crashlytics/Models/FIRCLSFileManager.h"
+#import "Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.h"
 #import "Crashlytics/Crashlytics/Models/FIRCLSSettings.h"
 #import "Crashlytics/Crashlytics/Settings/Models/FIRCLSApplicationIdentifierModel.h"
 
@@ -425,22 +426,15 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 }
 
 - (void)recordError:(NSError *)error userInfo:(NSDictionary<NSString *, id> *)userInfo {
-  if (!error) {
-    return;
-  }
-
   NSString *rolloutsInfoJSON = [_remoteConfigManager getRolloutAssignmentsEncodedJsonString];
 
-  // Capture the stack and time before the async queue.
-  // Capturing inside the callback, results in the promise
-  // thread being recorded rather than the caller thread.
-  NSArray *addresses = [NSThread callStackReturnAddresses];
-  uint64_t timestamp = time(NULL);
+  FIRCLSNonFatalError *nonFatalError = [[FIRCLSNonFatalError alloc] initWithError:error
+                                                                         userInfo:userInfo
+                                                                 rolloutsInfoJSON:rolloutsInfoJSON];
 
   [self waitForContextInit:@"recordError"
                   callback:^{
-                    FIRCLSUserLoggingRecordError(error, userInfo, rolloutsInfoJSON, addresses,
-                                                 timestamp);
+                    [nonFatalError recordError];
                   }];
 }
 

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -429,7 +429,7 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
   if (!error) {
     return;
   }
-  
+
   NSString *rolloutsInfoJSON = [_remoteConfigManager getRolloutAssignmentsEncodedJsonString];
 
   FIRCLSNonFatalError *nonFatalError = [[FIRCLSNonFatalError alloc] initWithError:error

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -426,6 +426,10 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
 }
 
 - (void)recordError:(NSError *)error userInfo:(NSDictionary<NSString *, id> *)userInfo {
+  if (!error) {
+    return;
+  }
+  
   NSString *rolloutsInfoJSON = [_remoteConfigManager getRolloutAssignmentsEncodedJsonString];
 
   FIRCLSNonFatalError *nonFatalError = [[FIRCLSNonFatalError alloc] initWithError:error

--- a/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.h
@@ -47,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Records the error to disk. No-op if intialization failed.
+ * The action to record to disk is executed on the thread this method is called on.
  */
 - (void)recordError;
 

--- a/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.h
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * An internal model representing a logged non-fatal error.
+ * This class synchronously captures the thread state and timestamp upon
+ * initialization to safely preserve the execution context.
+ */
+@interface FIRCLSNonFatalError : NSObject
+
+@property(nonatomic, strong, readonly) NSError *error;
+@property(nonatomic, copy, readonly, nullable) NSDictionary<NSString *, id> *userInfo;
+@property(nonatomic, copy, readonly, nullable) NSString *rolloutsInfoJSON;
+@property(nonatomic, copy, readonly) NSArray<NSNumber *> *stackTrace;
+@property(nonatomic, assign, readonly) uint64_t timestamp;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+/**
+ * Initializes a non-fatal error, recording the stack trace at initialization.
+ * Fails to initialize if error is nil.
+ *
+ * @param error The NSError being logged. If nil, initialization fails.
+ * @param userInfo Optional dictionary of custom key-value pairs.
+ * @param rolloutsInfoJSON Optional JSON string containing active feature rollouts.
+ */
+- (nullable instancetype)initWithError:(NSError *)error
+                              userInfo:(nullable NSDictionary<NSString *, id> *)userInfo
+                      rolloutsInfoJSON:(nullable NSString *)rolloutsInfoJSON
+    NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Records the error to disk. No-op if intialization failed.
+ */
+- (void)recordError;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.m
@@ -27,10 +27,10 @@
   self = [super init];
   if (self) {
     _error = error;
-    _userInfo = userInfo;
-    _rolloutsInfoJSON = rolloutsInfoJSON;
+    _userInfo = [userInfo copy];
+    _rolloutsInfoJSON = [rolloutsInfoJSON copy];
     // Take a snapshot of the thread at initialization.
-    _stackTrace = [NSThread callStackReturnAddresses];
+    _stackTrace = [[NSThread callStackReturnAddresses] copy];
     _timestamp = time(NULL);
   }
   return self;

--- a/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.m
@@ -30,7 +30,7 @@
     _userInfo = [userInfo copy];
     _rolloutsInfoJSON = [rolloutsInfoJSON copy];
     // Take a snapshot of the thread at initialization.
-    _stackTrace = [[NSThread callStackReturnAddresses] copy];
+    _stackTrace = [NSThread callStackReturnAddresses];
     _timestamp = time(NULL);
   }
   return self;

--- a/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.m
@@ -40,3 +40,5 @@
   FIRCLSUserLoggingRecordError(self.error, self.userInfo, self.rolloutsInfoJSON, self.stackTrace,
                                self.timestamp);
 }
+
+@end

--- a/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.m
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.h"
+#include "Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h"
+
+@implementation FIRCLSNonFatalError
+
+- (instancetype)initWithError:(NSError *)error
+                     userInfo:(NSDictionary<NSString *, id> *)userInfo
+             rolloutsInfoJSON:(NSString *)rolloutsInfoJSON {
+  if (!error) {
+    return nil;
+  }
+
+  self = [super init];
+  if (self) {
+    _error = error;
+    _userInfo = userInfo;
+    _rolloutsInfoJSON = rolloutsInfoJSON;
+    // Take a snapshot of the thread at initialization.
+    _stackTrace = [NSThread callStackReturnAddresses];
+    _timestamp = time(NULL);
+  }
+  return self;
+}
+
+- (void)recordError {
+  FIRCLSUserLoggingRecordError(self.error, self.userInfo, self.rolloutsInfoJSON, self.stackTrace,
+                               self.timestamp);
+}


### PR DESCRIPTION
#### **Description**
Historically, non-fatal errors in Crashlytics were simple enough that passing a few parameters to a helper function sufficed. However, with the added complexity of Crashlytics' asynchronous initialization, we now need to explicitly separate the **data collection** logic from the **disk recording** logic to ensure we preserve the correct execution context.

This PR addresses that complexity by introducing a dedicated `FIRCLSNonFatalError` class. This model records the state of the error at initialization and provides another method to write the error to disk, effectively seperating the 2.

#### **Related Issues & PRs**
* **Addresses feedback from:** #16126 
* **Facilitates:** #16045. By centralizing the non-fatal error payload into a dedicated object, we are laying the groundwork to easily support modifying the `userInfo` dictionary before the error is written to disk. The logic to modify the userinfo dict can move to a method within this class instead of being in `recordError(error:, userInfo:)` in `FIRCrashlytics.m` and this method should be called in the initializer for this class to update the dict if needed.

#### **Changes Made**
* Created the `FIRCLSNonFatalError` class in `Crashlytics/Models/` to act as an immutable state snapshot.
* Updated `recordError:userInfo:` to initialize this model before entering the async queue, guaranteeing the origin stack trace is preserved regardless of how long initialization takes.

#### **Testing & Verification**
* [x] **Real Device Testing:** Deployed and verified on a physical iOS device to ensure non-fatal payloads are generated and uploaded correctly.
* [x] **Unit Tests:** All existing and newly affected unit tests are passing successfully.
* [x] **Code Quality:** Passed the internal linting and formatting checks (`./scripts/check.sh`).

#no-changelog