### PR TITLE
bound array access in StoragePath url parsers

### DIFF
--- a/FirebaseStorage/Sources/Internal/StoragePath.swift
+++ b/FirebaseStorage/Sources/Internal/StoragePath.swift
@@ -59,7 +59,7 @@ class StoragePath: NSCopying, Equatable {
       if bucketObject.contains("/") {
         let splitStringArray = bucketObject.split(separator: "/", maxSplits: 1).map(String.init)
         if let bucketName = splitStringArray.first {
-          let object = splitStringArray.count == 2 ? splitStringArray[1] : nil
+          let object = splitStringArray.dropFirst().first
           return StoragePath(with: bucketName, object: object)
         }
       } else if bucketObject.count > 0 {
@@ -92,6 +92,10 @@ class StoragePath: NSCopying, Equatable {
 
     guard pathComponents.count > 5 else {
       return StoragePath(with: bucketName)
+    }
+    guard pathComponents[4] == "o" else {
+      throw StoragePathError.storagePathError("Internal error: URL must be in the form of " +
+        "http[s]://<host>/v0/b/<bucket>/o/<path/to/object>[?token=signed_url_params]")
     }
     // Construct object name
     var objectName = pathComponents[5]

--- a/FirebaseStorage/Sources/Internal/StoragePath.swift
+++ b/FirebaseStorage/Sources/Internal/StoragePath.swift
@@ -58,8 +58,10 @@ class StoragePath: NSCopying, Equatable {
       let bucketObject = aURIString.dropFirst("gs://".count)
       if bucketObject.contains("/") {
         let splitStringArray = bucketObject.split(separator: "/", maxSplits: 1).map(String.init)
-        let object = splitStringArray.count == 2 ? splitStringArray[1] : nil
-        return StoragePath(with: splitStringArray[0], object: object)
+        if let bucketName = splitStringArray.first {
+          let object = splitStringArray.count == 2 ? splitStringArray[1] : nil
+          return StoragePath(with: bucketName, object: object)
+        }
       } else if bucketObject.count > 0 {
         return StoragePath(with: String(bucketObject))
       }
@@ -88,7 +90,7 @@ class StoragePath: NSCopying, Equatable {
     }
     let bucketName = pathComponents[3]
 
-    guard pathComponents.count > 4 else {
+    guard pathComponents.count > 5 else {
       return StoragePath(with: bucketName)
     }
     // Construct object name

--- a/FirebaseStorage/Sources/Internal/StoragePath.swift
+++ b/FirebaseStorage/Sources/Internal/StoragePath.swift
@@ -90,12 +90,15 @@ class StoragePath: NSCopying, Equatable {
     }
     let bucketName = pathComponents[3]
 
-    guard pathComponents.count > 5 else {
+    guard pathComponents.count > 4 else {
       return StoragePath(with: bucketName)
     }
     guard pathComponents[4] == "o" else {
       throw StoragePathError.storagePathError("Internal error: URL must be in the form of " +
         "http[s]://<host>/v0/b/<bucket>/o/<path/to/object>[?token=signed_url_params]")
+    }
+    guard pathComponents.count > 5 else {
+      return StoragePath(with: bucketName)
     }
     // Construct object name
     var objectName = pathComponents[5]

--- a/FirebaseStorage/Tests/Unit/StoragePathTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePathTests.swift
@@ -105,6 +105,13 @@ class StoragePathTests: XCTestCase {
     XCTAssertThrowsError(try StoragePath.path(string: "http://firebasestorage.googleapis.com/"))
   }
 
+  func testHTTPURLThrowsOnMissingObjectMarker() {
+    // A path segment in the "/o" marker position that isn't "o" is not a valid
+    // Storage URL and must throw rather than be parsed as an object.
+    let httpURL = "http://firebasestorage.googleapis.com/v0/b/bucket/x/path/to/object"
+    XCTAssertThrowsError(try StoragePath.path(string: httpURL))
+  }
+
   func testThrowsOnInvalidScheme() {
     let ftpURL = "ftp://firebasestorage.googleapis.com/v0/b/bucket/o/path/to/object"
     XCTAssertThrowsError(try StoragePath.path(string: ftpURL))

--- a/FirebaseStorage/Tests/Unit/StoragePathTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePathTests.swift
@@ -84,8 +84,21 @@ class StoragePathTests: XCTestCase {
     XCTAssertEqual(path.object, "#hashtag/no/token")
   }
 
+  func testHTTPURLObjectMarkerWithoutObject() throws {
+    // "/o" object marker present but no object path; must not index past the
+    // path components.
+    let httpURL = "http://firebasestorage.googleapis.com/v0/b/bucket/o"
+    let path = try StoragePath.path(string: httpURL)
+    XCTAssertEqual(path.bucket, "bucket")
+    XCTAssertNil(path.object)
+  }
+
   func testGSURIThrowsOnNoBucket() {
     XCTAssertThrowsError(try StoragePath.path(string: "gs://"))
+  }
+
+  func testGSURIThrowsOnOnlySlashes() {
+    XCTAssertThrowsError(try StoragePath.path(string: "gs:///"))
   }
 
   func testHTTPURLThrowsOnNoBucket() {

--- a/FirebaseStorage/Tests/Unit/StoragePathTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePathTests.swift
@@ -110,6 +110,11 @@ class StoragePathTests: XCTestCase {
     // Storage URL and must throw rather than be parsed as an object.
     let httpURL = "http://firebasestorage.googleapis.com/v0/b/bucket/x/path/to/object"
     XCTAssertThrowsError(try StoragePath.path(string: httpURL))
+
+    // Same invalid marker but with no object path (exactly five components) must
+    // also throw rather than be parsed as a bucket-only path.
+    let shortHTTPURL = "http://firebasestorage.googleapis.com/v0/b/bucket/x"
+    XCTAssertThrowsError(try StoragePath.path(string: shortHTTPURL))
   }
 
   func testThrowsOnInvalidScheme() {


### PR DESCRIPTION
`StoragePath` parses `gs://` and `http[s]://` Storage URLs reached via `Storage.reference(forURL:)`. Those strings frequently come from another user (download URLs persisted in a database, deep links, share flows), so a crafted value crashes the consuming app.

Repro: `try StoragePath.path(string: "http://firebasestorage.googleapis.com/v0/b/bucket/o")` (the `/o` object marker with no object path), or `try StoragePath.path(string: "gs:///")`.
Expected: a bucket-only path, or a thrown invalid-URI error.
Actual: `Fatal error: Index out of range`.
Cause: `path(HTTPURL:)` reads `pathComponents[5]` after guarding only `count > 4`, so the bare `/o` form (5 components) indexes past the end; `path(GSURI:)` reads `splitStringArray[0]`, but `split(separator: "/", maxSplits: 1)` returns an empty array when the remainder is only slashes.
Fix: require `count > 5` before reading the object component, and read the bucket via `splitStringArray.first`. Existing parses are unchanged; the bare `/o` form now resolves to the bucket root and an all-slash `gs://` input throws the existing error.
