### PR TITLE
feat(appcheck): add helpful log for registering debug tokens

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [changed] The default App Check provider when running on a simulator is now
   the debug provider; physical devices continue to default to DeviceCheck. (#16190)
 - [changed] Removed redundant debug token warning log. (#16197)
+- [changed] Log an actionable warning when debug token exchange fails. (#16232)
 
 # 12.14.0
 - [added] Added `AppAttestProviderFactory` to simplify App Check setup when

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.h
@@ -28,6 +28,7 @@ FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeProviderIsMissing
 
 // FIRAppCheckDebugProvider.m
 FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageDebugProviderIncompleteFIROptions;
+FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeDebugTokenExchangeFailed;
 
 // FIRAppCheckDebugProviderFactory.m
 FOUNDATION_EXPORT NSString *const kFIRLoggerAppCheckMessageCodeDebugToken;

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheckLogger.m
@@ -28,6 +28,7 @@ NSString *const kFIRLoggerAppCheckMessageCodeProviderIsMissing = @"I-FAA002002";
 
 // FIRAppCheckDebugProvider.m
 NSString *const kFIRLoggerAppCheckMessageDebugProviderIncompleteFIROptions = @"I-FAA004001";
+NSString *const kFIRLoggerAppCheckMessageCodeDebugTokenExchangeFailed = @"I-FAA004002";
 
 // FIRAppCheckDebugProviderFactory.m
 NSString *const kFIRLoggerAppCheckMessageCodeDebugToken = @"I-FAA005001";

--- a/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProvider.m
+++ b/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProvider.m
@@ -88,7 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
     FIRLogWarning(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeDebugTokenExchangeFailed,
                   @"Failed to exchange debug token. If you haven't registered it, "
                    "you can do so in the Firebase Console: "
-                   "https://firebase.google.com/project/%@/appcheck/apps?selectedAppId=%@",
+                   "https://console.firebase.google.com/project/%@/appcheck/apps?selectedAppId=%@",
                   self.projectID, self.googleAppID);
   }
 }

--- a/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProvider.m
+++ b/FirebaseAppCheck/Sources/DebugProvider/FIRAppCheckDebugProvider.m
@@ -31,15 +31,21 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FIRAppCheckDebugProvider ()
 
 @property(nonatomic, readonly) GACAppCheckDebugProvider *debugProvider;
+@property(nonatomic, readonly, copy, nullable) NSString *projectID;
+@property(nonatomic, readonly, copy) NSString *googleAppID;
 
 @end
 
 @implementation FIRAppCheckDebugProvider
 
-- (instancetype)initWithDebugProvider:(GACAppCheckDebugProvider *)debugProvider {
+- (instancetype)initWithDebugProvider:(GACAppCheckDebugProvider *)debugProvider
+                            projectID:(nullable NSString *)projectID
+                          googleAppID:(NSString *)googleAppID {
   self = [super init];
   if (self) {
     _debugProvider = debugProvider;
+    _projectID = [projectID copy];
+    _googleAppID = [googleAppID copy];
   }
   return self;
 }
@@ -62,7 +68,9 @@ NS_ASSUME_NONNULL_BEGIN
                                                      APIKey:app.options.APIKey
                                                requestHooks:@[ [app.heartbeatLogger requestHook] ]];
 
-  return [self initWithDebugProvider:debugProvider];
+  return [self initWithDebugProvider:debugProvider
+                           projectID:app.options.projectID
+                         googleAppID:app.options.googleAppID];
 }
 
 - (NSString *)currentDebugToken {
@@ -73,6 +81,18 @@ NS_ASSUME_NONNULL_BEGIN
   return [self.debugProvider localDebugToken];
 }
 
+#pragma mark - Private Helpers
+
+- (void)logDebugTokenExchangeError {
+  if (self.projectID.length > 0 && self.googleAppID.length > 0) {
+    FIRLogWarning(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageCodeDebugTokenExchangeFailed,
+                  @"Failed to exchange debug token. If you haven't registered it, "
+                   "you can do so in the Firebase Console: "
+                   "https://firebase.google.com/project/%@/appcheck/apps?selectedAppId=%@",
+                  self.projectID, self.googleAppID);
+  }
+}
+
 #pragma mark - FIRAppCheckProvider
 
 - (void)getTokenWithCompletion:(void (^)(FIRAppCheckToken *_Nullable token,
@@ -80,6 +100,7 @@ NS_ASSUME_NONNULL_BEGIN
   [self.debugProvider getTokenWithCompletion:^(GACAppCheckToken *_Nullable internalToken,
                                                NSError *_Nullable error) {
     if (error) {
+      [self logDebugTokenExchangeError];
       handler(nil, error);
       return;
     }
@@ -93,6 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
   [self.debugProvider getLimitedUseTokenWithCompletion:^(GACAppCheckToken *_Nullable internalToken,
                                                          NSError *_Nullable error) {
     if (error) {
+      [self logDebugTokenExchangeError];
       handler(nil, error);
       return;
     }

--- a/FirebaseAppCheck/Tests/Unit/DebugProvider/FIRAppCheckDebugProviderTests.m
+++ b/FirebaseAppCheck/Tests/Unit/DebugProvider/FIRAppCheckDebugProviderTests.m
@@ -33,7 +33,11 @@ static NSString *const kProjectNumber = @"123456789";
 
 @interface FIRAppCheckDebugProvider (Tests)
 
-- (instancetype)initWithDebugProvider:(GACAppCheckDebugProvider *)debugProvider;
+- (instancetype)initWithDebugProvider:(GACAppCheckDebugProvider *)debugProvider
+                            projectID:(nullable NSString *)projectID
+                          googleAppID:(NSString *)googleAppID;
+@property(nonatomic, readonly, copy, nullable) NSString *projectID;
+@property(nonatomic, readonly, copy) NSString *googleAppID;
 
 @end
 
@@ -50,7 +54,9 @@ static NSString *const kProjectNumber = @"123456789";
 - (void)setUp {
   self.resourceName = [NSString stringWithFormat:@"projects/%@/apps/%@", kProjectID, kAppID];
   self.debugProviderMock = OCMStrictClassMock([GACAppCheckDebugProvider class]);
-  self.provider = [[FIRAppCheckDebugProvider alloc] initWithDebugProvider:self.debugProviderMock];
+  self.provider = [[FIRAppCheckDebugProvider alloc] initWithDebugProvider:self.debugProviderMock
+                                                                projectID:nil
+                                                              googleAppID:kAppID];
 }
 
 - (void)tearDown {
@@ -69,7 +75,15 @@ static NSString *const kProjectNumber = @"123456789";
   // The following disables automatic token refresh, which could interfere with tests.
   app.dataCollectionDefaultEnabled = NO;
 
-  XCTAssertNotNil([[FIRAppCheckDebugProvider alloc] initWithApp:app]);
+  FIRAppCheckDebugProvider *provider = [[FIRAppCheckDebugProvider alloc] initWithApp:app];
+  XCTAssertNotNil(provider);
+  XCTAssertEqualObjects(provider.projectID, kProjectID);
+  XCTAssertEqualObjects(provider.googleAppID, kAppID);
+}
+
+- (void)testInitWithDebugProvider {
+  XCTAssertNil(self.provider.projectID);
+  XCTAssertEqualObjects(self.provider.googleAppID, kAppID);
 }
 
 - (void)testInitWithIncompleteApp {


### PR DESCRIPTION
If the debug provider fails to return a valid FAC token, assume the token is unregistered. To assist developers, log a direct link to the Firebase console where they can register the debug token printed at app startup.


As currently implemented, the project ID and app ID will be printed to the console (interpolated into the URL).

<details>
  <summary>Precedent on logging these fields</summary>

  * Firebase Database: Logs the projectID when falling back to the default RTDB host URL:
    * Note: FFLog is a macro that redirects to FIRLogDebug.
    * https://github.com/firebase/firebase-ios-sdk/blob/ed8932ba4820ded0385326a706d9f74b7d9206c1/FirebaseDatabase/Sources/Api/FIRDatabase.m#L74-L75
  * Firebase Remote Config: Logs the full URL request (which contains the projectID in the path) when making a fetch call:
  * https://github.com/firebase/firebase-ios-sdk/blob/ed8932ba4820ded0385326a706d9f74b7d9206c1/FirebaseRemoteConfig/Sources/RCNConfigFetch.m#L668-L669
  * Firebase Messaging: Logs the old and new App IDs when invalidating a cached token because the App ID changed:
  * https://github.com/firebase/firebase-ios-sdk/blob/ed8932ba4820ded0385326a706d9f74b7d9206c1/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m#L100-L103

</details>

Example (on attesting with unregistered debug token):
```console
<Debug> [AppCheckCore][I-GAC004004] Failed to exchange debug token to app check token: Error Domain=com.google.app_check_core Code=0 "The server responded with an error: 
 - URL: https://firebaseappcheck.googleapis.com/v1/projects/appcheck-testing/apps/<redacted>:exchangeDebugToken 
 - HTTP status code: 403 
 - Response body: {
  "error": {
    "code": 403,
    "message": "App attestation failed.",
    "status": "PERMISSION_DENIED"
  }
}
" UserInfo={NSLocalizedFailureReason=The server responded with an error: 
 - URL: https://firebaseappcheck.googleapis.com/v1/projects/appcheck-testing/apps//<redacted>:exchangeDebugToken 
 - HTTP status code: 403 
 - Response body: {
  "error": {
    "code": 403,
    "message": "App attestation failed.",
    "status": "PERMISSION_DENIED"
  }
}
}
12.15.0 - [FirebaseAppCheck][I-FAA004002] Failed to exchange debug token. If you haven't registered it, you can do so in the Firebase Console: https://firebase.google.com/project/appcheck-testing/appcheck/apps?selectedAppId=<redacted>
```

The last line from above is from the new log:

```console
12.15.0 - [FirebaseAppCheck][I-FAA004002] Failed to exchange debug token.
If you haven't registered it, you can do so in the Firebase Console:
https://firebase.google.com/project/appcheck-testing/appcheck/apps?selectedAppId=<redacted>
```

Verified it takes you to the debug token manager for the given app ID.

Tangential docs: [cl/923512169](http://cl/923512169)

cc: @weixifan @andrewheard @rlazo 