### PR TITLE
[Perf] Fix a race condition

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixed race condition crash. (#16144)
+
 # 12.13.0
 - [fixed] Fixed NSURLSession delegate instrumentation for NSProxy delegates. (#14478)
 - [fixed] Address crash by deferring class disposal in FPRObjectSwizzler. (#14473)

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-- [fixed] Fixed race condition crash. (#16144)
+- [fixed] Fixed a race condition crash in `FPRConfigurations` by making
+  `remoteConfigFlags` atomic and explicitly nullable. (#16144)
 
 # 12.13.0
 - [fixed] Fixed NSURLSession delegate instrumentation for NSProxy delegates. (#14478)

--- a/FirebasePerformance/Sources/Configurations/FPRConfigurations+Private.h
+++ b/FirebasePerformance/Sources/Configurations/FPRConfigurations+Private.h
@@ -32,7 +32,7 @@ typedef NS_OPTIONS(NSUInteger, FPRConfigurationSource) {
 @property(nonatomic) FPRConfigurationSource sources;
 
 /** @brief Instance of remote config flags. */
-@property(atomic) FPRRemoteConfigFlags *remoteConfigFlags;
+@property(atomic, nullable) FPRRemoteConfigFlags *remoteConfigFlags;
 
 /** @brief The class to use when FIRApp is referenced. */
 @property(nonatomic) Class FIRAppClass;

--- a/FirebasePerformance/Sources/Configurations/FPRConfigurations+Private.h
+++ b/FirebasePerformance/Sources/Configurations/FPRConfigurations+Private.h
@@ -32,7 +32,7 @@ typedef NS_OPTIONS(NSUInteger, FPRConfigurationSource) {
 @property(nonatomic) FPRConfigurationSource sources;
 
 /** @brief Instance of remote config flags. */
-@property(nonatomic) FPRRemoteConfigFlags *remoteConfigFlags;
+@property(atomic) FPRRemoteConfigFlags *remoteConfigFlags;
 
 /** @brief The class to use when FIRApp is referenced. */
 @property(nonatomic) Class FIRAppClass;


### PR DESCRIPTION
Fix #16144 

AI analysis:

**Crash Analysis**
The crash occurs in [FPRConfigurations sdkDisabledVersions] at line 271 of 
FPRConfigurations.m
 (or alternatively at line 224 in sdkEnabled). Both of these lines correspond to the exact same check:

The crash is a segmentation fault (SIGSEGV) inside objc_retain, which indicates that the app is attempting to retain an invalid or garbage pointer.

**The Root Cause:** Data Race on remoteConfigFlags
This is a race condition caused by unsafe concurrent access to the remoteConfigFlags property:

Non-atomic Property: In FPRConfigurations+Private.h, the property is declared as nonatomic:
nonatomic properties are not thread-safe. If one thread reads the property while another is writing to it, the behavior is undefined, often resulting in a pointer that points to garbage or a deallocated object.

**Concurrent Access Patterns:**

_Write:_ The property is initialized lazily in setupRemoteConfigFlags, which is called inside update (line 119). This runs asynchronously on self.updateQueue (a background serial queue).
_Read:_ Methods like sdkEnabled and sdkDisabledVersions read self.remoteConfigFlags directly from whatever thread they are called on.
In this specific crash, Thread 0 (the main thread) was calling sdkEnabled during early app startup (triggered by StartupAnalytics.Trace.init), while the background updateQueue was likely trying to initialize remoteConfigFlags at the same time. The main thread read a partially written or non-synchronized pointer, leading to the crash in objc_retain.

**Proposed Solution**
The most straightforward and safe fix is to make the remoteConfigFlags property atomic. This ensures that the getter and setter for the pointer are synchronized, preventing the read/write race.