### PR TITLE
[AI] Use `respond(to:options:)` for `String` generation

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [fixed] Fixed an issue in `GenerativeModelSession` where `String` generation
+  used the wrong overload for `respond(to:)` and `streamResponse(to:)`,
+  resulting in frequent prompt refusals. (#16165)
+
 # 12.13.0
 - [feature] **Public Preview**: Added support for hybrid inference, enabling
   fallback between on-device (Foundation Models) and cloud (Gemini) models. (#16111)

--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 - [fixed] Fixed an issue in `GenerativeModelSession` where `String` generation
   used the wrong overload for `respond(to:)` and `streamResponse(to:)`,
-  resulting in frequent prompt refusals. (#16165)
+  resulting in occasional prompt refusals. (#16165)
 
 # 12.13.0
 - [feature] **Public Preview**: Added support for hybrid inference, enabling

--- a/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
@@ -49,33 +49,36 @@
       -> _ModelSessionResponse {
       let prompt = try prompt.toFoundationModelsPrompt()
 
-      let response: FoundationModels.LanguageModelSession
-        .Response<FoundationModels.GeneratedContent>
+      let rawContent: GeneratedContent
+      let transcriptEntries: ArraySlice<Transcript.Entry>
       if let schema {
-        response = try await respond(
+        let response = try await respond(
           to: prompt,
           schema: schema.generationSchema,
           includeSchemaInPrompt: includeSchemaInPrompt,
           options: options.generationOptions
         )
+        rawContent = response.rawContent
+        transcriptEntries = response.transcriptEntries
       } else {
-        response = try await respond(
+        let response = try await respond(
           to: prompt,
-          schema: String.generationSchema,
           options: options.generationOptions
         )
+        rawContent = response.rawContent
+        transcriptEntries = response.transcriptEntries
       }
 
       #if DEBUG
         if AILog.additionalLoggingEnabled() {
           AILog.debug(
             code: .foundationModelsResponseTranscript,
-            "Foundation Models Transcript: \(response.transcriptEntries)"
+            "Foundation Models Transcript: \(transcriptEntries)"
           )
         }
       #endif // DEBUG
 
-      return makeResponse(from: response.rawContent, schema: schema)
+      return makeResponse(from: rawContent, schema: schema)
     }
 
     /// Sends a prompt to the model and streams the model's response.

--- a/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
@@ -102,42 +102,43 @@
           return
         }
 
-        let stream: FoundationModels.LanguageModelSession
-          .ResponseStream<FoundationModels.GeneratedContent>
-        if let schema {
-          stream = streamResponse(
-            to: foundationModelsPrompt,
-            schema: schema.generationSchema,
-            includeSchemaInPrompt: includeSchemaInPrompt,
-            options: options.generationOptions
-          )
-        } else {
-          stream = streamResponse(
-            to: foundationModelsPrompt,
-            schema: String.generationSchema,
-            options: options.generationOptions
-          )
-        }
-
         let task = Task {
           do {
-            for try await snapshot in stream {
-              let response = makeResponse(from: snapshot.rawContent, schema: schema)
+            func processStream<T>(_ stream: LanguageModelSession.ResponseStream<T>) async throws {
+              for try await snapshot in stream {
+                let response = makeResponse(from: snapshot.rawContent, schema: schema)
 
-              continuation.yield(response)
+                continuation.yield(response)
+              }
+
+              #if DEBUG
+                if AILog.additionalLoggingEnabled() {
+                  // Streaming has completed but we call `collect()` to get a
+                  // `LanguageModelSession.Response`, which contains `transcriptEntries`.
+                  let response = try await stream.collect()
+                  AILog.debug(
+                    code: .foundationModelsStreamResponseTranscript,
+                    "Foundation Models Transcript: \(response.transcriptEntries)"
+                  )
+                }
+              #endif // DEBUG
             }
 
-            #if DEBUG
-              if AILog.additionalLoggingEnabled() {
-                // Streaming has completed but we call `collect()` to get a
-                // `LanguageModelSession.Response`, which contains `transcriptEntries`.
-                let response = try await stream.collect()
-                AILog.debug(
-                  code: .foundationModelsStreamResponseTranscript,
-                  "Foundation Models Transcript: \(response.transcriptEntries)"
-                )
-              }
-            #endif // DEBUG
+            if let schema {
+              let stream = streamResponse(
+                to: foundationModelsPrompt,
+                schema: schema.generationSchema,
+                includeSchemaInPrompt: includeSchemaInPrompt,
+                options: options.generationOptions
+              )
+              try await processStream(stream)
+            } else {
+              let stream = streamResponse(
+                to: foundationModelsPrompt,
+                options: options.generationOptions
+              )
+              try await processStream(stream)
+            }
 
             continuation.finish()
           } catch {

--- a/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
@@ -49,8 +49,8 @@
       -> _ModelSessionResponse {
       let prompt = try prompt.toFoundationModelsPrompt()
 
-      let rawContent: GeneratedContent
-      let transcriptEntries: ArraySlice<Transcript.Entry>
+      let rawContent: FoundationModels.GeneratedContent
+      let transcriptEntries: ArraySlice<FoundationModels.Transcript.Entry>
       if let schema {
         let response = try await respond(
           to: prompt,


### PR DESCRIPTION
Fixed unexpected refusals when generating `String` types by using [`respond(to:options:)`](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/respond(to:options:)) / [`streamResponse(to:options:)`](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/streamresponse(to:options:)) instead of [`respond(to:schema:includeSchemaInPrompt:options:)`](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/respond(to:schema:includeschemainprompt:options:)) / [`streamResponse(to:schema:includeSchemaInPrompt:options:)`](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/streamresponse(to:schema:includeschemainprompt:options:)) with `String.generationSchema` as the schema. These methods return a `String` type instead of [`GeneratedContent`](https://developer.apple.com/documentation/foundationmodels/generatedcontent) and support the [`permissiveContentTransformations`](https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel/guardrails/permissivecontenttransformations) guardrails option.