### PR TITLE
fix(config): fix race condition in experiment updates

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fixed a race condition that could lead to a crash in ABTesting when
+  updating experiments. (#16145)
+
 # 12.13.0
 - [fixed] Remote Config Realtime updates now trigger when a parameter's experiment
   or variant assignment changes, ensuring more accurate A/B test analytics and

--- a/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
@@ -149,7 +149,7 @@ static NSString *const kMethodNameLatestStartTime =
                                   events:lifecycleEvent
                                   policy:ABTExperimentPayloadExperimentOverflowPolicyDiscardOldest
                            lastStartTime:lastStartTime
-                                payloads:_experimentPayloads
+                                payloads:[_experimentPayloads copy]
                        completionHandler:handler];
 
   /// Update activated experiments payload and metadata in DB.


### PR DESCRIPTION
Fixes a race condition crash in `ABTesting` when Remote Config updates experiments.

#### Problem
* `RCNConfigExperiment` passes its internal mutable array `_experimentPayloads` to `FIRExperimentController` ([RCNConfigExperiment.m#L152](https://github.com/firebase/firebase-ios-sdk/blob/dc18b7f5b90caf81e5e39cc4052637b2ff238a4d/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m#L152)).
* `FIRExperimentController` dispatches to a background queue and attempts to copy this array ([FIRExperimentController.m#L51](https://github.com/firebase/firebase-ios-sdk/blob/dc18b7f5b90caf81e5e39cc4052637b2ff238a4d/FirebaseABTesting/Sources/FIRExperimentController.m#L51)).
* If `_experimentPayloads` is mutated on the Remote Config serial queue (e.g., during a fetch completion) while the background thread is copying it, the app crashes with an array bounds exception (`range {0, 1} extends beyond bounds for empty array`).

#### Solution
Pass an immutable copy of `_experimentPayloads` from Remote Config so that the background thread in `ABTesting` operates on a safe snapshot.

Fix #16145