### PR TITLE
[Core] Require `swift-tools-version:6.1` in `Package.swift`

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Firebase 12.15.0
+- [changed] Firebase now requires Swift tools version 6.1 for the Swift Package.
+  The package will no longer resolve in Xcode versions older than 16.3. Note that
+  the minimum officially supported version for the SDK remains Xcode 26.2+.
+
 # Firebase 12.14.0
 - [fixed] Remove extra comma in Package.swift that caused SPM resolution
   failures for some configurations.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 // The swift-tools-version declares the minimum version of Swift required to
 // build this package.
 


### PR DESCRIPTION
Updated `Package.swift` to require the Swift 6.1 version of the [`PackageDescription` library](https://developer.apple.com/documentation/packagedescription/package#:~:text=The%20Swift%20tools%20version%20declares%20the%20version%20of%20the%20PackageDescription%20library%2C%20the%20minimum%20version%20of%20the%20Swift%20tools%20and%20Swift%20language%20compatibility%20version%20to%20process%20the%20manifest%2C%20and%20the%20required%20minimum%20version%20of%20the%20Swift%20tools%20to%20use%20the%20Swift%20package.) (i.e., `swift-tools-version:6.1`) in preparation for the use of [Swift Package Traits](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/packagetraits/).

Note: This change will require Xcode 16.3+ to open the package, the first to include Swift 6.1, however the [minimum officially supported version](https://firebase.google.com/support/release-notes/ios#version_12120_-_april_6_2026) for Firebase is Xcode 26.2+.