### PR TITLE
fix(appcheck): remove redundant fac debug token logging

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [changed] Removed redundant debug token warning log.
+- [changed] Removed redundant debug token warning log. (#16197)
 
 # 12.14.0
 - [added] Added `AppAttestProviderFactory` to simplify App Check setup when

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Unreleased
-- [fixed] Improved debug token logging to clearly state when an environment
-  variable is overriding the local token.
+- [changed] Removed redundant debug token warning log.
 
 # 12.14.0
 - [added] Added `AppAttestProviderFactory` to simplify App Check setup when

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Improved debug token logging to clearly state when an environment
+  variable is overriding the local token.
+
 # 12.14.0
 - [added] Added `AppAttestProviderFactory` to simplify App Check setup when
   using the App Attest provider. (#16182)

--- a/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProviderFactory.m
+++ b/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProviderFactory.m
@@ -26,7 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable id<FIRAppCheckProvider>)createProviderWithApp:(FIRApp *)app {
   FIRAppCheckDebugProvider *provider = [[FIRAppCheckDebugProvider alloc] initWithApp:app];
 
-
   return provider;
 }
 

--- a/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProviderFactory.m
+++ b/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProviderFactory.m
@@ -26,9 +26,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable id<FIRAppCheckProvider>)createProviderWithApp:(FIRApp *)app {
   FIRAppCheckDebugProvider *provider = [[FIRAppCheckDebugProvider alloc] initWithApp:app];
 
-  // Print only locally generated token to avoid a valid token leak on CI.
-  FIRLogWarning(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeDebugToken,
-                @"Firebase App Check debug token: '%@'.", [provider localDebugToken]);
+  NSString *currentToken = [provider currentDebugToken];
+  NSString *localToken = [provider localDebugToken];
+
+  if ([currentToken isEqualToString:localToken]) {
+    // Print only locally generated token to avoid a valid token leak on CI.
+    FIRLogWarning(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeDebugToken,
+                  @"Firebase App Check debug token: '%@'.", localToken);
+  } else {
+    FIRLogWarning(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeDebugToken,
+                  @"Firebase App Check debug token is overridden by environment variable.");
+  }
 
   return provider;
 }

--- a/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProviderFactory.m
+++ b/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProviderFactory.m
@@ -33,9 +33,6 @@ NS_ASSUME_NONNULL_BEGIN
     // Print only locally generated token to avoid a valid token leak on CI.
     FIRLogWarning(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeDebugToken,
                   @"Firebase App Check debug token: '%@'.", localToken);
-  } else {
-    FIRLogWarning(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeDebugToken,
-                  @"Firebase App Check debug token is overridden by environment variable.");
   }
 
   return provider;

--- a/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProviderFactory.m
+++ b/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProviderFactory.m
@@ -26,14 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable id<FIRAppCheckProvider>)createProviderWithApp:(FIRApp *)app {
   FIRAppCheckDebugProvider *provider = [[FIRAppCheckDebugProvider alloc] initWithApp:app];
 
-  NSString *currentToken = [provider currentDebugToken];
-  NSString *localToken = [provider localDebugToken];
-
-  if ([currentToken isEqualToString:localToken]) {
-    // Print only locally generated token to avoid a valid token leak on CI.
-    FIRLogWarning(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeDebugToken,
-                  @"Firebase App Check debug token: '%@'.", localToken);
-  }
 
   return provider;
 }


### PR DESCRIPTION
When a debug token is provided to FirebaseAppCheck via environment variable, the locally generated one is still printed, despite it being unused. **This is confusing.**

AppCheckCore already handles the logging debug tokens.

Docs: [cl/926230971](http://cl/926230971)

**Without** `-FIRDebugEnabled`:

Before
```
12.15.0 - [FirebaseCore][I-COR000001] Configuring the default app.
<Warning> [AppCheckCore][I-GAC004001] App Check debug token: '<redacted>'.
12.15.0 - [FirebaseAppCheck][I-FAA005001] Firebase App Check debug token: '<redacted>'.
12.15.0 - [FirebaseCore][I-COR000033] Data Collection flag is not set.
```

After
```
12.15.0 - [FirebaseCore][I-COR000001] Configuring the default app.
<Warning> [AppCheckCore][I-GAC004001] App Check debug token: '<redacted>'.
12.15.0 - [FirebaseCore][I-COR000033] Data Collection flag is not set.
```

cc: @rizafran 