### PR TITLE
chore(m180): update versions for Release 12.14.0

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Firebase'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Firebase'
 
   s.description      = <<-DESC
@@ -36,14 +36,14 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.ios.deployment_target = '15.0'
     ss.osx.deployment_target = '10.15'
     ss.tvos.deployment_target = '15.0'
-    ss.ios.dependency 'FirebaseAnalytics', '~> 12.13.0'
-    ss.osx.dependency 'FirebaseAnalytics', '~> 12.13.0'
-    ss.tvos.dependency 'FirebaseAnalytics', '~> 12.13.0'
+    ss.ios.dependency 'FirebaseAnalytics', '~> 12.14.0'
+    ss.osx.dependency 'FirebaseAnalytics', '~> 12.14.0'
+    ss.tvos.dependency 'FirebaseAnalytics', '~> 12.14.0'
     ss.dependency 'Firebase/CoreOnly'
   end
 
   s.subspec 'CoreOnly' do |ss|
-    ss.dependency 'FirebaseCore', '~> 12.13.0'
+    ss.dependency 'FirebaseCore', '~> 12.14.0'
     ss.source_files = 'CoreOnly/Sources/Firebase.h'
     ss.preserve_paths = 'CoreOnly/Sources/module.modulemap'
     if ENV['FIREBASE_POD_REPO_FOR_DEV_POD'] then
@@ -70,7 +70,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'ABTesting' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseABTesting', '~> 12.13.0'
+    ss.dependency 'FirebaseABTesting', '~> 12.14.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '15.0'
     ss.osx.deployment_target = '10.15'
@@ -80,13 +80,13 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'AppDistribution' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseAppDistribution', '~> 12.13.0-beta'
+    ss.ios.dependency 'FirebaseAppDistribution', '~> 12.14.0-beta'
     ss.ios.deployment_target = '15.0'
   end
 
   s.subspec 'AppCheck' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseAppCheck', '~> 12.13.0'
+    ss.dependency 'FirebaseAppCheck', '~> 12.14.0'
     ss.ios.deployment_target = '15.0'
     ss.osx.deployment_target = '10.15'
     ss.tvos.deployment_target = '15.0'
@@ -95,7 +95,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Auth' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseAuth', '~> 12.13.0'
+    ss.dependency 'FirebaseAuth', '~> 12.14.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '15.0'
     ss.osx.deployment_target = '10.15'
@@ -105,7 +105,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Crashlytics' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseCrashlytics', '~> 12.13.0'
+    ss.dependency 'FirebaseCrashlytics', '~> 12.14.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '15.0'
     ss.osx.deployment_target = '10.15'
@@ -115,7 +115,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Database' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseDatabase', '~> 12.13.0'
+    ss.dependency 'FirebaseDatabase', '~> 12.14.0'
     # Standard platforms PLUS watchOS 7.
     ss.ios.deployment_target = '15.0'
     ss.osx.deployment_target = '10.15'
@@ -125,7 +125,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Firestore' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseFirestore', '~> 12.13.0'
+    ss.dependency 'FirebaseFirestore', '~> 12.14.0'
     ss.ios.deployment_target = '15.0'
     ss.osx.deployment_target = '10.15'
     ss.tvos.deployment_target = '15.0'
@@ -133,7 +133,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Functions' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseFunctions', '~> 12.13.0'
+    ss.dependency 'FirebaseFunctions', '~> 12.14.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '15.0'
     ss.osx.deployment_target = '10.15'
@@ -143,20 +143,20 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'InAppMessaging' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseInAppMessaging', '~> 12.13.0-beta'
-    ss.tvos.dependency 'FirebaseInAppMessaging', '~> 12.13.0-beta'
+    ss.ios.dependency 'FirebaseInAppMessaging', '~> 12.14.0-beta'
+    ss.tvos.dependency 'FirebaseInAppMessaging', '~> 12.14.0-beta'
     ss.ios.deployment_target = '15.0'
     ss.tvos.deployment_target = '15.0'
   end
 
   s.subspec 'Installations' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseInstallations', '~> 12.13.0'
+    ss.dependency 'FirebaseInstallations', '~> 12.14.0'
   end
 
   s.subspec 'Messaging' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseMessaging', '~> 12.13.0'
+    ss.dependency 'FirebaseMessaging', '~> 12.14.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '15.0'
     ss.osx.deployment_target = '10.15'
@@ -166,7 +166,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'MLModelDownloader' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseMLModelDownloader', '~> 12.13.0-beta'
+    ss.dependency 'FirebaseMLModelDownloader', '~> 12.14.0-beta'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '15.0'
     ss.osx.deployment_target = '10.15'
@@ -176,15 +176,15 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Performance' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebasePerformance', '~> 12.13.0'
-    ss.tvos.dependency 'FirebasePerformance', '~> 12.13.0'
+    ss.ios.dependency 'FirebasePerformance', '~> 12.14.0'
+    ss.tvos.dependency 'FirebasePerformance', '~> 12.14.0'
     ss.ios.deployment_target = '15.0'
     ss.tvos.deployment_target = '15.0'
   end
 
   s.subspec 'RemoteConfig' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseRemoteConfig', '~> 12.13.0'
+    ss.dependency 'FirebaseRemoteConfig', '~> 12.14.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '15.0'
     ss.osx.deployment_target = '10.15'
@@ -194,7 +194,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Storage' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseStorage', '~> 12.13.0'
+    ss.dependency 'FirebaseStorage', '~> 12.14.0'
     # Standard platforms PLUS watchOS.
     ss.ios.deployment_target = '15.0'
     ss.osx.deployment_target = '10.15'

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseABTesting'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Firebase ABTesting'
 
   s.description      = <<-DESC
@@ -51,7 +51,7 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
-  s.dependency 'FirebaseCore', '~> 12.13.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }

--- a/FirebaseAI.podspec
+++ b/FirebaseAI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAI'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Firebase AI SDK'
 
   s.description      = <<-DESC
@@ -43,8 +43,8 @@ Build AI-powered apps and features with the Gemini API using the Firebase AI SDK
   s.tvos.framework = 'UIKit'
   s.watchos.framework = 'WatchKit'
 
-  s.dependency 'FirebaseAILogic', '12.13.0'
-  s.dependency 'FirebaseCore', '~> 12.13.0'
+  s.dependency 'FirebaseAILogic', '12.14.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests_dir = 'FirebaseAI/Wrapper/Tests/'

--- a/FirebaseAILogic.podspec
+++ b/FirebaseAILogic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAILogic'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Firebase AI Logic SDK'
 
   s.description      = <<-DESC
@@ -51,10 +51,10 @@ Build AI-powered apps and features with the Gemini API using the Firebase AI Log
   s.ios.pod_target_xcconfig = swift_flags_xcconfig
   s.osx.pod_target_xcconfig = swift_flags_xcconfig
 
-  s.dependency 'FirebaseAppCheckInterop', '~> 12.13.0'
-  s.dependency 'FirebaseAuthInterop', '~> 12.13.0'
-  s.dependency 'FirebaseCore', '~> 12.13.0'
-  s.dependency 'FirebaseCoreExtension', '~> 12.13.0'
+  s.dependency 'FirebaseAppCheckInterop', '~> 12.14.0'
+  s.dependency 'FirebaseAuthInterop', '~> 12.14.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
+  s.dependency 'FirebaseCoreExtension', '~> 12.14.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests_dir = 'FirebaseAI/Tests/Unit/'

--- a/FirebaseAnalytics.podspec
+++ b/FirebaseAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'FirebaseAnalytics'
-    s.version          = '12.13.0'
+    s.version          = '12.14.0'
     s.summary          = 'Firebase Analytics for iOS'
 
     s.description      = <<-DESC
@@ -26,8 +26,8 @@ Pod::Spec.new do |s|
     s.libraries  = 'c++', 'sqlite3', 'z'
     s.frameworks = 'StoreKit'
 
-    s.dependency 'FirebaseCore', '~> 12.13.0'
-    s.dependency 'FirebaseInstallations', '~> 12.13.0'
+    s.dependency 'FirebaseCore', '~> 12.14.0'
+    s.dependency 'FirebaseInstallations', '~> 12.14.0'
     s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 8.1'
     s.dependency 'GoogleUtilities/MethodSwizzler', '~> 8.1'
     s.dependency 'GoogleUtilities/NSData+zlib', '~> 8.1'
@@ -37,17 +37,17 @@ Pod::Spec.new do |s|
     s.default_subspecs = 'Default'
 
     s.subspec 'Default' do |ss|
-        ss.dependency 'GoogleAppMeasurement/Default', '12.13.0'
+        ss.dependency 'GoogleAppMeasurement/Default', '12.14.0'
         ss.vendored_frameworks = 'Frameworks/FirebaseAnalytics.xcframework'
     end
 
     s.subspec 'Core' do |ss|
-        ss.dependency 'GoogleAppMeasurement/Core', '12.13.0'
+        ss.dependency 'GoogleAppMeasurement/Core', '12.14.0'
         ss.vendored_frameworks = 'Frameworks/FirebaseAnalytics.xcframework'
     end
 
     s.subspec 'IdentitySupport' do |ss|
-        ss.dependency 'GoogleAppMeasurement/IdentitySupport', '12.13.0'
+        ss.dependency 'GoogleAppMeasurement/IdentitySupport', '12.14.0'
         ss.vendored_frameworks = 'Frameworks/FirebaseAnalytics.xcframework'
     end
 

--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAppCheck'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Firebase App Check SDK.'
 
   s.description      = <<-DESC
@@ -45,8 +45,8 @@ Pod::Spec.new do |s|
   s.tvos.weak_framework = 'DeviceCheck'
 
   s.dependency 'AppCheckCore', '~> 11.0'
-  s.dependency 'FirebaseAppCheckInterop', '~> 12.13.0'
-  s.dependency 'FirebaseCore', '~> 12.13.0'
+  s.dependency 'FirebaseAppCheckInterop', '~> 12.14.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
   s.dependency 'GoogleUtilities/Environment', '~> 8.1'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.1'
 

--- a/FirebaseAppCheckInterop.podspec
+++ b/FirebaseAppCheckInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAppCheckInterop'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Interfaces that allow other Firebase SDKs to use AppCheck functionality.'
 
   s.description      = <<-DESC

--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAppDistribution'
-  s.version          = '12.13.0-beta'
+  s.version          = '12.14.0-beta'
   s.summary          = 'App Distribution for Firebase iOS SDK.'
 
   s.description      = <<-DESC
@@ -30,10 +30,10 @@ iOS SDK for App Distribution for Firebase.
   ]
   s.public_header_files = base_dir + 'Public/FirebaseAppDistribution/*.h'
 
-  s.dependency 'FirebaseCore', '~> 12.13.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 8.1'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.1'
-  s.dependency 'FirebaseInstallations', '~> 12.13.0'
+  s.dependency 'FirebaseInstallations', '~> 12.14.0'
 
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAuth'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Apple platform client for Firebase Authentication'
 
   s.description      = <<-DESC
@@ -55,10 +55,10 @@ supports email and password accounts, as well as several 3rd party authenticatio
   }
   s.framework = 'Security'
   s.ios.framework = 'SafariServices'
-  s.dependency 'FirebaseAuthInterop', '~> 12.13.0'
-  s.dependency 'FirebaseAppCheckInterop', '~> 12.13.0'
-  s.dependency 'FirebaseCore', '~> 12.13.0'
-  s.dependency 'FirebaseCoreExtension', '~> 12.13.0'
+  s.dependency 'FirebaseAuthInterop', '~> 12.14.0'
+  s.dependency 'FirebaseAppCheckInterop', '~> 12.14.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
+  s.dependency 'FirebaseCoreExtension', '~> 12.14.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 8.1'
   s.dependency 'GoogleUtilities/Environment', '~> 8.1'
   s.dependency 'GTMSessionFetcher/Core', '>= 3.4', '< 6.0'

--- a/FirebaseAuthInterop.podspec
+++ b/FirebaseAuthInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAuthInterop'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Interfaces that allow other Firebase SDKs to use Auth functionality.'
 
   s.description      = <<-DESC

--- a/FirebaseCombineSwift.podspec
+++ b/FirebaseCombineSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCombineSwift'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Swift extensions with Combine support for Firebase'
 
   s.description      = <<-DESC
@@ -51,11 +51,11 @@ for internal testing only. It should not be published.
   s.osx.framework = 'AppKit'
   s.tvos.framework = 'UIKit'
 
-  s.dependency 'FirebaseCore', '~> 12.13.0'
-  s.dependency 'FirebaseAuth', '~> 12.13.0'
-  s.dependency 'FirebaseFunctions', '~> 12.13.0'
-  s.dependency 'FirebaseFirestore', '~> 12.13.0'
-  s.dependency 'FirebaseStorage', '~> 12.13.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
+  s.dependency 'FirebaseAuth', '~> 12.14.0'
+  s.dependency 'FirebaseFunctions', '~> 12.14.0'
+  s.dependency 'FirebaseFirestore', '~> 12.14.0'
+  s.dependency 'FirebaseStorage', '~> 12.14.0'
 
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
@@ -104,6 +104,6 @@ for internal testing only. It should not be published.
     int_tests.resources = 'FirebaseStorage/Tests/Integration/Resources/1mb.dat',
                           'FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist',
                           'FirebaseStorage/Tests/Integration/Resources/HomeImprovement.numbers'
-    int_tests.dependency 'FirebaseAuth', '~> 12.13.0'
+    int_tests.dependency 'FirebaseAuth', '~> 12.14.0'
   end
 end

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Firebase Core'
 
   s.description      = <<-DESC
@@ -53,7 +53,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   # Remember to also update version in `cmake/external/GoogleUtilities.cmake`
   s.dependency 'GoogleUtilities/Environment', '~> 8.1'
   s.dependency 'GoogleUtilities/Logger', '~> 8.1'
-  s.dependency 'FirebaseCoreInternal', '~> 12.13.0'
+  s.dependency 'FirebaseCoreInternal', '~> 12.14.0'
 
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',

--- a/FirebaseCoreExtension.podspec
+++ b/FirebaseCoreExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'FirebaseCoreExtension'
-    s.version          = '12.13.0'
+    s.version          = '12.14.0'
     s.summary          = 'Extended FirebaseCore APIs for Firebase product SDKs'
 
     s.description      = <<-DESC
@@ -38,5 +38,5 @@ Pod::Spec.new do |s|
       'DEFINES_MODULE' => 'YES'
     }
 
-    s.dependency 'FirebaseCore', '~> 12.13.0'
+    s.dependency 'FirebaseCore', '~> 12.14.0'
   end

--- a/FirebaseCoreInternal.podspec
+++ b/FirebaseCoreInternal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCoreInternal'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'APIs for internal FirebaseCore usage.'
 
   s.description      = <<-DESC

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCrashlytics'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Best and lightest-weight crash reporting for mobile, desktop and tvOS.'
   s.description      = 'Firebase Crashlytics helps you track, prioritize, and fix stability issues that erode app quality.'
   s.homepage         = 'https://firebase.google.com/'
@@ -59,10 +59,10 @@ Pod::Spec.new do |s|
     cp -f ./Crashlytics/CrashlyticsInputFiles.xcfilelist ./CrashlyticsInputFiles.xcfilelist
   PREPARE_COMMAND_END
 
-  s.dependency 'FirebaseCore', '~> 12.13.0'
-  s.dependency 'FirebaseInstallations', '~> 12.13.0'
-  s.dependency 'FirebaseSessions', '~> 12.13.0'
-  s.dependency 'FirebaseRemoteConfigInterop', '~> 12.13.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
+  s.dependency 'FirebaseInstallations', '~> 12.14.0'
+  s.dependency 'FirebaseSessions', '~> 12.14.0'
+  s.dependency 'FirebaseRemoteConfigInterop', '~> 12.14.0'
   s.dependency 'PromisesObjC', '~> 2.4'
   s.dependency 'GoogleDataTransport', '~> 10.1'
   s.dependency 'GoogleUtilities/Environment', '~> 8.1'

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseDatabase'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Firebase Realtime Database'
 
   s.description      = <<-DESC
@@ -48,9 +48,9 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.macos.frameworks = 'CFNetwork', 'Security', 'SystemConfiguration'
   s.watchos.frameworks = 'CFNetwork', 'Security', 'WatchKit'
   s.dependency 'leveldb-library', '~> 1.22'
-  s.dependency 'FirebaseCore', '~> 12.13.0'
-  s.dependency 'FirebaseAppCheckInterop', '~> 12.13.0'
-  s.dependency 'FirebaseSharedSwift', '~> 12.13.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
+  s.dependency 'FirebaseAppCheckInterop', '~> 12.14.0'
+  s.dependency 'FirebaseSharedSwift', '~> 12.14.0'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.1'
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
@@ -72,7 +72,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
       'SharedTestUtilities/FIRComponentTestUtilities.[mh]',
       'SharedTestUtilities/FIROptionsMock.[mh]',
     ]
-    unit_tests.dependency 'FirebaseAppCheckInterop', '~> 12.13.0'
+    unit_tests.dependency 'FirebaseAppCheckInterop', '~> 12.14.0'
     unit_tests.dependency 'OCMock'
     unit_tests.resources = 'FirebaseDatabase/Tests/Resources/syncPointSpec.json',
                            'FirebaseDatabase/Tests/Resources/GoogleService-Info.plist'

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFirestore'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Google Cloud Firestore'
   s.description      = <<-DESC
 Google Cloud Firestore is a NoSQL document database built for automatic scaling, high performance, and ease of application development.
@@ -35,9 +35,9 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
     "#{s.module_name}_Privacy" => 'Firestore/Swift/Source/Resources/PrivacyInfo.xcprivacy'
   }
 
-  s.dependency 'FirebaseCore', '~> 12.13.0'
-  s.dependency 'FirebaseCoreExtension', '~> 12.13.0'
-  s.dependency 'FirebaseFirestoreInternal', '~> 12.13.0'
-  s.dependency 'FirebaseSharedSwift', '~> 12.13.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
+  s.dependency 'FirebaseCoreExtension', '~> 12.14.0'
+  s.dependency 'FirebaseFirestoreInternal', '~> 12.14.0'
+  s.dependency 'FirebaseSharedSwift', '~> 12.14.0'
 
 end

--- a/FirebaseFirestoreInternal.podspec
+++ b/FirebaseFirestoreInternal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFirestoreInternal'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Google Cloud Firestore'
 
   s.description      = <<-DESC
@@ -92,8 +92,8 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
     "#{s.module_name}_Privacy" => 'Firestore/Source/Resources/PrivacyInfo.xcprivacy'
   }
 
-  s.dependency 'FirebaseAppCheckInterop', '~> 12.13.0'
-  s.dependency 'FirebaseCore', '~> 12.13.0'
+  s.dependency 'FirebaseAppCheckInterop', '~> 12.14.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
 
   abseil_version = '~> 1.20240722.0'
   s.dependency 'abseil/algorithm', abseil_version

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFunctions'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Cloud Functions for Firebase'
 
   s.description      = <<-DESC
@@ -35,12 +35,12 @@ Cloud Functions for Firebase.
     'FirebaseFunctions/Sources/**/*.swift',
   ]
 
-  s.dependency 'FirebaseCore', '~> 12.13.0'
-  s.dependency 'FirebaseCoreExtension', '~> 12.13.0'
-  s.dependency 'FirebaseAppCheckInterop', '~> 12.13.0'
-  s.dependency 'FirebaseAuthInterop', '~> 12.13.0'
-  s.dependency 'FirebaseMessagingInterop', '~> 12.13.0'
-  s.dependency 'FirebaseSharedSwift', '~> 12.13.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
+  s.dependency 'FirebaseCoreExtension', '~> 12.14.0'
+  s.dependency 'FirebaseAppCheckInterop', '~> 12.14.0'
+  s.dependency 'FirebaseAuthInterop', '~> 12.14.0'
+  s.dependency 'FirebaseMessagingInterop', '~> 12.14.0'
+  s.dependency 'FirebaseSharedSwift', '~> 12.14.0'
   s.dependency 'GTMSessionFetcher/Core', '>= 3.4', '< 6.0'
 
   s.test_spec 'objc' do |objc_tests|

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInAppMessaging'
-  s.version          = '12.13.0-beta'
+  s.version          = '12.14.0-beta'
   s.summary          = 'Firebase In-App Messaging for iOS'
 
   s.description      = <<-DESC
@@ -80,9 +80,9 @@ See more product details at https://firebase.google.com/products/in-app-messagin
 
   s.framework = 'UIKit'
 
-  s.dependency 'FirebaseCore', '~> 12.13.0'
-  s.dependency 'FirebaseInstallations', '~> 12.13.0'
-  s.dependency 'FirebaseABTesting', '~> 12.13.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
+  s.dependency 'FirebaseInstallations', '~> 12.14.0'
+  s.dependency 'FirebaseABTesting', '~> 12.14.0'
   s.dependency 'GoogleUtilities/Environment', '~> 8.1'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.1'
   s.dependency 'nanopb', '~> 3.30910.0'

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInstallations'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Firebase Installations'
 
   s.description      = <<-DESC
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   }
 
   s.framework = 'Security'
-  s.dependency 'FirebaseCore', '~> 12.13.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
   s.dependency 'PromisesObjC', '~> 2.4'
   s.dependency 'GoogleUtilities/Environment', '~> 8.1'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.1'

--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseMLModelDownloader'
-  s.version          = '12.13.0-beta'
+  s.version          = '12.14.0-beta'
   s.summary          = 'Firebase ML Model Downloader'
 
   s.description      = <<-DESC
@@ -36,9 +36,9 @@ Pod::Spec.new do |s|
   ]
 
   s.framework = 'Foundation'
-  s.dependency 'FirebaseCore', '~> 12.13.0'
-  s.dependency 'FirebaseCoreExtension', '~> 12.13.0'
-  s.dependency 'FirebaseInstallations', '~> 12.13.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
+  s.dependency 'FirebaseCoreExtension', '~> 12.14.0'
+  s.dependency 'FirebaseInstallations', '~> 12.14.0'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.1'
 
   s.pod_target_xcconfig = {

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseMessaging'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Firebase Messaging'
 
   s.description      = <<-DESC
@@ -60,8 +60,8 @@ device, and it is completely free.
   s.tvos.framework = 'SystemConfiguration'
   s.osx.framework = 'SystemConfiguration'
   s.weak_framework = 'UserNotifications'
-  s.dependency 'FirebaseInstallations', '~> 12.13.0'
-  s.dependency 'FirebaseCore', '~> 12.13.0'
+  s.dependency 'FirebaseInstallations', '~> 12.14.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 8.1'
   s.dependency 'GoogleUtilities/Reachability', '~> 8.1'
   s.dependency 'GoogleUtilities/Environment', '~> 8.1'

--- a/FirebaseMessagingInterop.podspec
+++ b/FirebaseMessagingInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseMessagingInterop'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Interfaces that allow other Firebase SDKs to use Messaging functionality.'
 
   s.description      = <<-DESC

--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebasePerformance'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Firebase Performance'
 
   s.description      = <<-DESC
@@ -58,10 +58,10 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
   s.ios.framework = 'CoreTelephony'
   s.framework = 'QuartzCore'
   s.framework = 'SystemConfiguration'
-  s.dependency 'FirebaseCore', '~> 12.13.0'
-  s.dependency 'FirebaseInstallations', '~> 12.13.0'
-  s.dependency 'FirebaseRemoteConfig', '~> 12.13.0'
-  s.dependency 'FirebaseSessions', '~> 12.13.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
+  s.dependency 'FirebaseInstallations', '~> 12.14.0'
+  s.dependency 'FirebaseRemoteConfig', '~> 12.14.0'
+  s.dependency 'FirebaseSessions', '~> 12.14.0'
   s.dependency 'GoogleDataTransport', '~> 10.1'
   s.dependency 'GoogleUtilities/Environment', '~> 8.1'
   s.dependency 'GoogleUtilities/MethodSwizzler', '~> 8.1'

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseRemoteConfig'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Firebase Remote Config'
 
   s.description      = <<-DESC
@@ -49,13 +49,13 @@ app update.
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
-  s.dependency 'FirebaseABTesting', '~> 12.13.0'
-  s.dependency 'FirebaseSharedSwift', '~> 12.13.0'
-  s.dependency 'FirebaseCore', '~> 12.13.0'
-  s.dependency 'FirebaseInstallations', '~> 12.13.0'
+  s.dependency 'FirebaseABTesting', '~> 12.14.0'
+  s.dependency 'FirebaseSharedSwift', '~> 12.14.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
+  s.dependency 'FirebaseInstallations', '~> 12.14.0'
   s.dependency 'GoogleUtilities/Environment', '~> 8.1'
   s.dependency 'GoogleUtilities/NSData+zlib', '~> 8.1'
-  s.dependency 'FirebaseRemoteConfigInterop', '~> 12.13.0'
+  s.dependency 'FirebaseRemoteConfigInterop', '~> 12.14.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.scheme = { :code_coverage => true }

--- a/FirebaseRemoteConfigInterop.podspec
+++ b/FirebaseRemoteConfigInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseRemoteConfigInterop'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Interfaces that allow other Firebase SDKs to use Remote Config functionality.'
 
   s.description      = <<-DESC

--- a/FirebaseSessions.podspec
+++ b/FirebaseSessions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseSessions'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Firebase Sessions'
 
   s.description      = <<-DESC
@@ -39,9 +39,9 @@ Pod::Spec.new do |s|
     base_dir + 'SourcesObjC/**/*.{c,h,m,mm}',
   ]
 
-  s.dependency 'FirebaseCore', '~> 12.13.0'
-  s.dependency 'FirebaseCoreExtension', '~> 12.13.0'
-  s.dependency 'FirebaseInstallations', '~> 12.13.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
+  s.dependency 'FirebaseCoreExtension', '~> 12.14.0'
+  s.dependency 'FirebaseInstallations', '~> 12.14.0'
   s.dependency 'GoogleDataTransport', '~> 10.1'
   s.dependency 'GoogleUtilities/Environment', '~> 8.1'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.1'

--- a/FirebaseSharedSwift.podspec
+++ b/FirebaseSharedSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'FirebaseSharedSwift'
-  s.version                 = '12.13.0'
+  s.version                 = '12.14.0'
   s.summary                 = 'Shared Swift Extensions for Firebase'
 
   s.description      = <<-DESC

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseStorage'
-  s.version          = '12.13.0'
+  s.version          = '12.14.0'
   s.summary          = 'Firebase Storage'
 
   s.description      = <<-DESC
@@ -37,10 +37,10 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
     'FirebaseStorage/Typedefs/*.h',
   ]
 
-  s.dependency 'FirebaseAppCheckInterop', '~> 12.13.0'
-  s.dependency 'FirebaseAuthInterop', '~> 12.13.0'
-  s.dependency 'FirebaseCore', '~> 12.13.0'
-  s.dependency 'FirebaseCoreExtension', '~> 12.13.0'
+  s.dependency 'FirebaseAppCheckInterop', '~> 12.14.0'
+  s.dependency 'FirebaseAuthInterop', '~> 12.14.0'
+  s.dependency 'FirebaseCore', '~> 12.14.0'
+  s.dependency 'FirebaseCoreExtension', '~> 12.14.0'
   s.dependency 'GTMSessionFetcher/Core', '>= 3.4', '< 6.0'
   s.dependency 'GoogleUtilities/Environment', '~> 8.1'
 
@@ -57,7 +57,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
     objc_tests.requires_app_host = true
     objc_tests.resources = 'FirebaseStorage/Tests/Integration/Resources/1mb.dat',
                           'FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist'
-    objc_tests.dependency 'FirebaseAuth', '~> 12.13.0'
+    objc_tests.dependency 'FirebaseAuth', '~> 12.14.0'
     objc_tests.pod_target_xcconfig = {
       'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
     }
@@ -86,6 +86,6 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
     int_tests.resources = 'FirebaseStorage/Tests/Integration/Resources/1mb.dat',
                           'FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist',
                           'FirebaseStorage/Tests/Integration/Resources/HomeImprovement.numbers'
-    int_tests.dependency 'FirebaseAuth', '~> 12.13.0'
+    int_tests.dependency 'FirebaseAuth', '~> 12.14.0'
   end
 end

--- a/GoogleAppMeasurement.podspec
+++ b/GoogleAppMeasurement.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'GoogleAppMeasurement'
-    s.version          = '12.13.0'
+    s.version          = '12.14.0'
     s.summary          = 'Shared measurement methods for Google libraries. Not intended for direct use.'
 
     s.description      = <<-DESC
@@ -37,8 +37,8 @@ Pod::Spec.new do |s|
     s.default_subspecs = 'Default'
 
     s.subspec 'Default' do |ss|
-        ss.dependency 'GoogleAppMeasurement/Core', '12.13.0'
-        ss.dependency 'GoogleAppMeasurement/IdentitySupport', '12.13.0'
+        ss.dependency 'GoogleAppMeasurement/Core', '12.14.0'
+        ss.dependency 'GoogleAppMeasurement/IdentitySupport', '12.14.0'
         ss.ios.dependency 'GoogleAdsOnDeviceConversion', '~> 3.5.0'
     end
 
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
     end
 
     s.subspec 'IdentitySupport' do |ss|
-        ss.dependency 'GoogleAppMeasurement/Core', '12.13.0'
+        ss.dependency 'GoogleAppMeasurement/Core', '12.14.0'
         ss.vendored_frameworks = 'Frameworks/GoogleAppMeasurementIdentitySupport.xcframework'
     end
 end

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@
 
 import PackageDescription
 
-let firebaseVersion = "12.13.0"
+let firebaseVersion = "12.14.0"
 
 let shouldUseSourceFirestore = Context.environment["FIREBASE_SOURCE_FIRESTORE"] != nil
 

--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -21,7 +21,7 @@ import Foundation
 /// The version and releasing fields of the non-Firebase pods should be reviewed every release.
 /// The array should be ordered so that any pod's dependencies precede it in the list.
 public let shared = Manifest(
-  version: "12.13.0",
+  version: "12.14.0",
   pods: [
     Pod("FirebaseSharedSwift"),
     Pod("FirebaseCoreInternal"),


### PR DESCRIPTION
This PR updates the podspec versions to point to `12.14.0` for the next release, since `12.13.0` just went out.

#no-changelog