### PR TITLE
[ABT] Fix race crash

### DIFF
--- a/FirebaseABTesting/CHANGELOG.md
+++ b/FirebaseABTesting/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-- [fixed] Fix crash caused by a race condition on the mutable `payloads` array. (#16145)
+- [fixed] Fixed a race condition that could lead to a crash in ABTesting when
+  updating experiments. (#16145)
 
 # 10.16.0
 - [fixed] Fix crash caused by empty experiment payload. (#11873)

--- a/FirebaseABTesting/CHANGELOG.md
+++ b/FirebaseABTesting/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fix crash caused by a race condition on the mutable `payloads` array. (#16145)
+
 # 10.16.0
 - [fixed] Fix crash caused by empty experiment payload. (#11873)
 

--- a/FirebaseABTesting/Sources/FIRExperimentController.m
+++ b/FirebaseABTesting/Sources/FIRExperimentController.m
@@ -165,6 +165,7 @@ NSArray *ABTExperimentsToClearFromPayloads(
                                   payloads:(NSArray<NSData *> *)payloads
                          completionHandler:
                              (nullable void (^)(NSError *_Nullable error))completionHandler {
+  NSArray<NSData *> *payloadsCopy = [payloads copy];
   FIRExperimentController *__weak weakSelf = self;
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
     FIRExperimentController *strongSelf = weakSelf;
@@ -172,7 +173,7 @@ NSArray *ABTExperimentsToClearFromPayloads(
                                                                     events:events
                                                                     policy:policy
                                                              lastStartTime:lastStartTime
-                                                                  payloads:payloads
+                                                                  payloads:payloadsCopy
                                                          completionHandler:completionHandler];
   });
 }


### PR DESCRIPTION
Fix #16145

**Crash Analysis**
The crash occurs due to a thread safety issue (race condition) when creating a copy of a mutable array on a background thread.

**1. The Underlying Cause**
The crash is a classic concurrency issue caused by 
FIRExperimentController.m
 asynchronously accessing a mutable array that is passed by the caller.

**A. Asynchronous Execution in Firebase ABTesting**
In FIRExperimentController.m, the updateExperimentsWithServiceOrigin:events:policy:lastStartTime:payloads:completionHandler: method dispatches the work to a background queue:

**B. Mutation by the Caller (RCNConfigExperiment.m)**
Even though the user's request states they are not using any A/B testing functionality, Firebase Remote Config internally uses Firebase ABTesting to process experiments (frc service origin).

In RCNConfigExperiment.m , the _experimentPayloads property is a mutable array (NSMutableArray<NSData *>*). During synchronization, Remote Config triggers an update:

**C. Race Condition**
updateExperimentsWithHandler: passes _experimentPayloads (NSMutableArray) to updateExperimentsWithServiceOrigin:.
FIRExperimentController captures a reference to this mutable array inside a dispatch_async block.
While the background thread starts executing, the main thread concurrently receives a new server payload and mutates the array (e.g., it clears all objects in updateExperimentsWithResponse: by calling [_experimentPayloads removeAllObjects]).
As the background thread reaches line 51 of FIRExperimentController.m (NSArray *payloadsCopy = [payloads copy]), it executes initWithArray:range:copyItems:. It reads the array's count and tries to obtain the objects. Because the array was cleared by the main thread, it tries to read a range that is out of the new bounds of the empty array, resulting in the crash: *** -[__NSArrayM getObjects:range:]: range {0, 1} extends beyond bounds for empty array

**2. The Fix**
To fix this crash, FIRExperimentController must create an immutable copy of the payloads array synchronously on the calling thread before passing it to the background queue.

