### PR TITLE
chore: fix a bunch of typos in the swift files

### DIFF
--- a/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
@@ -151,7 +151,7 @@ public final class LiveSession: Sendable {
   /// the same configuration (URI, headers, model, system instruction, tools, etc.)
   /// as the original session.
   ///
-  /// To optain a valid handle, ensure you pass an instance of
+  /// To obtain a valid handle, ensure you pass an instance of
   /// ``SessionResumptionConfig`` to ``LiveGenerativeModel/connect(sessionResumption:)``,
   /// and then listen for the hande provided from a ``LiveSessionResumptionUpdate``
   /// server message.

--- a/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
+++ b/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
@@ -564,7 +564,7 @@ class FirestoreEncoderTests: XCTestCase {
       .failsEncodingWithJSONEncoder()
   }
 
-  func testDecodingDocumentIDWithConfictingFieldsDoesNotThrow() throws {
+  func testDecodingDocumentIDWithConflictingFieldsDoesNotThrow() throws {
     struct Model: Codable, Equatable {
       var name: String
       @DocumentID var docId: DocumentReference?


### PR DESCRIPTION
Typos found systematically but reviewed manually.
Changes are backward compatible.

Thanks