### PR TITLE
[App Check] Add `AppAttestProviderFactory`

### DIFF
--- a/FirebaseAppCheck.podspec
+++ b/FirebaseAppCheck.podspec
@@ -94,6 +94,8 @@ Pod::Spec.new do |s|
     swift_unit_tests.source_files = [
       base_dir + 'Tests/Unit/Swift/**/*.swift',
     ]
+
+    swift_unit_tests.dependency 'FirebaseCoreExtension', '~> 12.14.0'
   end
 
 end

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [added] Added `AppAttestProviderFactory` to simplify App Check setup when
-  using the App Attest provider."(#16182)
+  using the App Attest provider. (#16182)
 
 # 10.27.0
 - [fixed] [CocoaPods] missing symbol error for FIRGetLoggerLevel. (#12899)

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [added] Added `AppAttestProviderFactory` to simplify App Check setup when
+  using the App Attest provider."(#16182)
+
 # 10.27.0
 - [fixed] [CocoaPods] missing symbol error for FIRGetLoggerLevel. (#12899)
 

--- a/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProviderFactory.m
+++ b/FirebaseAppCheck/Sources/AppAttestProvider/FIRAppAttestProviderFactory.m
@@ -1,0 +1,26 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppAttestProviderFactory.h"
+
+#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppAttestProvider.h"
+#import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckProvider.h"
+
+@implementation FIRAppAttestProviderFactory
+
+- (nullable id<FIRAppCheckProvider>)createProviderWithApp:(nonnull FIRApp *)app {
+  return [[FIRAppAttestProvider alloc] initWithApp:app];
+}
+
+@end

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppAttestProviderFactory.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppAttestProviderFactory.h
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "FIRAppCheckAvailability.h"
+#import "FIRAppCheckProviderFactory.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A factory that vends `AppAttestProvider` instances for a given `FirebaseApp`.
+FIR_APP_ATTEST_PROVIDER_AVAILABILITY
+NS_SWIFT_NAME(AppAttestProviderFactory)
+@interface FIRAppAttestProviderFactory : NSObject <FIRAppCheckProviderFactory>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FirebaseAppCheck.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FirebaseAppCheck.h
@@ -30,3 +30,4 @@
 
 // App Attest provider.
 #import "FIRAppAttestProvider.h"
+#import "FIRAppAttestProviderFactory.h"

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppAttestProviderFactoryTests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppAttestProviderFactoryTests.swift
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FirebaseAppCheck
+import FirebaseCoreExtension
+import XCTest
+
+final class AppAttestProviderFactoryTests: XCTestCase {
+  func testCreateProviderWithApp() async throws {
+    let options = FirebaseOptions(googleAppID: "app_id", gcmSenderID: "sender_id")
+    options.apiKey = "api_key"
+    options.projectID = "project_id"
+    let appName = "test_app_name"
+    let app = FirebaseApp(instanceWithName: appName, options: options)
+    // The following disables automatic token refresh, which could interfere with tests.
+    app.isDataCollectionDefaultEnabled = false
+
+    let factory = AppAttestProviderFactory()
+
+    let provider = try XCTUnwrap(factory.createProvider(with: app))
+    XCTAssertTrue(provider.isKind(of: AppAttestProvider.self))
+    await app.delete()
+  }
+}

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppAttestProviderFactoryTests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppAttestProviderFactoryTests.swift
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 import FirebaseAppCheck
-import FirebaseCoreExtension
+internal import FirebaseCoreExtension
 import XCTest
 
+@available(iOS 14.0, macOS 11.3, macCatalyst 14.5, tvOS 15.0, watchOS 9.0, *)
 final class AppAttestProviderFactoryTests: XCTestCase {
   func testCreateProviderWithApp() async throws {
     let options = FirebaseOptions(googleAppID: "app_id", gcmSenderID: "sender_id")

--- a/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/AppCheckAPITests.swift
@@ -33,6 +33,14 @@ final class AppCheckAPITests {
       }
     }
 
+    // MARK: - AppAttestProviderFactory
+
+    if #available(iOS 14.0, macOS 11.3, macCatalyst 14.5, tvOS 15.0, watchOS 9.0, *),
+       let app = FirebaseApp.app() {
+      let factory = AppAttestProviderFactory()
+      _ = factory.createProvider(with: app)
+    }
+
     // MARK: - AppCheck
 
     // `AppCheckTokenDidChange` & associated notification keys

--- a/Package.swift
+++ b/Package.swift
@@ -1308,7 +1308,10 @@ let package = Package(
     ),
     .testTarget(
       name: "FirebaseAppCheckUnitSwift",
-      dependencies: ["FirebaseAppCheck"],
+      dependencies: [
+        "FirebaseAppCheck",
+        "FirebaseCoreExtension",
+      ],
       path: "FirebaseAppCheck/Tests/Unit/Swift",
       swiftSettings: [
         .swiftLanguageMode(SwiftLanguageMode.v5),


### PR DESCRIPTION
Added a built-in `AppAttestProviderFactory` so that developers don't need to manually create one. From the [documentation](https://firebase.google.com/docs/app-check/ios/app-attest-provider#initialize), this simplifies
```
class YourSimpleAppCheckProviderFactory: NSObject, AppCheckProviderFactory {
  func createProvider(with app: FirebaseApp) -> AppCheckProvider? {
    return AppAttestProvider(app: app)
  }
}

AppCheck.setAppCheckProviderFactory(YourAppCheckProviderFactory())
```
to
```
AppCheck.setAppCheckProviderFactory(AppAttestProviderFactory())
```