### PR TITLE
chore(m180): Update carthage json versions

### DIFF
--- a/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseABTestingBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseABTesting-f8afbe4fd89721e4.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseABTesting-17b3a7cce9c2d524.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseABTesting-637ebc6cbd9d8925.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseABTesting-e179169f36bf94cf.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseABTesting-328b9123860fa215.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseABTesting-240f73a221798c3b.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseABTesting-453e3715e84856d3.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAILogicBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAILogicBinary.json
@@ -2,6 +2,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseAILogic-e7cf2116e42a5d8e.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseAILogic-8bc8837239c36bf3.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseAILogic-66b9dfb7b6b2e9af.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseAILogic-e6ede00ccb443899.zip",
   "12.5.0": "https://dl.google.com/dl/firebase/ios/carthage/12.5.0/FirebaseAILogic-543b2fedd88a76fd.zip",
   "12.6.0": "https://dl.google.com/dl/firebase/ios/carthage/12.6.0/FirebaseAILogic-127f2f25e744831a.zip",
   "12.7.0": "https://dl.google.com/dl/firebase/ios/carthage/12.7.0/FirebaseAILogic-80017565705ec5ff.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAnalyticsBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseAnalytics-df3afb09bbd5e6f4.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseAnalytics-79b9046f03fffdd9.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseAnalytics-3792c63bd418ee4d.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseAnalytics-509d43cfe08b2156.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAnalytics-b37787f72cdbb950.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseAnalytics-866ebeb7925d0267.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAnalytics-61b0d6c9596bf37a.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppCheckBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseAppCheck-ac07812d496e0727.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseAppCheck-77ee4e7e4d31c8b5.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseAppCheck-a11f86e8d876cdaf.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseAppCheck-f10f5fda2e48ce4c.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAppCheck-dac2380c7e1b9898.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseAppCheck-f0fb8c2a38b272c7.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAppCheck-f45ebf0c8d5ae0aa.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAppDistributionBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseAppDistribution-65f6474aa8393329.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseAppDistribution-66d6cefaf371fda2.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseAppDistribution-974df7ffdb3f3906.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseAppDistribution-cb826860c12147e6.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAppDistribution-042b04483c9241b6.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseAppDistribution-8498aaebd9f9e633.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAppDistribution-aa1bb9ef501d82e7.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseAuthBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseAuth-0e942a3add1a3919.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseAuth-ac5ad06680f102e0.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseAuth-0a5378975e10c627.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseAuth-ebb5145697e2e3dc.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseAuth-9f0a14da6c12ea6d.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseAuth-e4ba94c15c57a75f.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseAuth-9d35d5c62a3e1a75.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseCrashlyticsBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseCrashlytics-b39296402bc5db93.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseCrashlytics-751687c364305f0a.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseCrashlytics-05e22c4ed1a8e80b.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseCrashlytics-14134e3593df498d.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseCrashlytics-623ce628d0404f39.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseCrashlytics-6054b7e88b91a91d.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseCrashlytics-49a8a1b1f30115df.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseDatabaseBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseDatabase-740fd2c59012f647.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseDatabase-8ff34422ab50c812.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseDatabase-7fa22f368e883381.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseDatabase-c77408fa6b6c347e.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseDatabase-a87ae96a7eeb2535.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseDatabase-2b6c597465ec9d34.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseDatabase-34750cd661cbd49b.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFirestoreBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseFirestore-bb952aca63e09d18.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseFirestore-f203ce019586eed6.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseFirestore-fbcdee99a0da6de0.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseFirestore-7f3885c117631396.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseFirestore-8d65b82dc9d53ddf.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseFirestore-e8ec00ce472204d2.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseFirestore-acab074433fa0c6f.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseFunctionsBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseFunctions-61a6223e133ce1f3.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseFunctions-7f55fffde7d5b5b2.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseFunctions-bb12d7881808c6cf.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseFunctions-1cec9043b1126d6a.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseFunctions-f3aa95160827b0af.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseFunctions-6d891e5b755e773c.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseFunctions-8589fb2f6bff1e38.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseGoogleSignInBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/GoogleSignIn-fe7ccb3e501e785a.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/GoogleSignIn-99c23ce3db931d3a.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/GoogleSignIn-ac3e5d8abd052773.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/GoogleSignIn-772e6de1779f505a.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/GoogleSignIn-31b2e32d1dadbaa8.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/GoogleSignIn-0a9fd70d77dbb99e.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/GoogleSignIn-bcaadfe04c892ecb.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseInAppMessagingBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseInAppMessaging-ef1e19aafce40411.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseInAppMessaging-a185674e921c4a62.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseInAppMessaging-107b6f1a203e8a24.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseInAppMessaging-98df0304da56f03e.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseInAppMessaging-0ec7907b67ce2888.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseInAppMessaging-349edad4650cdc0e.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseInAppMessaging-9447455910a3800d.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMLModelDownloaderBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseMLModelDownloader-971e20f69f1c0bbb.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseMLModelDownloader-1d2b4b4461787761.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseMLModelDownloader-8213cf02ed7e0f22.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseMLModelDownloader-cef24ededff8fc64.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseMLModelDownloader-6bfb3459ae557ef3.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseMLModelDownloader-1d7e6bff24c9b2ec.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseMLModelDownloader-2ce9f1e78f15027f.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseMessagingBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseMessaging-df038d1c9fa53d25.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseMessaging-60a2bd57e0230e88.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseMessaging-ff647714ec841a88.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseMessaging-2741616d8d440a0e.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseMessaging-d1ab6eaf596d9b7d.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseMessaging-2a16804f5c5602a0.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseMessaging-9175a3fe41e7c83c.zip",

--- a/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebasePerformanceBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebasePerformance-c30d957c99c1f1f6.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebasePerformance-2aa956db64dd90ec.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebasePerformance-4f721eb9bce3ff38.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebasePerformance-9afee440c65be3b0.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebasePerformance-1913383f1952dce6.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebasePerformance-5e59e383ee5e57f7.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebasePerformance-79cbc1d26656ac6d.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseRemoteConfigBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseRemoteConfig-2febbb9885f9f7c1.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseRemoteConfig-f999f990313fc1af.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseRemoteConfig-0acd93bfd5de8298.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseRemoteConfig-48b0c45d392ba5ff.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseRemoteConfig-3e803b148769baed.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseRemoteConfig-41aaab0dc398a6fc.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseRemoteConfig-5d12611a14be55c9.zip",

--- a/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
+++ b/ReleaseTooling/CarthageJSON/FirebaseStorageBinary.json
@@ -49,6 +49,7 @@
   "12.10.0": "https://dl.google.com/dl/firebase/ios/carthage/12.10.0/FirebaseStorage-9c80624f61f0c00e.zip",
   "12.11.0": "https://dl.google.com/dl/firebase/ios/carthage/12.11.0/FirebaseStorage-961134db6650fae1.zip",
   "12.12.0": "https://dl.google.com/dl/firebase/ios/carthage/12.12.0/FirebaseStorage-2ad96356056bde76.zip",
+  "12.13.0": "https://dl.google.com/dl/firebase/ios/carthage/12.13.0/FirebaseStorage-1b667f19b747f6b9.zip",
   "12.2.0": "https://dl.google.com/dl/firebase/ios/carthage/12.2.0/FirebaseStorage-20489713b94790a0.zip",
   "12.3.0": "https://dl.google.com/dl/firebase/ios/carthage/12.3.0/FirebaseStorage-318fa79cc514a2be.zip",
   "12.4.0": "https://dl.google.com/dl/firebase/ios/carthage/12.4.0/FirebaseStorage-e758b10b671ddad7.zip",


### PR DESCRIPTION
This PR updates the carthage json versions in the repo to include the newly published `12.13.0` versions for this release.

#no-changelog