### PR TITLE
reject out-of-range integers in JsonReader::ParseInt

### DIFF
--- a/Firestore/core/src/util/json_reader.h
+++ b/Firestore/core/src/util/json_reader.h
@@ -104,30 +104,35 @@ class JsonReader : public util::ReadContext {
       // silently wraps a value that does not fit `IntType`. Reject it instead,
       // matching the range checking the string branch below gets from
       // `absl::SimpleAtoi`.
+      bool out_of_range = false;
       if (value.is_number_unsigned()) {
-        if (value.get<uint64_t>() >
-            static_cast<uint64_t>(std::numeric_limits<IntType>::max())) {
-          reader.Fail("Integer value out of range: " + value.dump());
-          return 0;
-        }
+        out_of_range =
+            value.get<uint64_t>() >
+            static_cast<uint64_t>(std::numeric_limits<IntType>::max());
       } else {
         // A non-negative value may still be stored as a signed `int64_t`, so
         // accept it when it fits an unsigned `IntType` rather than rejecting
-        // every signed representation outright.
+        // every signed representation outright. Compute the bounds as
+        // `int64_t`/`uint64_t` so the comparisons never narrow `IntType::max()`
+        // into a signed type, which would warn for unsigned instantiations.
         const int64_t val = value.get<int64_t>();
+        const int64_t min_limit =
+            std::numeric_limits<IntType>::is_signed
+                ? static_cast<int64_t>(std::numeric_limits<IntType>::min())
+                : 0;
+        const uint64_t max_limit =
+            static_cast<uint64_t>(std::numeric_limits<IntType>::max());
         if (std::numeric_limits<IntType>::is_signed) {
-          if (val < static_cast<int64_t>(std::numeric_limits<IntType>::min()) ||
-              val > static_cast<int64_t>(std::numeric_limits<IntType>::max())) {
-            reader.Fail("Integer value out of range: " + value.dump());
-            return 0;
-          }
-        } else if (val < 0 ||
-                   static_cast<uint64_t>(val) >
-                       static_cast<uint64_t>(
-                           std::numeric_limits<IntType>::max())) {
-          reader.Fail("Integer value out of range: " + value.dump());
-          return 0;
+          out_of_range = val < min_limit ||
+                         (val > 0 && static_cast<uint64_t>(val) > max_limit);
+        } else {
+          out_of_range = val < 0 || static_cast<uint64_t>(val) > max_limit;
         }
+      }
+
+      if (out_of_range) {
+        reader.Fail("Integer value out of range: " + value.dump());
+        return 0;
       }
       return value.get<IntType>();
     }

--- a/Firestore/core/src/util/json_reader.h
+++ b/Firestore/core/src/util/json_reader.h
@@ -17,6 +17,7 @@
 #ifndef FIRESTORE_CORE_SRC_UTIL_JSON_READER_H_
 #define FIRESTORE_CORE_SRC_UTIL_JSON_READER_H_
 
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -99,6 +100,28 @@ class JsonReader : public util::ReadContext {
   template <typename IntType>
   IntType ParseInt(const nlohmann::json& value, JsonReader& reader) {
     if (value.is_number_integer()) {
+      // nlohmann stores integers as int64_t or uint64_t, so `get<IntType>()`
+      // silently wraps a value that does not fit `IntType`. Reject it instead,
+      // matching the range checking the string branch below gets from
+      // `absl::SimpleAtoi`.
+      if (value.is_number_unsigned()) {
+        if (value.get<uint64_t>() >
+            static_cast<uint64_t>(std::numeric_limits<IntType>::max())) {
+          reader.Fail("Integer value out of range: " + value.dump());
+          return 0;
+        }
+      } else if (!std::numeric_limits<IntType>::is_signed) {
+        reader.Fail("Integer value out of range: " + value.dump());
+        return 0;
+      } else if (value.get<int64_t>() <
+                     static_cast<int64_t>(
+                         std::numeric_limits<IntType>::min()) ||
+                 value.get<int64_t>() >
+                     static_cast<int64_t>(
+                         std::numeric_limits<IntType>::max())) {
+        reader.Fail("Integer value out of range: " + value.dump());
+        return 0;
+      }
       return value.get<IntType>();
     }
 

--- a/Firestore/core/src/util/json_reader.h
+++ b/Firestore/core/src/util/json_reader.h
@@ -110,17 +110,24 @@ class JsonReader : public util::ReadContext {
           reader.Fail("Integer value out of range: " + value.dump());
           return 0;
         }
-      } else if (!std::numeric_limits<IntType>::is_signed) {
-        reader.Fail("Integer value out of range: " + value.dump());
-        return 0;
-      } else if (value.get<int64_t>() <
-                     static_cast<int64_t>(
-                         std::numeric_limits<IntType>::min()) ||
-                 value.get<int64_t>() >
-                     static_cast<int64_t>(
-                         std::numeric_limits<IntType>::max())) {
-        reader.Fail("Integer value out of range: " + value.dump());
-        return 0;
+      } else {
+        // A non-negative value may still be stored as a signed `int64_t`, so
+        // accept it when it fits an unsigned `IntType` rather than rejecting
+        // every signed representation outright.
+        const int64_t val = value.get<int64_t>();
+        if (std::numeric_limits<IntType>::is_signed) {
+          if (val < static_cast<int64_t>(std::numeric_limits<IntType>::min()) ||
+              val > static_cast<int64_t>(std::numeric_limits<IntType>::max())) {
+            reader.Fail("Integer value out of range: " + value.dump());
+            return 0;
+          }
+        } else if (val < 0 ||
+                   static_cast<uint64_t>(val) >
+                       static_cast<uint64_t>(
+                           std::numeric_limits<IntType>::max())) {
+          reader.Fail("Integer value out of range: " + value.dump());
+          return 0;
+        }
       }
       return value.get<IntType>();
     }

--- a/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
+++ b/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
@@ -413,6 +413,21 @@ TEST_F(BundleSerializerTest, DecodesInvalidIntegerValueFails) {
   VerifyJsonStringDecodeFails(json_copy);
 }
 
+TEST_F(BundleSerializerTest, DecodesOutOfRangeIntegerValueFails) {
+  ProtoValue value;
+  value.set_integer_value(22222);
+  ProtoDocument document = TestDocument(value);
+
+  std::string json_string;
+  MessageToJsonString(document, &json_string);
+
+  // A raw (unquoted) JSON number that does not fit int64 must be rejected
+  // rather than silently wrapped, the same way the string-encoded form is.
+  auto json_copy =
+      ReplacedCopy(json_string, "\"22222\"", "18446744073709551615");
+  VerifyJsonStringDecodeFails(json_copy);
+}
+
 TEST_F(BundleSerializerTest, DecodesDoubleValues) {
   for (double_t v :
        {-std::numeric_limits<double>::infinity(),


### PR DESCRIPTION
Repro: load a bundle whose `integerValue` or timestamp `nanos` is a raw (unquoted) JSON number outside the target type's range, e.g. a `nanos` of `5294967295`.
Cause: `JsonReader::ParseInt` returns `value.get<IntType>()` on the `is_number_integer()` path with no bounds check, so `5294967295` wraps to `999999999` and slips past the downstream `nanos < 1e9` validation; the string branch already rejects the same input via `absl::SimpleAtoi`, so the two encodings disagree.
Fix: bounds-check the numeric branch against `IntType` before the cast so out-of-range numbers fail to decode, matching the string branch.