### PR TITLE
feat(ci): separate AI Logic live tests from the others

### DIFF
--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -61,12 +61,47 @@ jobs:
         path: .build
         key: ${{ needs.spm.outputs.cache_key }}
     - name: Run integration tests
-      run: scripts/repo.sh tests run --secrets ./scripts/secrets/AI.json --platforms ${{ matrix.target }} --xcode ${{ matrix.xcode }} AI
+      run: scripts/repo.sh tests run --secrets ./scripts/secrets/AI.json --platforms ${{ matrix.target }} --xcode ${{ matrix.xcode }} --exclude IntegrationTests-SPM/LiveSessionTests AI
     - name: Upload xcodebuild logs
       if: failure()
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: xcodebuild-${{ matrix.target }}-${{ matrix.os }}-${{ matrix.xcode }}.log
+        path: xcodebuild-*.log
+        retention-days: 2
+
+  testapp-integration-live:
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+    strategy:
+      matrix:
+        include:
+          - os: macos-15
+            target: iOS
+            xcode: Xcode_26.2
+          - os: macos-26
+            target: iOS
+            # TODO: Bump to 26.4 when "Unable to find a destination matching the provided destination specifier" is resolved.
+            xcode: Xcode_26.2
+    runs-on: ${{ matrix.os }}
+    needs: spm
+    env:
+      TEST_RUNNER_FIRAAppCheckDebugToken: ${{ secrets.VERTEXAI_INTEGRATION_FAC_DEBUG_TOKEN }}
+      TEST_RUNNER_VTXIntegrationImagen: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+      secrets_passphrase: ${{ secrets.GHASecretsGPGPassphrase1 }}
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      with:
+        path: .build
+        key: ${{ needs.spm.outputs.cache_key }}
+    - name: Run integration tests
+      run: scripts/repo.sh tests run --secrets ./scripts/secrets/AI.json --platforms ${{ matrix.target }} --xcode ${{ matrix.xcode }} --filter IntegrationTests-SPM/LiveSessionTests AI
+    - name: Upload xcodebuild logs
+      if: failure()
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: xcodebuild-live-${{ matrix.target }}-${{ matrix.os }}-${{ matrix.xcode }}.log
         path: xcodebuild-*.log
         retention-days: 2
 

--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -43,45 +43,25 @@ jobs:
           - os: macos-15
             target: iOS
             xcode: Xcode_26.2
-          - os: macos-26
-            target: iOS
-            # TODO: Bump to 26.4 when "Unable to find a destination matching the provided destination specifier" is resolved.
-            xcode: Xcode_26.2
-    runs-on: ${{ matrix.os }}
-    needs: spm
-    env:
-      TEST_RUNNER_FIRAAppCheckDebugToken: ${{ secrets.VERTEXAI_INTEGRATION_FAC_DEBUG_TOKEN }}
-      TEST_RUNNER_VTXIntegrationImagen: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
-      secrets_passphrase: ${{ secrets.GHASecretsGPGPassphrase1 }}
-    steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-      with:
-        path: .build
-        key: ${{ needs.spm.outputs.cache_key }}
-    - name: Run integration tests
-      run: scripts/repo.sh tests run --secrets ./scripts/secrets/AI.json --platforms ${{ matrix.target }} --xcode ${{ matrix.xcode }} --exclude IntegrationTests-SPM/LiveSessionTests AI
-    - name: Upload xcodebuild logs
-      if: failure()
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-      with:
-        name: xcodebuild-${{ matrix.target }}-${{ matrix.os }}-${{ matrix.xcode }}.log
-        path: xcodebuild-*.log
-        retention-days: 2
-
-  testapp-integration-live:
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
-    strategy:
-      matrix:
-        include:
+            test_filter_arg: --exclude IntegrationTests-SPM/LiveSessionTests
+            log_prefix: xcodebuild
           - os: macos-15
             target: iOS
             xcode: Xcode_26.2
+            test_filter_arg: --filter IntegrationTests-SPM/LiveSessionTests
+            log_prefix: xcodebuild-live
           - os: macos-26
             target: iOS
             # TODO: Bump to 26.4 when "Unable to find a destination matching the provided destination specifier" is resolved.
             xcode: Xcode_26.2
+            test_filter_arg: --exclude IntegrationTests-SPM/LiveSessionTests
+            log_prefix: xcodebuild
+          - os: macos-26
+            target: iOS
+            # TODO: Bump to 26.4 when "Unable to find a destination matching the provided destination specifier" is resolved.
+            xcode: Xcode_26.2
+            test_filter_arg: --filter IntegrationTests-SPM/LiveSessionTests
+            log_prefix: xcodebuild-live
     runs-on: ${{ matrix.os }}
     needs: spm
     env:
@@ -96,12 +76,12 @@ jobs:
         path: .build
         key: ${{ needs.spm.outputs.cache_key }}
     - name: Run integration tests
-      run: scripts/repo.sh tests run --secrets ./scripts/secrets/AI.json --platforms ${{ matrix.target }} --xcode ${{ matrix.xcode }} --filter IntegrationTests-SPM/LiveSessionTests AI
+      run: scripts/repo.sh tests run --secrets ./scripts/secrets/AI.json --platforms ${{ matrix.target }} --xcode ${{ matrix.xcode }} ${{ matrix.test_filter_arg }} AI
     - name: Upload xcodebuild logs
       if: failure()
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
-        name: xcodebuild-live-${{ matrix.target }}-${{ matrix.os }}-${{ matrix.xcode }}.log
+        name: ${{ matrix.log_prefix }}-${{ matrix.target }}-${{ matrix.os }}-${{ matrix.xcode }}.log
         path: xcodebuild-*.log
         retention-days: 2
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
   cat 1>&2 <<EOF
-USAGE: $0 product [platform] [method]
+USAGE: $0 product [platform] [method] [extra_flags...]
 product can be one of:
   Firebase
   Firestore
@@ -66,6 +66,8 @@ elements:
   asan
   tsan
   ubsan
+
+Optionally, any trailing arguments after 'method' are also appended as extra xcodebuild flags.
 EOF
   exit 1
 fi
@@ -329,6 +331,10 @@ if [[ -n "${SANITIZERS:-}" ]]; then
   done
 fi
 
+# Append any trailing arguments as extra xcodebuild flags (the extra_flags argument)
+if [[ $# -gt 3 ]]; then
+  xcb_flags+=("${@:4}")
+fi
 
 case "$product-$platform-$method" in
   FirebasePod-iOS-*)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -577,8 +577,8 @@ case "$product-$platform-$method" in
     # Filter out test-only flags for the build-for-testing phase
     # It's a bit hacky, but xcode doesn't generate a proper dependency graph
     # when it's only targeting a single test file or filtering out files.
-    local build_flags=()
-    local skip_next=false
+    build_flags=()
+    skip_next=false
     for arg in "${xcb_flags[@]}"; do
       if [[ "$skip_next" == "true" ]]; then
         skip_next=false

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -336,6 +336,7 @@ if [[ $# -gt 3 ]]; then
   xcb_flags+=("${@:4}")
 fi
 
+# TODO(b/519178233): Find some way to modernize this or refactor the design for extensibility
 case "$product-$platform-$method" in
   FirebasePod-iOS-*)
     RunXcodebuild \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -573,11 +573,28 @@ case "$product-$platform-$method" in
     ;;
 
   FirebaseAIIntegration-*-*)
+    # Filter out test-only flags for the build-for-testing phase
+    # It's a bit hacky, but xcode doesn't generate a proper dependency graph
+    # when it's only targeting a single test file or filtering out files.
+    local build_flags=()
+    local skip_next=false
+    for arg in "${xcb_flags[@]}"; do
+      if [[ "$skip_next" == "true" ]]; then
+        skip_next=false
+        continue
+      fi
+      if [[ "$arg" == "-only-testing" || "$arg" == "-skip-testing" ]]; then
+        skip_next=true
+        continue
+      fi
+      build_flags+=("$arg")
+    done
+
     # Build
     RunXcodebuild \
       -project 'FirebaseAI/Tests/TestApp/FirebaseAITestApp.xcodeproj' \
       -scheme "FirebaseAITestApp-SPM" \
-      "${xcb_flags[@]}" \
+      "${build_flags[@]}" \
       build-for-testing
 
     # Run tests

--- a/scripts/repo/Sources/Tests/Run.swift
+++ b/scripts/repo/Sources/Tests/Run.swift
@@ -163,8 +163,8 @@ extension Tests {
       }
     }
 
-    private mutating func validateFilters() throws {
-      // filter takes priority with xcodebuild, so we just don't allow them to be used in tangent
+    private func validateFilters() throws {
+      // filter takes priority with xcodebuild, so we just don't allow them to be used in tandem
       // to avoid any edge case issues
       if filter != nil && exclude != nil {
         throw ValidationError(

--- a/scripts/repo/Sources/Tests/Run.swift
+++ b/scripts/repo/Sources/Tests/Run.swift
@@ -163,7 +163,7 @@ extension Tests {
       }
     }
 
-    mutating private func validateFilters() throws {
+    private mutating func validateFilters() throws {
       // filter takes priority with xcodebuild, so we just don't allow them to be used in tangent
       // to avoid any edge case issues
       if filter != nil && exclude != nil {
@@ -288,7 +288,11 @@ extension Tests {
           inheritEnvironment: true
         )
 
-        let exitCode = try build.runWithSignals(["Firebase\(sdk)Integration", "\(platform)", "xcodebuild"] + extraArguments)
+        let exitCode = try build.runWithSignals([
+          "Firebase\(sdk)Integration",
+          "\(platform)",
+          "xcodebuild",
+        ] + extraArguments)
         guard exitCode == 0 else {
           log.error(
             "Failed to run integration tests.",

--- a/scripts/repo/Sources/Tests/Run.swift
+++ b/scripts/repo/Sources/Tests/Run.swift
@@ -25,7 +25,7 @@ extension Tests {
     nonisolated(unsafe) static var configuration = CommandConfiguration(
       abstract: "Run the integration tests for a given SDK.",
       usage: """
-        tests run [--overwrite] [--secrets <file_path>] [--xcode <version_or_path>] [--platforms <platforms> ...] [<sdk>]
+        tests run [--overwrite] [--secrets <file_path>] [--xcode <version_or_path>] [--platforms <platforms> ...] [--filter <suite_or_function>] [--exclude <suite_or_function>] [<sdk>]
 
         tests run --xcode Xcode_16.4.0 --platforms iOS --platforms macOS AI
         tests run --xcode "/Applications/Xcode_15.0.0.app" --platforms tvOS Storage
@@ -70,6 +70,22 @@ extension Tests {
     @Option(help: "Path to a json file containing an array of secret files to use, if any.")
     var secrets: String? = nil
 
+    @Option(
+      help: """
+      Optional test target to run against.
+      Can be a test suite or test function identifier (eg; "IntegrationTests-SPM/LiveSessionTests" or "IntegrationTests-SPM/LiveSessionTests/realtime_functionCalling").
+      """
+    )
+    var filter: String? = nil
+
+    @Option(
+      help: """
+      Optional test target to exclude from running.
+      Can be a test suite or test function identifier (eg; "IntegrationTests-SPM/LiveSessionTests" or "IntegrationTests-SPM/LiveSessionTests/realtime_functionCalling").
+      """
+    )
+    var exclude: String? = nil
+
     @Flag(help: "Overwrite existing decrypted secret files.")
     var overwrite: Bool = false
 
@@ -95,6 +111,7 @@ extension Tests {
       } else {
         try validateProvidedXcode()
       }
+      try validateFilters()
     }
 
     /// When the `xcode` option isn't provided, try to find an installation on disk.
@@ -146,6 +163,16 @@ extension Tests {
       }
     }
 
+    mutating private func validateFilters() throws {
+      // filter takes priority with xcodebuild, so we just don't allow them to be used in tangent
+      // to avoid any edge case issues
+      if filter != nil && exclude != nil {
+        throw ValidationError(
+          "Cannot supply both --filter and --exclude options, please only specify one."
+        )
+      }
+    }
+
     private func findXcodeVersions() throws -> [URL] {
       let applicationDirs = FileManager.default.urls(
         for: .applicationDirectory, in: .allDomainsMask
@@ -193,6 +220,20 @@ extension Tests {
       return xcodes
     }
 
+    private func buildExtraArguments() -> [String] {
+      var arguments: [String] = []
+      if let filter {
+        arguments.append(contentsOf: ["-only-testing", filter])
+        log.info("Filtering tests", metadata: ["filter": "\(filter)"])
+      }
+      if let exclude {
+        arguments.append(contentsOf: ["-skip-testing", exclude])
+        log.info("Excluding tests", metadata: ["exclude": "\(exclude)"])
+      }
+
+      return arguments
+    }
+
     mutating func run() throws {
       var secretFiles: [SecretFile] = []
 
@@ -231,6 +272,8 @@ extension Tests {
       }
 
       let buildScript = URL(filePath: "scripts/build.sh", relativeTo: URL.currentDirectory())
+      let extraArguments = buildExtraArguments()
+
       for platform in platforms {
         log.info(
           "Running integration tests",
@@ -245,9 +288,7 @@ extension Tests {
           inheritEnvironment: true
         )
 
-        let exitCode = try build.runWithSignals([
-          "Firebase\(sdk)Integration", "\(platform)",
-        ])
+        let exitCode = try build.runWithSignals(["Firebase\(sdk)Integration", "\(platform)", "xcodebuild"] + extraArguments)
         guard exitCode == 0 else {
           log.error(
             "Failed to run integration tests.",


### PR DESCRIPTION
Per [b/507471448](https://buganizer.corp.google.com/issues/507471448),

This PR separates the AI Logic live tests from the non live tests. Since the live tests are flakey, this will prevent the live tests from needing to re-run whenever the non live tests fail.

This is achieved by doing the following:
- The `build.sh` script was expanded to support "extra xcb flags" by just treating any trailing flags as additional arguments for xcb.
- The `run` command in `repo` was updated to add `filter` and `exclude` options, which are passed to the build script via the extra flags.
- The AI Logic CI workflow file was updated to use a matrix where it passes in the `exclude` and `filter` options to make two runs: one with live tests, and one without.

#no-changelog