### PR TITLE
[AI] Disable `FirebaseAppCheckTokenAutoRefreshEnabled` for tests

### DIFF
--- a/FirebaseAI/Tests/TestApp/FirebaseAITestApp.xcodeproj/project.pbxproj
+++ b/FirebaseAI/Tests/TestApp/FirebaseAITestApp.xcodeproj/project.pbxproj
@@ -29,6 +29,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		8606E6252FD0A4290088F6B3 /* Exceptions for "Resources" folder in "FirebaseAITestApp-SPM" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 866138572CC943DD00F4B78E /* FirebaseAITestApp-SPM */;
+		};
 		863E940D2EC69AF000BE4F4E /* Exceptions for "Resources" folder in "IntegrationTests-SPM" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -52,6 +59,7 @@
 		863E94072EC69AF000BE4F4E /* Resources */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
+				8606E6252FD0A4290088F6B3 /* Exceptions for "Resources" folder in "FirebaseAITestApp-SPM" target */,
 				863E940D2EC69AF000BE4F4E /* Exceptions for "Resources" folder in "IntegrationTests-SPM" target */,
 			);
 			path = Resources;
@@ -365,6 +373,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"Resources/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Resources/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -403,6 +412,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"Resources/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Resources/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/FirebaseAI/Tests/TestApp/Resources/Info.plist
+++ b/FirebaseAI/Tests/TestApp/Resources/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FirebaseAppCheckTokenAutoRefreshEnabled</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
Set `FirebaseAppCheckTokenAutoRefreshEnabled` to `false` in the Firebase AI Logic integration test app to see if this is the cause of many `[connection] nw_socket_set_connection_idle [C3.1.1.1:3] setsockopt SO_CONNECTION_IDLE failed [42: Protocol not available]` messages in logs.

#no-changelog