### PR TITLE
[AI] Run Live API integration tests on schedule only

### DIFF
--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -54,7 +54,8 @@ jobs:
     # needs: spm
     env:
       TEST_RUNNER_FIRAAppCheckDebugToken: ${{ secrets.VERTEXAI_INTEGRATION_FAC_DEBUG_TOKEN }}
-      TEST_RUNNER_VTXIntegrationImagen: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      TEST_RUNNER_FALIntegrationImagen: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      TEST_RUNNER_FALIntegrationLiveSession: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
       secrets_passphrase: ${{ secrets.GHASecretsGPGPassphrase1 }}
     steps:

--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -50,8 +50,7 @@ jobs:
             xcode: Xcode_26.2
             action: test
     runs-on: ${{ matrix.os }}
-    # // Temporarily stop waiting for SPM before starting integration tests.
-    # needs: spm
+    needs: spm
     env:
       TEST_RUNNER_FIRAAppCheckDebugToken: ${{ secrets.VERTEXAI_INTEGRATION_FAC_DEBUG_TOKEN }}
       TEST_RUNNER_FALIntegrationImagen: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -60,10 +60,10 @@ jobs:
       secrets_passphrase: ${{ secrets.GHASecretsGPGPassphrase1 }}
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-      with:
-        path: .build
-        key: ${{ needs.spm.outputs.cache_key }}
+    # - uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+    #   with:
+    #     path: .build
+    #     key: ${{ needs.spm.outputs.cache_key }}
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FirebaseAI/TestApp-GoogleService-Info.plist.gpg \
         FirebaseAI/Tests/TestApp/Resources/GoogleService-Info.plist "$secrets_passphrase"

--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -50,7 +50,8 @@ jobs:
             xcode: Xcode_26.2
             action: test
     runs-on: ${{ matrix.os }}
-    needs: spm
+    # // Temporarily stop waiting for SPM before starting integration tests.
+    # needs: spm
     env:
       TEST_RUNNER_FIRAAppCheckDebugToken: ${{ secrets.VERTEXAI_INTEGRATION_FAC_DEBUG_TOKEN }}
       TEST_RUNNER_VTXIntegrationImagen: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -60,10 +60,10 @@ jobs:
       secrets_passphrase: ${{ secrets.GHASecretsGPGPassphrase1 }}
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    # - uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-    #   with:
-    #     path: .build
-    #     key: ${{ needs.spm.outputs.cache_key }}
+    - uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      with:
+        path: .build
+        key: ${{ needs.spm.outputs.cache_key }}
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FirebaseAI/TestApp-GoogleService-Info.plist.gpg \
         FirebaseAI/Tests/TestApp/Resources/GoogleService-Info.plist "$secrets_passphrase"

--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -43,10 +43,12 @@ jobs:
           - os: macos-15
             target: iOS
             xcode: Xcode_26.2
+            action: build
           - os: macos-26
             target: iOS
             # TODO: Bump to 26.4 when "Unable to find a destination matching the provided destination specifier" is resolved.
             xcode: Xcode_26.2
+            action: test
     runs-on: ${{ matrix.os }}
     needs: spm
     env:
@@ -60,8 +62,19 @@ jobs:
       with:
         path: .build
         key: ${{ needs.spm.outputs.cache_key }}
-    - name: Run integration tests
-      run: scripts/repo.sh tests run --secrets ./scripts/secrets/AI.json --platforms ${{ matrix.target }} --xcode ${{ matrix.xcode }} AI
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FirebaseAI/TestApp-GoogleService-Info.plist.gpg \
+        FirebaseAI/Tests/TestApp/Resources/GoogleService-Info.plist "$secrets_passphrase"
+    - name: Install Secret GoogleService-Info-Spark.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FirebaseAI/TestApp-GoogleService-Info-Spark.plist.gpg \
+        FirebaseAI/Tests/TestApp/Resources/GoogleService-Info-Spark.plist "$secrets_passphrase"
+    - name: Install Secret Credentials.swift
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FirebaseAI/TestApp-Credentials.swift.gpg \
+        FirebaseAI/Tests/TestApp/Tests/Integration/Credentials.swift "$secrets_passphrase"
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    - name: Run IntegrationTests
+      run: scripts/build.sh FirebaseAIIntegration ${{ matrix.target }} ${{ matrix.action }}
     - name: Upload xcodebuild logs
       if: failure()
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/ImagenIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/ImagenIntegrationTests.swift
@@ -25,8 +25,8 @@ import Testing
 
 @Suite(
   .enabled(
-    if: ProcessInfo.processInfo.environment["VTXIntegrationImagen"] != nil,
-    "Only runs if the environment variable VTXIntegrationImagen is set."
+    if: ProcessInfo.processInfo.environment["FALIntegrationImagen"] == "true",
+    "Only runs if the environment variable FALIntegrationImagen is set to true."
   ),
   .serialized
 )

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
@@ -19,7 +19,13 @@ import Testing
 
 @testable import struct FirebaseAILogic.APIConfig
 
-@Suite(.serialized)
+@Suite(
+  .enabled(
+    if: ProcessInfo.processInfo.environment["FALIntegrationLiveSession"] == "true",
+    "Only runs if the environment variable FALIntegrationLiveSession is set to true."
+  ),
+  .serialized
+)
 struct LiveSessionTests {
   private static let arguments = InstanceConfig.liveConfigs.flatMap { config in
     switch config.apiConfig.service {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -576,7 +576,7 @@ case "$product-$platform-$method" in
       -project 'FirebaseAI/Tests/TestApp/FirebaseAITestApp.xcodeproj' \
       -scheme "FirebaseAITestApp-SPM" \
       "${xcb_flags[@]}" \
-      build
+      build-for-testing
     ;;
 
   FirebaseAIIntegration-*-test)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -123,7 +123,12 @@ function RunXcodebuild() {
 
   local xcbeautify_cmd
   if command -v xcbeautify &> /dev/null; then
-    xcbeautify_cmd=(xcbeautify --renderer github-actions --disable-logging)
+    xcbeautify_cmd=(
+      env NSUnbufferedIO=YES
+      xcbeautify
+      --renderer github-actions
+      --disable-logging
+    )
   else
     echo "xcbeautify not found, using raw xcodebuild output."
     xcbeautify_cmd=(cat)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -580,7 +580,6 @@ case "$product-$platform-$method" in
     ;;
 
   FirebaseAIIntegration-*-test)
-    # Run tests excluding LiveSessionTests
     RunXcodebuild \
       -project 'FirebaseAI/Tests/TestApp/FirebaseAITestApp.xcodeproj' \
       -scheme "FirebaseAITestApp-SPM" \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -588,7 +588,6 @@ case "$product-$platform-$method" in
       -parallel-testing-enabled NO \
       -retry-tests-on-failure \
       -test-iterations 3 \
-      -skip-testing:IntegrationTests-SPM/LiveSessionTests \
       test
     ;;
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -567,14 +567,7 @@ case "$product-$platform-$method" in
     ;;
 
   FirebaseAIIntegration-*-*)
-    # Build
-    RunXcodebuild \
-      -project 'FirebaseAI/Tests/TestApp/FirebaseAITestApp.xcodeproj' \
-      -scheme "FirebaseAITestApp-SPM" \
-      "${xcb_flags[@]}" \
-      build-for-testing
-
-    # Run tests
+    # Run tests excluding LiveSessionTests
     RunXcodebuild \
       -project 'FirebaseAI/Tests/TestApp/FirebaseAITestApp.xcodeproj' \
       -scheme "FirebaseAITestApp-SPM" \
@@ -582,7 +575,8 @@ case "$product-$platform-$method" in
       -parallel-testing-enabled NO \
       -retry-tests-on-failure \
       -test-iterations 3 \
-      test-without-building
+      -skip-testing:IntegrationTests-SPM/LiveSessionTests \
+      test
     ;;
 
   Sessions-*-integration)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -571,7 +571,15 @@ case "$product-$platform-$method" in
       build
     ;;
 
-  FirebaseAIIntegration-*-*)
+  FirebaseAIIntegration-*-build)
+    RunXcodebuild \
+      -project 'FirebaseAI/Tests/TestApp/FirebaseAITestApp.xcodeproj' \
+      -scheme "FirebaseAITestApp-SPM" \
+      "${xcb_flags[@]}" \
+      build
+    ;;
+
+  FirebaseAIIntegration-*-test)
     # Run tests excluding LiveSessionTests
     RunXcodebuild \
       -project 'FirebaseAI/Tests/TestApp/FirebaseAITestApp.xcodeproj' \


### PR DESCRIPTION
- Updated the flaky `LiveSessionTests` from `FirebaseAIIntegration` to run on scheduled (nightly) and manual CI runs only.
- Added `NSUnbufferedIO=YES` to `xcbeautify` invocation to get some output before testing completes.
- Updated the macos-15 job to only build the integration tests. Tests now run only on macos-26.
  - Reverted back to the pre-`scripts/repo.sh` refactor (https://github.com/firebase/firebase-ios-sdk/pull/15415) for now to simplify `build-for-testing` vs. `test` switching.

#no-changelog