### PR TITLE
feat(cocoapods): Add CocoaPods deprecation warnings to Podspec, README, and CHANGELOG

### DIFF
--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -16,6 +16,12 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
     :tag => 'CocoaPods-' + s.version.to_s
   }
 
+  s.deprecated_in_favor_of = 'the Firebase Apple SDK via Swift Package ' \
+                             'Manager. Firebase products remain fully ' \
+                             'supported, but new versions will no longer be ' \
+                             'published to CocoaPods after October 2026. ' \
+                             'See: https://firebase.google.com/docs/ios/cocoapods-deprecation'
+
   s.social_media_url = 'https://twitter.com/Firebase'
 
   ios_deployment_target = '15.0'

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -17,8 +17,9 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   }
 
   s.deprecated_in_favor_of = 'the Firebase Apple SDK via Swift Package ' \
-                             'Manager. Firebase products remain fully ' \
-                             'supported, but new versions will no longer be ' \
+                             'Manager. Existing CocoaPods versions will ' \
+                             'remain available and installations will remain ' \
+                             'functional, but new versions will no longer be ' \
                              'published to CocoaPods after October 2026. ' \
                              'See: https://firebase.google.com/docs/ios/cocoapods-deprecation'
 

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
 - [fixed] Remove extra comma in Package.swift that caused SPM resolution
   failures for some configurations.
-- todo: deprecation announcement and link to migration guide
+- [deprecated] The Firebase Apple SDK via CocoaPods is deprecated in favor of 
+  Swift Package Manager. Firebase products remain fully supported, but new
+  versions will no longer be published to CocoaPods after **October 2026**.
+  See the [migration guide](https://firebase.google.com/docs/ios/cocoapods-deprecation) for more information.
 
 # Firebase 12.12.0
 - [changed] Firebase now requires at least Xcode 26.2 and the Swift

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 - [fixed] Remove extra comma in Package.swift that caused SPM resolution
   failures for some configurations.
-- [deprecated] The Firebase Apple SDK via CocoaPods is deprecated in favor of 
+- [deprecated] The Firebase Apple SDK via CocoaPods is deprecated in favor of
   Swift Package Manager. Firebase products remain fully supported, but new
   versions will no longer be published to CocoaPods after **October 2026**.
   See the [migration guide](https://firebase.google.com/docs/ios/cocoapods-deprecation) for more information.

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Unreleased
 - [fixed] Remove extra comma in Package.swift that caused SPM resolution
   failures for some configurations.
-- [deprecated] Installing the Firebase Apple SDK using CocoaPods is deprecated in favor of
-  Swift Package Manager. Firebase products remain fully supported, but new
-  versions will no longer be published to CocoaPods after **October 2026**.
-  See the [migration guide](https://firebase.google.com/docs/ios/cocoapods-deprecation) for more information.
+- [deprecated] New versions of the Firebase Apple SDK will no longer be
+  published to CocoaPods after October 2026. Existing CocoaPods versions will
+  remain available and installations will remain functional. See the
+  [migration guide](https://firebase.google.com/docs/ios/cocoapods-deprecation)
+  for more information.
 
 # Firebase 12.12.0
 - [changed] Firebase now requires at least Xcode 26.2 and the Swift

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 - [fixed] Remove extra comma in Package.swift that caused SPM resolution
   failures for some configurations.
-- [deprecated] The Firebase Apple SDK via CocoaPods is deprecated in favor of
+- [deprecated] Installing the Firebase Apple SDK using CocoaPods is deprecated in favor of
   Swift Package Manager. Firebase products remain fully supported, but new
   versions will no longer be published to CocoaPods after **October 2026**.
   See the [migration guide](https://firebase.google.com/docs/ios/cocoapods-deprecation) for more information.

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 - [fixed] Remove extra comma in Package.swift that caused SPM resolution
   failures for some configurations.
+- todo: deprecation announcement and link to migration guide
 
 # Firebase 12.12.0
 - [changed] Firebase now requires at least Xcode 26.2 and the Swift

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
   </a>
 </p>
 
+- todo: deprecation announcement and link to migration guide
+
 # Firebase Apple Open Source Development
 
 This repository contains the source code for all Apple platform Firebase SDKs except FirebaseAnalytics.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 </p>
 
 > [!WARNING]
-> **CocoaPods Deprecation:** The Firebase Apple SDK via CocoaPods is deprecated in favor of Swift Package Manager. Firebase products remain fully supported, but new versions will no longer be published to CocoaPods after **October 2026**. See the [migration guide](https://firebase.google.com/docs/ios/cocoapods-deprecation) for more information.
+> **CocoaPods Deprecation:** The Firebase Apple SDK via CocoaPods is deprecated in favor of Swift
+> Package Manager. Firebase products remain fully supported, but new versions will no longer be
+> published to CocoaPods after **October 2026**. See the [migration guide](https://firebase.google.com/docs/ios/cocoapods-deprecation) for more information.
 
 # Firebase Apple Open Source Development
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 > [!WARNING]
-> **CocoaPods Deprecation:** The Firebase Apple SDK via CocoaPods is deprecated in favor of Swift
+> **CocoaPods Deprecation:** Installing the Firebase Apple SDK using CocoaPods is deprecated in favor of Swift
 > Package Manager. Firebase products remain fully supported, but new versions will no longer be
 > published to CocoaPods after **October 2026**. See the [migration guide](https://firebase.google.com/docs/ios/cocoapods-deprecation) for more information.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
   </a>
 </p>
 
-- todo: deprecation announcement and link to migration guide
+> [!WARNING]
+> **CocoaPods Deprecation:** The Firebase Apple SDK via CocoaPods is deprecated in favor of Swift Package Manager. Firebase products remain fully supported, but new versions will no longer be published to CocoaPods after **October 2026**. See the [migration guide](https://firebase.google.com/docs/ios/cocoapods-deprecation) for more information.
 
 # Firebase Apple Open Source Development
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   </a>
 </p>
 
-> [!IMPORTANT]
+> [!WARNING]
 > **CocoaPods:** New versions of the Firebase Apple SDK will no longer be
 > published to CocoaPods after **October 2026**. Existing CocoaPods versions
 > will remain available and installations will remain functional. See the

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@
   </a>
 </p>
 
-> [!WARNING]
-> **CocoaPods Deprecation:** Installing the Firebase Apple SDK using CocoaPods is deprecated in favor of Swift
-> Package Manager. Firebase products remain fully supported, but new versions will no longer be
-> published to CocoaPods after **October 2026**. See the [migration guide](https://firebase.google.com/docs/ios/cocoapods-deprecation) for more information.
+> [!IMPORTANT]
+> **CocoaPods:** New versions of the Firebase Apple SDK will no longer be
+> published to CocoaPods after **October 2026**. Existing CocoaPods versions
+> will remain available and installations will remain functional. See the
+> [migration guide](https://firebase.google.com/docs/ios/cocoapods-deprecation)
+> for more information.
+
 
 # Firebase Apple Open Source Development
 


### PR DESCRIPTION
In preparation for the CocoaPods ecosystem transitioning to a read-only state in December 2026, this PR introduces the official deprecation warnings for the Firebase Apple SDK via CocoaPods. 

## Changes Made
This PR unifies the deprecation messaging across:

* **`FirebaseCore.podspec`**: Added the `s.deprecated_in_favor_of` attribute to surface the warning directly in terminal output during `pod install`.
* **`README.md`**: Added a `> [!WARNING]` callout near the top of the file for high visibility on the repository homepage.
* **`CHANGELOG.md`**: Added a new `[deprecated]` entry under `# Unreleased` to document the change for the next release.

## Messaging 
All surfaces now use the finalized and approved messaging:
> New versions of the Firebase Apple SDK will no longer be
> published to CocoaPods after **October 2026**. Existing CocoaPods versions
> will remain available and installations will remain functional. See the
> [migration guide](https://firebase.google.com/docs/ios/cocoapods-deprecation) for more information.

Note: `FirebaseCore.podspec` was staged to SpecStaging without issue or needing to add `--allow-warnings`.

### Next Steps

There are some opportunities to clean up the`README.md` in general, but I am considering it as oos for this PR.
