### PR TITLE
validate resource name format before PopFirst in bundle parsing

### DIFF
--- a/Firestore/core/src/bundle/bundle_serializer.cc
+++ b/Firestore/core/src/bundle/bundle_serializer.cc
@@ -400,7 +400,8 @@ ResourcePath BundleSerializer::DecodeName(JsonReader& reader,
   }
   auto path =
       ResourcePath::FromString(document_name.get_ref<const std::string&>());
-  if (!rpc_serializer_.IsLocalResourceName(path)) {
+  if (!rpc_serializer_.IsLocalResourceName(path) || path.size() < 5 ||
+      path[4] != "documents") {
     reader.Fail("Resource name is not valid for current instance: " +
                 path.CanonicalString());
     return {};

--- a/Firestore/core/src/bundle/bundle_serializer.cc
+++ b/Firestore/core/src/bundle/bundle_serializer.cc
@@ -648,7 +648,7 @@ BundledDocumentMetadata BundleSerializer::DecodeDocumentMetadata(
   if (!reader.ok()) {
     return {};
   }
-  if (!DocumentKey::IsDocumentKey(path)) {
+  if (path.empty() || !DocumentKey::IsDocumentKey(path)) {
     reader.Fail("Resource name is not a valid document key: " +
                 path.CanonicalString());
     return {};
@@ -684,7 +684,7 @@ BundleDocument BundleSerializer::DecodeDocument(JsonReader& reader,
   if (!reader.ok()) {
     return {};
   }
-  if (!DocumentKey::IsDocumentKey(path)) {
+  if (path.empty() || !DocumentKey::IsDocumentKey(path)) {
     reader.Fail("Resource name is not a valid document key: " +
                 path.CanonicalString());
     return {};

--- a/Firestore/core/src/bundle/bundle_serializer.cc
+++ b/Firestore/core/src/bundle/bundle_serializer.cc
@@ -648,6 +648,11 @@ BundledDocumentMetadata BundleSerializer::DecodeDocumentMetadata(
   if (!reader.ok()) {
     return {};
   }
+  if (!DocumentKey::IsDocumentKey(path)) {
+    reader.Fail("Resource name is not a valid document key: " +
+                path.CanonicalString());
+    return {};
+  }
   DocumentKey key = DocumentKey(path);
 
   SnapshotVersion read_time = DecodeSnapshotVersion(
@@ -677,6 +682,11 @@ BundleDocument BundleSerializer::DecodeDocument(JsonReader& reader,
       DecodeName(reader, reader.RequiredObject("name", document));
   // Return early if !ok(), `DocumentKey` aborts with invalid inputs.
   if (!reader.ok()) {
+    return {};
+  }
+  if (!DocumentKey::IsDocumentKey(path)) {
+    reader.Fail("Resource name is not a valid document key: " +
+                path.CanonicalString());
     return {};
   }
   DocumentKey key = DocumentKey(path);

--- a/Firestore/core/src/remote/serializer.cc
+++ b/Firestore/core/src/remote/serializer.cc
@@ -1521,7 +1521,8 @@ bool Serializer::IsLocalResourceName(const ResourcePath& path) const {
 
 bool Serializer::IsLocalDocumentKey(absl::string_view path) const {
   auto resource = ResourcePath::FromStringView(path);
-  return IsLocalResourceName(resource) &&
+  return IsLocalResourceName(resource) && resource.size() >= 5 &&
+         resource[4] == "documents" &&
          DocumentKey::IsDocumentKey(resource.PopFirst(5));
 }
 

--- a/Firestore/core/src/remote/serializer.cc
+++ b/Firestore/core/src/remote/serializer.cc
@@ -1522,8 +1522,7 @@ bool Serializer::IsLocalResourceName(const ResourcePath& path) const {
 bool Serializer::IsLocalDocumentKey(absl::string_view path) const {
   auto resource = ResourcePath::FromStringView(path);
   return IsLocalResourceName(resource) && resource.size() >= 5 &&
-         resource[4] == "documents" &&
-         DocumentKey::IsDocumentKey(resource.PopFirst(5));
+         resource[4] == "documents" && (resource.size() - 5) % 2 == 0;
 }
 
 api::PipelineSnapshot Serializer::DecodePipelineResponse(

--- a/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
+++ b/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
@@ -1166,6 +1166,39 @@ TEST_F(BundleSerializerTest, DecodeInvalidBundledDocumentMetadataFails) {
   }
 }
 
+TEST_F(BundleSerializerTest, DecodeNonDocumentKeyResourceNameFails) {
+  // A resource name that points at a collection (odd number of segments after
+  // the `documents` prefix) passes the local-resource-name check but is not a
+  // valid `DocumentKey`. It must be rejected gracefully instead of tripping the
+  // `HARD_ASSERT` inside the `DocumentKey` constructor.
+  {
+    ProtoDocument document = TestDocument(ProtoValue());
+    document.set_name(FullPath("bundle"));
+    std::string json_string;
+    MessageToJsonString(document, &json_string);
+
+    JsonReader reader;
+    bundle_serializer.DecodeDocument(reader, Parse(json_string));
+    EXPECT_NOT_OK(reader.status());
+  }
+
+  {
+    ProtoBundledDocumentMetadata metadata;
+    metadata.set_name(FullPath("bundle"));
+    metadata.set_exists(true);
+    google::protobuf::Timestamp t1;
+    t1.set_seconds(0);
+    t1.set_nanos(0);
+    *metadata.mutable_read_time() = t1;
+    std::string json_string;
+    MessageToJsonString(metadata, &json_string);
+
+    JsonReader reader;
+    bundle_serializer.DecodeDocumentMetadata(reader, Parse(json_string));
+    EXPECT_NOT_OK(reader.status());
+  }
+}
+
 TEST_F(BundleSerializerTest, DecodeTargetWithoutImplicitOrderByOnName) {
   std::string json(
       R"({"name":"myNamedQuery",

--- a/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
+++ b/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
@@ -1175,8 +1175,8 @@ TEST_F(BundleSerializerTest, DecodeNonDocumentKeyResourceNameFails) {
   //      prefix),
   //   2. a root `documents` path (resolves to an empty key), and
   //   3. a short path (fewer than five segments, would crash `PopFirst(5)`).
-  const std::vector<std::string> names = {
-      FullPath("bundle"), FullPath(""), "projects/p/databases/default"};
+  const std::vector<std::string> names = {FullPath("bundle"), FullPath(""),
+                                          "projects/p/databases/default"};
 
   for (const auto& name : names) {
     {

--- a/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
+++ b/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
@@ -1167,35 +1167,44 @@ TEST_F(BundleSerializerTest, DecodeInvalidBundledDocumentMetadataFails) {
 }
 
 TEST_F(BundleSerializerTest, DecodeNonDocumentKeyResourceNameFails) {
-  // A resource name that points at a collection (odd number of segments after
-  // the `documents` prefix) passes the local-resource-name check but is not a
-  // valid `DocumentKey`. It must be rejected gracefully instead of tripping the
-  // `HARD_ASSERT` inside the `DocumentKey` constructor.
-  {
-    ProtoDocument document = TestDocument(ProtoValue());
-    document.set_name(FullPath("bundle"));
-    std::string json_string;
-    MessageToJsonString(document, &json_string);
+  // Resource names that pass the local-resource-name check but are not valid
+  // `DocumentKey`s must be rejected gracefully instead of tripping the
+  // `HARD_ASSERT` inside the `DocumentKey` constructor or the length assert
+  // inside `PopFirst`. Three malformed shapes are covered:
+  //   1. a collection path (odd number of segments after the `documents`
+  //      prefix),
+  //   2. a root `documents` path (resolves to an empty key), and
+  //   3. a short path (fewer than five segments, would crash `PopFirst(5)`).
+  const std::vector<std::string> names = {
+      FullPath("bundle"), FullPath(""), "projects/p/databases/default"};
 
-    JsonReader reader;
-    bundle_serializer.DecodeDocument(reader, Parse(json_string));
-    EXPECT_NOT_OK(reader.status());
-  }
+  for (const auto& name : names) {
+    {
+      ProtoDocument document = TestDocument(ProtoValue());
+      document.set_name(name);
+      std::string json_string;
+      MessageToJsonString(document, &json_string);
 
-  {
-    ProtoBundledDocumentMetadata metadata;
-    metadata.set_name(FullPath("bundle"));
-    metadata.set_exists(true);
-    google::protobuf::Timestamp t1;
-    t1.set_seconds(0);
-    t1.set_nanos(0);
-    *metadata.mutable_read_time() = t1;
-    std::string json_string;
-    MessageToJsonString(metadata, &json_string);
+      JsonReader reader;
+      bundle_serializer.DecodeDocument(reader, Parse(json_string));
+      EXPECT_NOT_OK(reader.status());
+    }
 
-    JsonReader reader;
-    bundle_serializer.DecodeDocumentMetadata(reader, Parse(json_string));
-    EXPECT_NOT_OK(reader.status());
+    {
+      ProtoBundledDocumentMetadata metadata;
+      metadata.set_name(name);
+      metadata.set_exists(true);
+      google::protobuf::Timestamp t1;
+      t1.set_seconds(0);
+      t1.set_nanos(0);
+      *metadata.mutable_read_time() = t1;
+      std::string json_string;
+      MessageToJsonString(metadata, &json_string);
+
+      JsonReader reader;
+      bundle_serializer.DecodeDocumentMetadata(reader, Parse(json_string));
+      EXPECT_NOT_OK(reader.status());
+    }
   }
 }
 


### PR DESCRIPTION
DecodeName and IsLocalDocumentKey accept a resource name from bundle input and call PopFirst(5) after only checking IsLocalResourceName, which still allows a four-segment name like projects/p/databases/d. That trips the length assertion inside PopFirst. ExtractLocalPathFromResourceName and DocumentKey::FromName already require size() > 4 and a documents segment, so this applies the same format check at the two bundle-reachable sites.