### PR TITLE
docs(appcheck): prefer 'AppCheckDebugToken' for debug env var injection

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -3,7 +3,7 @@
   generic `AppCheckDebugToken` environment variable instead of the legacy
   `FIRAAppCheckDebugToken`. Note that `FIRAAppCheckDebugToken` remains
   supported for backwards compatibility, with `AppCheckDebugToken` taking
-  priority if both are set.
+  priority if both are set. (#16230)
 - [changed] The default App Check provider when running on a simulator is now
   the debug provider; physical devices continue to default to DeviceCheck. (#16190)
 - [changed] Removed redundant debug token warning log. (#16197)

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Unreleased
+- [changed] Updated `AppCheckDebugProvider` documentation to recommend the
+  generic `AppCheckDebugToken` environment variable instead of the legacy
+  `FIRAAppCheckDebugToken`. Note that `FIRAAppCheckDebugToken` remains
+  supported for backwards compatibility, with `AppCheckDebugToken` taking
+  priority if both are set.
 - [changed] The default App Check provider when running on a simulator is now
   the debug provider; physical devices continue to default to DeviceCheck. (#16190)
 - [changed] Removed redundant debug token warning log. (#16197)

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckDebugProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRAppCheckDebugProvider.h
@@ -54,11 +54,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// etc.
 /// 3. Configure  `AppCheckDebugProviderFactory` before `FirebaseApp.configure()`
 /// `AppCheck.setAppCheckProviderFactory(AppCheckDebugProviderFactory())`
-/// 4. Add an environment variable to the scheme with a name `FIRAAppCheckDebugToken` and value like
-/// `$(MY_APP_CHECK_DEBUG_TOKEN)`.
+/// 4. Add an environment variable to the scheme with a name
+///    `AppCheckDebugToken` and value like `$(APP_CHECK_DEBUG_TOKEN)`.
 /// 5. Configure the build script to pass the debug token as the environment variable, e.g.:
 /// `xcodebuild test -scheme InstallationsExample -workspace InstallationsExample.xcworkspace \
-/// MY_APP_CHECK_DEBUG_TOKEN=$(MY_SECRET_ON_CI)`
+/// APP_CHECK_DEBUG_TOKEN=$(MY_SECRET_ON_CI)`
 ///
 NS_SWIFT_NAME(AppCheckDebugProvider)
 @interface FIRAppCheckDebugProvider : NSObject <FIRAppCheckProvider>
@@ -71,7 +71,8 @@ NS_SWIFT_NAME(AppCheckDebugProvider)
 - (NSString *)localDebugToken;
 
 /** Returns the currently used App Check debug token. The priority:
- *  - `FIRAAppCheckDebugToken` env variable value
+ *  - `AppCheckDebugToken` env variable value
+ *  - `FIRAAppCheckDebugToken` env variable value (deprecated)
  *  - A previously generated token, stored locally on the device
  *  - A newly generated random token. The generated token will be stored
  *    locally for future use


### PR DESCRIPTION
AppCheckDebugToken is already supported in app-check repo: https://github.com/google/app-check/blob/f50adb523de54441f6aee444f25c12735d110e66/AppCheckCore/Sources/DebugProvider/GACAppCheckDebugProvider.m#L147-L169

Docs: [cl/926711307](http://cl/926711307)

The name is shorter, easier to remember, and drops the `FIRA` prefix of `FIRAAppCheckDebugToken`