### PR TITLE
build: error on C++20 language extension usage

### DIFF
--- a/cmake/compiler_setup.cmake
+++ b/cmake/compiler_setup.cmake
@@ -63,7 +63,7 @@ if(CXX_CLANG OR CXX_GNU)
     list(
       APPEND common_flags
      -Wconditional-uninitialized -Werror=return-type -Winfinite-recursion -Wmove
-     -Wrange-loop-analysis -Wunreachable-code
+     -Wrange-loop-analysis -Wunreachable-code -Werror=c++20-extensions
 
      # Options added to match apple recommended project settings
      # TODO(wilhuff): re-enable -Wcomma once Abseil fixes the definition of


### PR DESCRIPTION
Adds `-Werror=c++20-extensions` so that usage of C++ 20 language extension features will cause errors.

Compiling code that uses C++ 20 features can succeed because Clang will use language extensions by default. That same code may not compile on other targets (e.g. Windows) that don't have the same language extensions. This is what caused #16229. Adding this flag will prevent similar issues in the future.