### PR TITLE
[Firestore] Fix implicit rounding error in `FSTUserDataReaderTests`

### DIFF
--- a/Firestore/Example/Tests/API/FSTUserDataReaderTests.mm
+++ b/Firestore/Example/Tests/API/FSTUserDataReaderTests.mm
@@ -87,8 +87,9 @@ using firebase::firestore::util::MakeString;
   // Note 2: LLONG_MAX cannot be represented exactly by a double and is rounded up by 1 from
   //         9223372036854775807 to 9223372036854775808.
   NSArray<NSNumber *> *values = @[
-    @(-INFINITY), @(-DBL_MAX), @(LLONG_MIN * 1.0), @(-1.1), @(-0x1.0p-1074), @(-0.0), @(0.0),
-    @(0x1.0p-1074), @(DBL_MIN), @(1.1), @(static_cast<double>(LLONG_MAX)), @(DBL_MAX), @(INFINITY)
+    @(-INFINITY), @(-DBL_MAX), @(static_cast<double>(LLONG_MIN)), @(-1.1), @(-0x1.0p-1074), @(-0.0),
+    @(0.0), @(0x1.0p-1074), @(DBL_MIN), @(1.1), @(static_cast<double>(LLONG_MAX)), @(DBL_MAX),
+    @(INFINITY)
   ];
   for (NSNumber *value in values) {
     Message<google_firestore_v1_Value> wrapped = FSTTestFieldValue(value);

--- a/Firestore/Example/Tests/API/FSTUserDataReaderTests.mm
+++ b/Firestore/Example/Tests/API/FSTUserDataReaderTests.mm
@@ -82,11 +82,13 @@ using firebase::firestore::util::MakeString;
 }
 
 - (void)testConvertsDoubles {
-  // Note that 0x1.0p-1074 is a hex floating point literal representing the minimum subnormal
-  // number: <https://en.wikipedia.org/wiki/Denormal_number>.
+  // Note 1: 0x1.0p-1074 is a hex floating point literal representing the minimum subnormal
+  //        number; see https://en.wikipedia.org/wiki/Denormal_number .
+  // Note 2: LLONG_MAX cannot be represented exactly by a double and is rounded up by 1 from
+  //         9223372036854775807 to 9223372036854775808.
   NSArray<NSNumber *> *values = @[
-    @(-INFINITY), @(-DBL_MAX), @(LLONG_MIN * -1.0), @(-1.1), @(-0x1.0p-1074), @(-0.0), @(0.0),
-    @(0x1.0p-1074), @(DBL_MIN), @(1.1), @(LLONG_MAX * 1.0), @(DBL_MAX), @(INFINITY)
+    @(-INFINITY), @(-DBL_MAX), @(LLONG_MIN * 1.0), @(-1.1), @(-0x1.0p-1074), @(-0.0), @(0.0),
+    @(0x1.0p-1074), @(DBL_MIN), @(1.1), @(static_cast<double>(LLONG_MAX)), @(DBL_MAX), @(INFINITY)
   ];
   for (NSNumber *value in values) {
     Message<google_firestore_v1_Value> wrapped = FSTTestFieldValue(value);

--- a/Firestore/Example/Tests/Integration/API/FIRAggregateTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRAggregateTests.mm
@@ -230,19 +230,21 @@
             ]]];
 
   // Count
-  XCTAssertEqual([snapshot valueForAggregateField:[FIRAggregateField aggregateFieldForCount]],
-                 [NSNumber numberWithLong:2L]);
-  XCTAssertEqual([snapshot count], [NSNumber numberWithLong:2L]);
+  XCTAssertEqualObjects(
+      [snapshot valueForAggregateField:[FIRAggregateField aggregateFieldForCount]],
+      [NSNumber numberWithLong:2L]);
+  XCTAssertEqualObjects([snapshot count], [NSNumber numberWithLong:2L]);
 
   // Sum
-  XCTAssertEqual(
+  XCTAssertEqualObjects(
       [snapshot valueForAggregateField:[FIRAggregateField aggregateFieldForSumOfField:@"pages"]],
       [NSNumber numberWithLong:150L], );
 
   // Average
-  XCTAssertEqual([snapshot valueForAggregateField:[FIRAggregateField
-                                                      aggregateFieldForAverageOfField:@"pages"]],
-                 [NSNumber numberWithDouble:75.0]);
+  XCTAssertEqualObjects(
+      [snapshot
+          valueForAggregateField:[FIRAggregateField aggregateFieldForAverageOfField:@"pages"]],
+      [NSNumber numberWithDouble:75.0]);
 }
 
 - (void)testCanRunEmptyAggregateQuery {
@@ -409,11 +411,12 @@
             ]]];
 
   // Count
-  XCTAssertEqual([snapshot valueForAggregateField:[FIRAggregateField aggregateFieldForCount]],
-                 [NSNumber numberWithLong:2L]);
+  XCTAssertEqualObjects(
+      [snapshot valueForAggregateField:[FIRAggregateField aggregateFieldForCount]],
+      [NSNumber numberWithLong:2L]);
 
   // Sum
-  XCTAssertEqual(
+  XCTAssertEqualObjects(
       [snapshot valueForAggregateField:[FIRAggregateField aggregateFieldForSumOfField:@"pages"]],
       [NSNumber numberWithLong:150L], );
 }
@@ -460,13 +463,13 @@
   [self awaitExpectation:expectation];
 
   // Count
-  XCTAssertEqual([result valueForAggregateField:[FIRAggregateField aggregateFieldForCount]],
-                 [NSNumber numberWithLong:2L]);
+  XCTAssertEqualObjects([result valueForAggregateField:[FIRAggregateField aggregateFieldForCount]],
+                        [NSNumber numberWithLong:2L]);
 
   // Sum
-  XCTAssertEqual(
+  XCTAssertEqualObjects(
       [result valueForAggregateField:[FIRAggregateField aggregateFieldForSumOfField:@"pages"]],
-      [NSNumber numberWithLong:150L], );
+      [NSNumber numberWithLong:150L]);
 }
 
 - (void)testCannotPerformMoreThanMaxAggregations {
@@ -818,7 +821,7 @@
                                                        aggregateFieldForSumOfField:@"rating"] ]]];
 
   // Sum
-  XCTAssertEqual(
+  XCTAssertEqualObjects(
       [snapshot valueForAggregateField:[FIRAggregateField aggregateFieldForSumOfField:@"rating"]],
       [NSNumber numberWithDouble:INFINITY]);
 }
@@ -843,7 +846,7 @@
                                                        aggregateFieldForSumOfField:@"rating"] ]]];
 
   // Sum
-  XCTAssertEqual(
+  XCTAssertEqualObjects(
       [snapshot valueForAggregateField:[FIRAggregateField aggregateFieldForSumOfField:@"rating"]],
       [NSNumber numberWithDouble:-INFINITY]);
 }
@@ -905,7 +908,8 @@
 
   switch ([FSTIntegrationTestCase backendEdition]) {
     case FSTBackendEditionStandard: {
-      XCTAssertEqual([snapshot valueForAggregateField:sumOfPages], [NSNumber numberWithLong:0L]);
+      XCTAssertEqualObjects([snapshot valueForAggregateField:sumOfPages],
+                            [NSNumber numberWithLong:0L]);
       break;
     }
     case FSTBackendEditionEnterprise: {

--- a/Firestore/Example/Tests/Integration/API/FIRAggregateTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRAggregateTests.mm
@@ -238,7 +238,7 @@
   // Sum
   XCTAssertEqualObjects(
       [snapshot valueForAggregateField:[FIRAggregateField aggregateFieldForSumOfField:@"pages"]],
-      [NSNumber numberWithLong:150L], );
+      [NSNumber numberWithLong:150L]);
 
   // Average
   XCTAssertEqualObjects(
@@ -376,7 +376,7 @@
   // Sum
   XCTAssertEqual(
       [snapshot valueForAggregateField:[FIRAggregateField aggregateFieldForSumOfField:longField]],
-      [NSNumber numberWithLong:3], );
+      [NSNumber numberWithLong:3]);
 }
 
 - (void)testCanGetDuplicateAggregations {
@@ -418,7 +418,7 @@
   // Sum
   XCTAssertEqualObjects(
       [snapshot valueForAggregateField:[FIRAggregateField aggregateFieldForSumOfField:@"pages"]],
-      [NSNumber numberWithLong:150L], );
+      [NSNumber numberWithLong:150L]);
 }
 
 - (void)testTerminateDoesNotCrashWithFlyingAggregateQuery {


### PR DESCRIPTION
The `testConvertsDoubles` test in `FSTUserDataReaderTests` was implicitly rounding `LLONG_MAX` from `9223372036854775807` to `9223372036854775808` when multiplying by `1.0` to get a `double` value. Although the value of this particular test is questionable, I updated it to explicitly cast to `double` since it seems like the intention of the test is to check that large numbers are handled.

Also changed `@(LLONG_MIN * -1.0)` to `@(LLONG_MIN * 1.0)` since multiplying a negative number by `-1` is just testing more positive numbers. Note: Since `LLONG_MIN` is `-9223372036854775808`, it could be represented exactly by a double and thus wasn't causing a warning.

Replaced `XCTAssertEqual` pointer equality comparisons on NSNumber instances with `XCTAssertEqualObjects`. The `XCTAssertEqual` tests pass in most cases, likely due to [tagged pointer optimization](https://developer.apple.com/videos/play/wwdc2020/10163/?time=1060), but for large numbers such as `INFINITY` and `-INFINITY` we must use `XCTAssertEqualObjects` or convert to a primitive type like `double` before using `XCTAssertEqual`.

#no-changelog