### PR TITLE
fix(ci): prevent Firestore SPM jobs from running on unrelated PRs

### DIFF
--- a/.github/workflows/sdk.firestore.yml
+++ b/.github/workflows/sdk.firestore.yml
@@ -517,6 +517,7 @@ jobs:
           --no-analyze
 
   spm-package-resolved:
+    needs: check
     runs-on: macos-26
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
@@ -590,6 +591,7 @@ jobs:
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestore ${{ matrix.target }} spmbuildonly
 
   spm-binary:
+    needs: check
     uses: ./.github/workflows/_spm.yml
     with:
       target: FirebaseFirestoreTests


### PR DESCRIPTION
The `spm-package-resolved` and `spm-binary` jobs in `sdk.firestore.yml` were missing their `needs: check` requirement. This caused them to bypass the `dorny/paths-filter` logic and spin up ~10-minute Xcode builds on every single PR in the repository, regardless of what files were changed.

This adds the missing dependencies so they properly skip when no Firestore files are touched.

#no-changelog