### PR TITLE
[AI] Reduce number of permutations in integration tests

### DIFF
--- a/FirebaseAI/Tests/TestApp/Sources/Constants.swift
+++ b/FirebaseAI/Tests/TestApp/Sources/Constants.swift
@@ -27,7 +27,7 @@ public enum ModelNames {
   public static let gemini2_5_FlashLive = "gemini-live-2.5-flash-native-audio"
   public static let gemini2_5_FlashLivePreview = "gemini-2.5-flash-native-audio-preview-12-2025"
   public static let gemini2_5_Pro = "gemini-2.5-pro"
-  public static let gemini3_1_FlashLitePreview = "gemini-3.1-flash-lite-preview"
+  public static let gemini3_1_FlashLite = "gemini-3.1-flash-lite"
   public static let gemini3_1_FlashImagePreview = "gemini-3.1-flash-image-preview"
   public static let gemma4_31B = "gemma-4-31b-it"
 }

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/CountTokensIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/CountTokensIntegrationTests.swift
@@ -45,11 +45,11 @@ struct CountTokensIntegrationTests {
     parts: "You are a friendly and helpful assistant."
   )
 
-  @Test(arguments: InstanceConfig.allConfigs)
+  @Test(arguments: InstanceConfig.defaultConfigs)
   func countTokens_text(_ config: InstanceConfig) async throws {
     let prompt = "Why is the sky blue?"
     let model = FirebaseAI.componentInstance(config).generativeModel(
-      modelName: ModelNames.gemini2_5_Flash,
+      modelName: ModelNames.gemini3_1_FlashLite,
       generationConfig: generationConfig,
       safetySettings: safetySettings
     )
@@ -63,10 +63,10 @@ struct CountTokensIntegrationTests {
     #expect(promptTokensDetails.tokenCount == response.totalTokens)
   }
 
-  @Test(arguments: InstanceConfig.allConfigs)
+  @Test(arguments: InstanceConfig.defaultConfigs)
   func countTokens_text_systemInstruction(_ config: InstanceConfig) async throws {
     let model = FirebaseAI.componentInstance(config).generativeModel(
-      modelName: ModelNames.gemini2_5_Flash,
+      modelName: ModelNames.gemini3_1_FlashLite,
       generationConfig: generationConfig,
       safetySettings: safetySettings,
       systemInstruction: systemInstruction
@@ -81,10 +81,10 @@ struct CountTokensIntegrationTests {
     #expect(promptTokensDetails.tokenCount == response.totalTokens)
   }
 
-  @Test(arguments: InstanceConfig.allConfigs)
+  @Test(arguments: InstanceConfig.defaultConfigs)
   func countTokens_jsonSchema(_ config: InstanceConfig) async throws {
     let model = FirebaseAI.componentInstance(config).generativeModel(
-      modelName: ModelNames.gemini2_5_Flash,
+      modelName: ModelNames.gemini3_1_FlashLite,
       generationConfig: GenerationConfig(
         responseMIMEType: "application/json",
         responseSchema: Schema.object(properties: [

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -51,8 +51,8 @@ struct GenerateContentIntegrationTests {
     (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashLite),
     (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2_5_FlashLite),
     (InstanceConfig.vertexAI_v1beta_global_appCheckLimitedUse, ModelNames.gemini2_5_FlashLite),
-    (InstanceConfig.googleAI_v1beta, ModelNames.gemini3_1_FlashLitePreview),
-    (InstanceConfig.googleAI_v1beta_appCheckLimitedUse, ModelNames.gemini3_1_FlashLitePreview),
+    (InstanceConfig.googleAI_v1beta, ModelNames.gemini3_1_FlashLite),
+    (InstanceConfig.googleAI_v1beta_appCheckLimitedUse, ModelNames.gemini3_1_FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemma4_31B),
     (InstanceConfig.googleAI_v1beta_freeTier, ModelNames.gemma4_31B),
     // Note: The following configs are commented out for easy one-off manual testing.
@@ -105,7 +105,7 @@ struct GenerateContentIntegrationTests {
 
   @Test(
     "Generate an enum and provide a system instruction",
-    arguments: InstanceConfig.allConfigs
+    arguments: InstanceConfig.defaultConfigs
   )
   func generateContentEnum(_ config: InstanceConfig) async throws {
     let model = FirebaseAI.componentInstance(config).generativeModel(
@@ -159,47 +159,18 @@ struct GenerateContentIntegrationTests {
       (.vertexAI_v1beta_global, ModelNames.gemini2_5_Pro, ThinkingConfig(
         thinkingBudget: 32768, includeThoughts: true
       )),
-      (.googleAI_v1beta, ModelNames.gemini2_5_Flash, ThinkingConfig(thinkingBudget: 0)),
-      (.googleAI_v1beta, ModelNames.gemini2_5_Flash, ThinkingConfig(thinkingBudget: 24576)),
-      (.googleAI_v1beta, ModelNames.gemini2_5_Flash, ThinkingConfig(
+      (.googleAI_v1beta, ModelNames.gemini2_5_FlashLite, ThinkingConfig(thinkingBudget: 0)),
+      (.googleAI_v1beta, ModelNames.gemini2_5_FlashLite, ThinkingConfig(thinkingBudget: 24576)),
+      (.googleAI_v1beta, ModelNames.gemini2_5_FlashLite, ThinkingConfig(
         thinkingBudget: 24576, includeThoughts: true
       )),
-      (.googleAI_v1beta, ModelNames.gemini2_5_Pro, ThinkingConfig(thinkingBudget: 128)),
-      (.googleAI_v1beta, ModelNames.gemini2_5_Pro, ThinkingConfig(thinkingBudget: 32768)),
-      (.googleAI_v1beta, ModelNames.gemini2_5_Pro, ThinkingConfig(
-        thinkingBudget: 32768, includeThoughts: true
-      )),
-      (
-        .googleAI_v1beta,
-        ModelNames.gemini3_1_FlashLitePreview,
-        ThinkingConfig(thinkingLevel: .minimal)
-      ),
-      (
-        .googleAI_v1beta,
-        ModelNames.gemini3_1_FlashLitePreview,
-        ThinkingConfig(thinkingLevel: .low)
-      ),
-      (
-        .googleAI_v1beta,
-        ModelNames.gemini3_1_FlashLitePreview,
-        ThinkingConfig(thinkingLevel: .medium)
-      ),
-      (
-        .googleAI_v1beta,
-        ModelNames.gemini3_1_FlashLitePreview,
-        ThinkingConfig(thinkingLevel: .high)
-      ),
-      (
-        .googleAI_v1beta,
-        ModelNames.gemini3_1_FlashLitePreview,
-        ThinkingConfig(thinkingBudget: 0)
-      ),
-      (
-        .googleAI_v1beta,
-        ModelNames.gemini3_1_FlashLitePreview,
-        ThinkingConfig(thinkingBudget: 32768)
-      ),
-      (.googleAI_v1beta, ModelNames.gemini3_1_FlashLitePreview, ThinkingConfig(
+      (.googleAI_v1beta, ModelNames.gemini3_1_FlashLite, ThinkingConfig(thinkingLevel: .minimal)),
+      (.googleAI_v1beta, ModelNames.gemini3_1_FlashLite, ThinkingConfig(thinkingLevel: .low)),
+      (.googleAI_v1beta, ModelNames.gemini3_1_FlashLite, ThinkingConfig(thinkingLevel: .medium)),
+      (.googleAI_v1beta, ModelNames.gemini3_1_FlashLite, ThinkingConfig(thinkingLevel: .high)),
+      (.googleAI_v1beta, ModelNames.gemini3_1_FlashLite, ThinkingConfig(thinkingBudget: 0)),
+      (.googleAI_v1beta, ModelNames.gemini3_1_FlashLite, ThinkingConfig(thinkingBudget: 32768)),
+      (.googleAI_v1beta, ModelNames.gemini3_1_FlashLite, ThinkingConfig(
         thinkingBudget: 32768, includeThoughts: true
       )),
       // Note: The following configs are commented out for easy one-off manual testing.
@@ -304,16 +275,12 @@ struct GenerateContentIntegrationTests {
       (.vertexAI_v1beta_global, ModelNames.gemini2_5_Pro, ThinkingConfig(
         thinkingBudget: -1, includeThoughts: true
       )),
-      (.googleAI_v1beta, ModelNames.gemini2_5_Flash, ThinkingConfig(thinkingBudget: -1)),
-      (.googleAI_v1beta, ModelNames.gemini2_5_Flash, ThinkingConfig(
+      (.googleAI_v1beta, ModelNames.gemini2_5_FlashLite, ThinkingConfig(thinkingBudget: -1)),
+      (.googleAI_v1beta, ModelNames.gemini2_5_FlashLite, ThinkingConfig(
         thinkingBudget: -1, includeThoughts: true
       )),
-      (.googleAI_v1beta, ModelNames.gemini2_5_Pro, ThinkingConfig(thinkingBudget: -1)),
-      (.googleAI_v1beta, ModelNames.gemini2_5_Pro, ThinkingConfig(
-        thinkingBudget: -1, includeThoughts: true
-      )),
-      (.googleAI_v1beta, ModelNames.gemini3_1_FlashLitePreview, ThinkingConfig(thinkingBudget: -1)),
-      (.googleAI_v1beta, ModelNames.gemini3_1_FlashLitePreview, ThinkingConfig(
+      (.googleAI_v1beta, ModelNames.gemini3_1_FlashLite, ThinkingConfig(thinkingBudget: -1)),
+      (.googleAI_v1beta, ModelNames.gemini3_1_FlashLite, ThinkingConfig(
         thinkingBudget: -1, includeThoughts: true
       )),
     ] as [(InstanceConfig, String, ThinkingConfig)]
@@ -549,11 +516,11 @@ struct GenerateContentIntegrationTests {
 
   @Test(
     "generateContent with Google Search returns grounding metadata",
-    arguments: InstanceConfig.allConfigs
+    arguments: InstanceConfig.defaultConfigs
   )
   func generateContent_withGoogleSearch_succeeds(_ config: InstanceConfig) async throws {
     let model = FirebaseAI.componentInstance(config).generativeModel(
-      modelName: ModelNames.gemini2_5_Flash,
+      modelName: ModelNames.gemini3_1_FlashLite,
       tools: [.googleSearch()]
     )
     let prompt = "What is the weather in Toronto today?"
@@ -588,11 +555,11 @@ struct GenerateContentIntegrationTests {
 
   @Test(
     "generateContent with URL Context",
-    arguments: InstanceConfig.allConfigs
+    arguments: InstanceConfig.defaultConfigs
   )
   func generateContent_withURLContext_succeeds(_ config: InstanceConfig) async throws {
     let model = FirebaseAI.componentInstance(config).generativeModel(
-      modelName: ModelNames.gemini2_5_Flash,
+      modelName: ModelNames.gemini3_1_FlashLite,
       tools: [.urlContext()]
     )
     let url = "https://developers.googleblog.com/en/introducing-gemma-3-270m/"
@@ -607,10 +574,10 @@ struct GenerateContentIntegrationTests {
     #expect(retrievedURL == URL(string: url))
   }
 
-  @Test(arguments: InstanceConfig.allConfigs)
+  @Test(arguments: InstanceConfig.defaultConfigs)
   func generateContent_codeExecution_succeeds(_ config: InstanceConfig) async throws {
     let model = FirebaseAI.componentInstance(config).generativeModel(
-      modelName: ModelNames.gemini2_5_FlashLite,
+      modelName: ModelNames.gemini3_1_FlashLite,
       generationConfig: generationConfig,
       tools: [.codeExecution()]
     )
@@ -640,11 +607,8 @@ struct GenerateContentIntegrationTests {
 
   @Test(arguments: [
     (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashLite),
-    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini3_1_FlashLitePreview),
-    (
-      InstanceConfig.vertexAI_v1beta_global_appCheckLimitedUse,
-      ModelNames.gemini3_1_FlashLitePreview
-    ),
+    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini3_1_FlashLite),
+    (InstanceConfig.vertexAI_v1beta_global_appCheckLimitedUse, ModelNames.gemini3_1_FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashLite),
     (InstanceConfig.googleAI_v1beta_appCheckLimitedUse, ModelNames.gemini2_5_FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemma4_31B),
@@ -778,7 +742,7 @@ struct GenerateContentIntegrationTests {
   @Test(arguments: InstanceConfig.appCheckNotConfiguredConfigs)
   func generateContent_appCheckNotConfigured_shouldFail(_ config: InstanceConfig) async throws {
     let model = FirebaseAI.componentInstance(config).generativeModel(
-      modelName: ModelNames.gemini2_5_Flash
+      modelName: ModelNames.gemini3_1_FlashLite
     )
     let prompt = "Where is Google headquarters located? Answer with the city name only."
 

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionTests.swift
@@ -463,7 +463,7 @@
       @available(watchOS, unavailable)
       func streamResponseGenerable(_ config: InstanceConfig) async throws {
         let firebaseAI = FirebaseAI.componentInstance(config)
-        let session = firebaseAI.generativeModelSession(model: ModelNames.gemini2_5_FlashLite)
+        let session = firebaseAI.generativeModelSession(model: ModelNames.gemini3_1_FlashLite)
         let prompt = "Generate a Ragdoll kitten"
         let config = GenerationConfig(
           thinkingConfig: ThinkingConfig(thinkingBudget: -1, includeThoughts: true)

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionTests.swift
@@ -278,7 +278,7 @@
     func respondTextWithAutomaticFunctionCalling(_ config: InstanceConfig) async throws {
       let temperatureTool = GetTemperature()
       let session = FirebaseAI.componentInstance(config).generativeModelSession(
-        model: ModelNames.gemini3_1_FlashLitePreview,
+        model: ModelNames.gemini3_1_FlashLite,
         tools: [temperatureTool],
         instructions: """
         You are a weather bot that specializes in reporting outdoor temperatures in Celsius.
@@ -312,7 +312,7 @@
     func respondGenerableWithAutomaticFunctionCalling(_ config: InstanceConfig) async throws {
       let temperatureTool = GetTemperature()
       let session = FirebaseAI.componentInstance(config).generativeModelSession(
-        model: ModelNames.gemini3_1_FlashLitePreview,
+        model: ModelNames.gemini3_1_FlashLite,
         tools: [temperatureTool],
         instructions: """
         You are a weather bot that specializes in reporting outdoor temperatures in Celsius.
@@ -341,7 +341,7 @@
     @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
     func respondTextWithURLContext(_ config: InstanceConfig) async throws {
       let session = FirebaseAI.componentInstance(config).generativeModelSession(
-        model: ModelNames.gemini2_5_Flash,
+        model: ModelNames.gemini3_1_FlashLite,
         tools: [.urlContext()]
       )
       let url = "https://blog.google/innovation-and-ai/technology/developers-tools/functiongemma/"
@@ -538,7 +538,7 @@
       func streamResponseTextWithAutomaticFunctionCalling(_ config: InstanceConfig) async throws {
         let temperatureTool = GetTemperature()
         let session = FirebaseAI.componentInstance(config).generativeModelSession(
-          model: ModelNames.gemini3_1_FlashLitePreview,
+          model: ModelNames.gemini3_1_FlashLite,
           tools: [temperatureTool],
           instructions: """
           You are a weather bot that specializes in reporting outdoor temperatures in Celsius.

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/ImplicitCacheTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/ImplicitCacheTests.swift
@@ -28,8 +28,6 @@ struct ImplicitCacheTests {
 
   @Test(arguments: [
     (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_Flash),
-    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashLite),
-    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_Pro),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_Pro),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini3_1_FlashLite),

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/ImplicitCacheTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/ImplicitCacheTests.swift
@@ -28,9 +28,11 @@ struct ImplicitCacheTests {
 
   @Test(arguments: [
     (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_Flash),
-    (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_Flash),
+    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashLite),
+    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_Pro),
+    (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_Pro),
-    (InstanceConfig.googleAI_v1beta, ModelNames.gemini3_1_FlashLitePreview),
+    (InstanceConfig.googleAI_v1beta, ModelNames.gemini3_1_FlashLite),
   ])
   func implicitCaching(_ config: InstanceConfig, modelName: String) async throws {
     let model = FirebaseAI.componentInstance(config).generativeModel(

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/ImplicitCacheTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/ImplicitCacheTests.swift
@@ -28,8 +28,8 @@ struct ImplicitCacheTests {
 
   @Test(arguments: [
     (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_Flash),
+    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_Pro),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashLite),
-    (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_Pro),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini3_1_FlashLite),
   ])
   func implicitCaching(_ config: InstanceConfig, modelName: String) async throws {

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -197,7 +197,7 @@ final class IntegrationTests: XCTestCase {
   func testCountTokens_appCheckNotConfigured_shouldFail() async throws {
     let app = try XCTUnwrap(FirebaseApp.app(name: FirebaseAppNames.appCheckNotConfigured))
     let vertex = FirebaseAI.firebaseAI(app: app, backend: .vertexAI())
-    let model = vertex.generativeModel(modelName: ModelNames.gemini3_1_FlashLite)
+    let model = vertex.generativeModel(modelName: ModelNames.gemini2_5_Flash)
     let prompt = "Why is the sky blue?"
 
     do {

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -51,9 +51,9 @@ final class IntegrationTests: XCTestCase {
 
   override func setUp() async throws {
     userID1 = try await TestHelpers.getUserID()
-    vertex = FirebaseAI.firebaseAI(backend: .vertexAI())
+    vertex = FirebaseAI.firebaseAI(backend: .vertexAI(location: "global"))
     model = vertex.generativeModel(
-      modelName: ModelNames.gemini2_5_Flash,
+      modelName: ModelNames.gemini3_1_FlashLite,
       generationConfig: generationConfig,
       safetySettings: safetySettings,
       tools: [],
@@ -69,7 +69,7 @@ final class IntegrationTests: XCTestCase {
   func testCountTokens_text() async throws {
     let prompt = "Why is the sky blue?"
     model = vertex.generativeModel(
-      modelName: ModelNames.gemini2_5_Flash,
+      modelName: ModelNames.gemini3_1_FlashLite,
       generationConfig: generationConfig,
       safetySettings: [
         SafetySetting(harmCategory: .harassment, threshold: .blockLowAndAbove, method: .severity),
@@ -173,7 +173,7 @@ final class IntegrationTests: XCTestCase {
       parameters: ["x": .integer(), "y": .integer()]
     )
     model = vertex.generativeModel(
-      modelName: ModelNames.gemini2_5_Flash,
+      modelName: ModelNames.gemini3_1_FlashLite,
       tools: [.functionDeclarations([sumDeclaration])],
       toolConfig: .init(functionCallingConfig: .any(allowedFunctionNames: ["sum"]))
     )
@@ -197,7 +197,7 @@ final class IntegrationTests: XCTestCase {
   func testCountTokens_appCheckNotConfigured_shouldFail() async throws {
     let app = try XCTUnwrap(FirebaseApp.app(name: FirebaseAppNames.appCheckNotConfigured))
     let vertex = FirebaseAI.firebaseAI(app: app, backend: .vertexAI())
-    let model = vertex.generativeModel(modelName: ModelNames.gemini2_5_Flash)
+    let model = vertex.generativeModel(modelName: ModelNames.gemini3_1_FlashLite)
     let prompt = "Why is the sky blue?"
 
     do {

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/MapsGroundingIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/MapsGroundingIntegrationTests.swift
@@ -21,11 +21,11 @@ import Testing
 struct MapsGroundingIntegrationTests {
   @Test(
     "generateContent with Google Maps returns grounding metadata",
-    arguments: InstanceConfig.allConfigs
+    arguments: InstanceConfig.defaultConfigs
   )
   func generateContent_withGoogleMaps_succeeds(_ config: InstanceConfig) async throws {
     let model = FirebaseAI.componentInstance(config).generativeModel(
-      modelName: ModelNames.gemini2_5_Flash,
+      modelName: ModelNames.gemini3_1_FlashLite,
       tools: [.googleMaps()]
     )
     let prompt = "Where is a good place to grab a coffee near Alameda, CA?"
@@ -37,11 +37,11 @@ struct MapsGroundingIntegrationTests {
 
   @Test(
     "respondTo with Google Maps returns grounding metadata",
-    arguments: InstanceConfig.allConfigs
+    arguments: InstanceConfig.defaultConfigs
   )
   func generativeModelSession_respondTo_withGoogleMaps_succeeds(_ config: InstanceConfig) async throws {
     let session = FirebaseAI.componentInstance(config).generativeModelSession(
-      model: ModelNames.gemini2_5_Flash,
+      model: ModelNames.gemini3_1_FlashLite,
       tools: [.googleMaps()]
     )
     let prompt = "Where is a good place to grab a coffee near Alameda, CA?"
@@ -53,11 +53,12 @@ struct MapsGroundingIntegrationTests {
 
   @Test(
     "streamResponse with Google Maps returns grounding metadata",
-    arguments: InstanceConfig.allConfigs
+    arguments: InstanceConfig.defaultConfigs
   )
   func generativeModelSession_streamResponse_withGoogleMaps_succeeds(_ config: InstanceConfig) async throws {
     let session = FirebaseAI.componentInstance(config).generativeModelSession(
-      model: ModelNames.gemini2_5_Flash,
+      // TODO: Replace with gemini3_1_FlashLite after resolving decoding failure.
+      model: ModelNames.gemini2_5_FlashLite,
       tools: [.googleMaps()]
     )
     let prompt = "Where is a good place to grab a coffee near Alameda, CA?"
@@ -70,7 +71,7 @@ struct MapsGroundingIntegrationTests {
 
   @Test(
     "generateContent with Google Maps and RetrievalConfig returns grounding metadata",
-    arguments: InstanceConfig.allConfigs
+    arguments: InstanceConfig.defaultConfigs
   )
   func generateContent_withGoogleMapsAndRetrievalConfig_succeeds(_ config: InstanceConfig) async throws {
     let toolConfig = ToolConfig(
@@ -79,7 +80,7 @@ struct MapsGroundingIntegrationTests {
       )
     )
     let model = FirebaseAI.componentInstance(config).generativeModel(
-      modelName: ModelNames.gemini2_5_Flash,
+      modelName: ModelNames.gemini3_1_FlashLite,
       tools: [.googleMaps()],
       toolConfig: toolConfig
     )
@@ -92,7 +93,7 @@ struct MapsGroundingIntegrationTests {
 
   @Test(
     "generateContent with Google Maps and languageCode returns grounding metadata",
-    arguments: InstanceConfig.allConfigs
+    arguments: InstanceConfig.defaultConfigs
   )
   func generateContent_withGoogleMapsAndLanguageConfig_succeeds(_ config: InstanceConfig) async throws {
     let toolConfig = ToolConfig(
@@ -101,7 +102,7 @@ struct MapsGroundingIntegrationTests {
       )
     )
     let model = FirebaseAI.componentInstance(config).generativeModel(
-      modelName: ModelNames.gemini2_5_Flash,
+      modelName: ModelNames.gemini3_1_FlashLite,
       tools: [.googleMaps()],
       toolConfig: toolConfig
     )

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/SchemaTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/SchemaTests.swift
@@ -38,7 +38,7 @@ struct SchemaTests {
 
   @Test(
     arguments: testConfigs(
-      instanceConfigs: InstanceConfig.allConfigs,
+      instanceConfigs: InstanceConfig.defaultConfigs,
       openAPISchema: .array(
         items: .string(description: "The name of the city"),
         description: "A list of city names",
@@ -73,7 +73,7 @@ struct SchemaTests {
   }
 
   @Test(arguments: testConfigs(
-    instanceConfigs: InstanceConfig.allConfigs,
+    instanceConfigs: InstanceConfig.defaultConfigs,
     openAPISchema: .integer(
       description: "A number",
       minimum: 110,
@@ -103,7 +103,7 @@ struct SchemaTests {
   }
 
   @Test(arguments: testConfigs(
-    instanceConfigs: InstanceConfig.allConfigs,
+    instanceConfigs: InstanceConfig.defaultConfigs,
     openAPISchema: .object(
       properties: [
         "productName": .string(description: "The name of the product"),
@@ -310,13 +310,13 @@ struct SchemaTests {
   }()
 
   @Test(arguments: testConfigs(
-    instanceConfigs: InstanceConfig.allConfigs,
+    instanceConfigs: InstanceConfig.defaultConfigs,
     openAPISchema: generateContentAnyOfOpenAPISchema,
     jsonSchema: generateContentAnyOfJSONSchema
   ))
   func generateContentAnyOfSchema(_ config: InstanceConfig, _ schema: SchemaType) async throws {
     let model = FirebaseAI.componentInstance(config).generativeModel(
-      modelName: ModelNames.gemini2_5_Flash,
+      modelName: ModelNames.gemini3_1_FlashLite,
       generationConfig: SchemaTests.generationConfig(schema: schema),
       safetySettings: safetySettings
     )

--- a/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
@@ -77,26 +77,27 @@ struct InstanceConfig: Equatable, Encodable {
     apiConfig: APIConfig(service: .googleAI(endpoint: .googleAIBypassProxy), version: .v1beta)
   )
 
-  static let allConfigs = [
-    vertexAI_v1beta,
+  static let defaultConfigs = [
     vertexAI_v1beta_global,
-    vertexAI_v1beta_global_appCheckLimitedUse,
     googleAI_v1beta,
-    googleAI_v1beta_appCheckLimitedUse,
     // Note: The following configs are commented out for easy one-off manual testing.
-    // googleAI_v1beta_freeTier,
+    // vertexAI_v1beta,
+    // vertexAI_v1beta_global_appCheckLimitedUse,
     // vertexAI_v1beta_staging,
     // vertexAI_v1beta_staging_global_bypassProxy,
+    // googleAI_v1beta_appCheckLimitedUse,
     // googleAI_v1beta_staging,
+    // googleAI_v1beta_freeTier,
     // googleAI_v1beta_freeTier_bypassProxy,
   ]
 
   static let liveConfigs = [
     vertexAI_v1beta,
-    vertexAI_v1beta_appCheckLimitedUse,
     googleAI_v1beta,
-    googleAI_v1beta_appCheckLimitedUse,
-    googleAI_v1beta_freeTier,
+    // Note: The following configs are commented out for easy one-off manual testing.
+    // vertexAI_v1beta_appCheckLimitedUse,
+    // googleAI_v1beta_appCheckLimitedUse,
+    // googleAI_v1beta_freeTier,
   ]
 
   static let vertexAI_v1beta_appCheckNotConfigured = InstanceConfig(


### PR DESCRIPTION
Reduced the total number of permutations tested in the integration tests. The integration tests have become too slow and flaky to be useful. In particular, the following changes were made:
- Replaced `gemini-3.1-flash-lite-preview` with `gemini-3.1-flash-lite` now that Gemini 3.1 Flash Lite is GA.
- Replaced `InstanceConfigs.allConfigs` with `InstanceConfigs.defaultConfigs`, which is a significantly narrowed down set of permutations.
  - Since Gemini 3 series models are only available on the `global` location, this default set no longer includes `us-central1`.
  - Individual tests, such as `GenerateContentIntegrationTests.generateContent` and `generateContentStream` provide some coverage of the `us-central1` location; model behaviour doesn't differ between the locations anyway.
- Replaced `gemini-2.5-flash` / `gemini-2.5-pro` with `gemini-3.1-flash-lite` on the Dev API tests since 2.5 Flash is no longer available for 1P projects and 3 Flash / Pro are not yet GA.
- Significantly narrowed down the set of permutations in `InstanceConfig.liveConfigs`.
  - The free tier is extra flaky and `appCheckLimitedUse` doesn't meaningfully test anything until we add a project with replay protection.

#no-changelog