### PR TITLE
Fix grep command in notices_generation script to avoid matching deprecation warnings

### DIFF
--- a/.github/actions/notices_generation/app.rb
+++ b/.github/actions/notices_generation/app.rb
@@ -78,10 +78,10 @@ def create_podfile(path: , sources: , target: , pods: [], min_ios_version: , sea
     if search_local_pod_version
       # `pod search` will search a pod locally and generate a corresonding pod
       # config in a Podfile with `grep`, e.g.
-      # pod search Firebase | grep "pod.*" -m 1
+      # pod search Firebase | grep "pod '.*" -m 1
       # will generate
       # pod 'Firebase', '~> 9.0.0'
-      output += `pod search "#{pod}" | grep "pod.*" -m 1`
+      output += `pod search "#{pod}" | grep "pod '.*" -m 1`
     else
       output += "pod \'#{pod}\'\n"
     end


### PR DESCRIPTION
This commit updates `.github/actions/notices_generation/app.rb` to change the `grep` command used for parsing `pod search` output. Previously, `grep "pod.*"` was inadvertently capturing the string "pod" inside deprecation warnings (e.g., `cocoapods-deprecation`). By changing the regex to `grep "pod '.*"`, the script strictly extracts the intended pod dependency declaration line, thus preventing malformed `Podfile` errors during the notice generation workflow.

---
*PR created automatically by Jules for task [14548785996103497267](https://jules.google.com/task/14548785996103497267) started by @ncooke3*

Fix #16204