### PR TITLE
[AI] Handle `GenerateContentResponse` with only `usageMetadata`

### DIFF
--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -544,11 +544,12 @@ extension GenerateContentResponse: Decodable {
       || container.contains(CodingKeys.promptFeedback)
       || container.contains(CodingKeys.usageMetadata) else {
       let jsonValue = try? JSONValue(from: decoder)
+      let responseString = jsonValue.map { ": \($0)" } ?? "."
       let context = DecodingError.Context(
-        codingPath: [],
+        codingPath: decoder.codingPath,
         debugDescription: """
         Failed to decode GenerateContentResponse; missing keys 'candidates', 'promptFeedback' or \
-        'usageMetadata' in response: \(jsonValue.debugDescription)
+        'usageMetadata' in response\(responseString)
         """
       )
       throw DecodingError.dataCorrupted(context)

--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -543,13 +543,12 @@ extension GenerateContentResponse: Decodable {
     guard container.contains(CodingKeys.candidates)
       || container.contains(CodingKeys.promptFeedback)
       || container.contains(CodingKeys.usageMetadata) else {
-      let jsonValue = try? JSONValue(from: decoder)
-      let responseString = jsonValue.map { ": \($0)" } ?? "."
+      let keys = container.allKeys.map { $0.stringValue }.joined(separator: ", ")
       let context = DecodingError.Context(
         codingPath: decoder.codingPath,
         debugDescription: """
         Failed to decode GenerateContentResponse; missing keys 'candidates', 'promptFeedback' or \
-        'usageMetadata' in response\(responseString)
+        'usageMetadata'. Found keys: \(keys.isEmpty ? "none" : keys)
         """
       )
       throw DecodingError.dataCorrupted(context)

--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -543,7 +543,7 @@ extension GenerateContentResponse: Decodable {
     guard container.contains(CodingKeys.candidates)
       || container.contains(CodingKeys.promptFeedback)
       || container.contains(CodingKeys.usageMetadata) else {
-      let keys = container.allKeys.map { $0.stringValue }.joined(separator: ", ")
+      let keys = container.allKeys.map { $0.stringValue }.sorted().joined(separator: ", ")
       let context = DecodingError.Context(
         codingPath: decoder.codingPath,
         debugDescription: """

--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -540,12 +540,16 @@ extension GenerateContentResponse: Decodable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
-    guard container.contains(CodingKeys.candidates) || container
-      .contains(CodingKeys.promptFeedback) else {
+    guard container.contains(CodingKeys.candidates)
+      || container.contains(CodingKeys.promptFeedback)
+      || container.contains(CodingKeys.usageMetadata) else {
+      let jsonValue = try? JSONValue(from: decoder)
       let context = DecodingError.Context(
         codingPath: [],
-        debugDescription: "Failed to decode GenerateContentResponse;" +
-          " missing keys 'candidates' and 'promptFeedback'."
+        debugDescription: """
+        Failed to decode GenerateContentResponse; missing keys 'candidates', 'promptFeedback' or \
+        'usageMetadata' in response: \(jsonValue.debugDescription)
+        """
       )
       throw DecodingError.dataCorrupted(context)
     }

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/MapsGroundingIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/MapsGroundingIntegrationTests.swift
@@ -57,8 +57,7 @@ struct MapsGroundingIntegrationTests {
   )
   func generativeModelSession_streamResponse_withGoogleMaps_succeeds(_ config: InstanceConfig) async throws {
     let session = FirebaseAI.componentInstance(config).generativeModelSession(
-      // TODO: Replace with gemini3_1_FlashLite after resolving decoding failure.
-      model: ModelNames.gemini2_5_FlashLite,
+      model: ModelNames.gemini3_1_FlashLite,
       tools: [.googleMaps()]
     )
     let prompt = "Where is a good place to grab a coffee near Alameda, CA?"

--- a/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
@@ -320,6 +320,7 @@ final class GenerateContentResponseTests: XCTestCase {
   func testDecodeGenerateContentResponse_missingRequiredKeys_throwsError() throws {
     let json = """
     {
+      "responseId": "test-response-id",
       "modelVersion": "gemini-2.5-flash"
     }
     """
@@ -338,7 +339,7 @@ final class GenerateContentResponseTests: XCTestCase {
       XCTAssertTrue(context.debugDescription.contains(
         "missing keys 'candidates', 'promptFeedback' or 'usageMetadata'"
       ))
-      XCTAssertTrue(context.debugDescription.contains("Found keys: modelVersion"))
+      XCTAssertTrue(context.debugDescription.contains("Found keys: modelVersion, responseId"))
     }
   }
 

--- a/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
@@ -295,6 +295,53 @@ final class GenerateContentResponseTests: XCTestCase {
     XCTAssertEqual(response.modelVersion, GenerateContentResponse.unknownModelVersion)
   }
 
+  func testDecodeGenerateContentResponse_withOnlyUsageMetadata() throws {
+    let json = """
+    {
+      "usageMetadata": {
+        "promptTokenCount": 10,
+        "candidatesTokenCount": 20,
+        "totalTokenCount": 30
+      },
+      "modelVersion": "gemini-2.5-flash"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try jsonDecoder.decode(GenerateContentResponse.self, from: jsonData)
+
+    XCTAssertEqual(response.modelVersion, "gemini-2.5-flash")
+    XCTAssertEqual(response.usageMetadata?.promptTokenCount, 10)
+    XCTAssertEqual(response.usageMetadata?.candidatesTokenCount, 20)
+    XCTAssertEqual(response.usageMetadata?.totalTokenCount, 30)
+    XCTAssertTrue(response.candidates.isEmpty)
+  }
+
+  func testDecodeGenerateContentResponse_missingRequiredKeys_throwsError() throws {
+    let json = """
+    {
+      "modelVersion": "gemini-2.5-flash"
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    XCTAssertThrowsError(try jsonDecoder.decode(
+      GenerateContentResponse.self,
+      from: jsonData
+    )) { error in
+      guard case let DecodingError.dataCorrupted(context) = error else {
+        XCTFail("Expected DecodingError.dataCorrupted, got \(error)")
+        return
+      }
+      XCTAssertEqual(context.codingPath.count, 0)
+      XCTAssertTrue(context.debugDescription.contains("Failed to decode GenerateContentResponse"))
+      XCTAssertTrue(context.debugDescription.contains(
+        "missing keys 'candidates', 'promptFeedback' or 'usageMetadata'"
+      ))
+      XCTAssertTrue(context.debugDescription.contains("in response:"))
+    }
+  }
+
   // MARK: - Candidate.isEmpty
 
   func testCandidateIsEmpty_allEmpty_isTrue() throws {

--- a/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
@@ -338,7 +338,7 @@ final class GenerateContentResponseTests: XCTestCase {
       XCTAssertTrue(context.debugDescription.contains(
         "missing keys 'candidates', 'promptFeedback' or 'usageMetadata'"
       ))
-      XCTAssertTrue(context.debugDescription.contains("in response:"))
+      XCTAssertTrue(context.debugDescription.contains("Found keys: modelVersion"))
     }
   }
 


### PR DESCRIPTION
Updated the `Decodable` implementation for `GenerateContentResponse` to handle cases where the only content is the `usageMetadata`. This sometimes occurs when streaming using Gemini 3.1 Flash Lite and may occur elsewhere.

#no-changelog