### PR TITLE
docs(analytics): explain the three SPM products

### DIFF
--- a/FirebaseAnalytics/README.md
+++ b/FirebaseAnalytics/README.md
@@ -6,9 +6,9 @@ The Firebase iOS SDK ships **three** Swift Package products for Analytics. Pick 
 
 | Package product | Underlying measurement library | IDFA / advertising | When to use |
 |-----------------|--------------------------------|--------------------|-------------|
-| **`FirebaseAnalytics`** | `GoogleAppMeasurement` | Yes — collects IDFA when ATT-authorized; includes Google Signals + advertising features | Default for consumer apps that want full Analytics, audience targeting, and ad-network attribution |
+| **`FirebaseAnalytics`** | `GoogleAppMeasurement` | Yes — collects IDFA when ATT-authorized; includes on-device conversion measurement | Default for consumer apps that want full Analytics, audience targeting, and ad-network attribution |
 | **`FirebaseAnalyticsCore`** | `GoogleAppMeasurementCore` | No | Apps that must avoid IDFA collection entirely (e.g., kids apps, restricted enterprise distributions, or apps whose privacy posture rules out any advertising-related data) |
-| **`FirebaseAnalyticsIdentitySupport`** | `GoogleAppMeasurementCore` + `GoogleAppMeasurementIdentitySupport` | No IDFA, but enables privacy-respecting identity features (e.g., requestTrackingAuthorization integration without ad-targeting) | Apps that need user-deletion / identity-management integrations on top of Core but still don't want advertising-tier data collection |
+| **`FirebaseAnalyticsIdentitySupport`** | `GoogleAppMeasurementCore` + `GoogleAppMeasurementIdentitySupport` | Yes - collects IDFA when ATT-authorized; excludes on-device conversion measurement | Apps that collect IDFA, but don't run any Google Ad campaigns |
 
 **Rule of thumb:** start with `FirebaseAnalytics` unless your app's privacy or store policy specifically requires you to avoid advertising features. Add `FirebaseAnalyticsCore` or `FirebaseAnalyticsIdentitySupport` instead — not in addition.
 

--- a/FirebaseAnalytics/README.md
+++ b/FirebaseAnalytics/README.md
@@ -1,5 +1,25 @@
 # Firebase Analytics SDK
 
+## Choosing the Right Analytics Product
+
+The Firebase iOS SDK ships **three** Swift Package products for Analytics. Pick the one whose ad-identifier and data-collection posture matches what your app is allowed to do — adding more than one is unnecessary and surface area you don't need.
+
+| Package product | Underlying measurement library | IDFA / advertising | When to use |
+|-----------------|--------------------------------|--------------------|-------------|
+| **`FirebaseAnalytics`** | `GoogleAppMeasurement` | Yes — collects IDFA when ATT-authorized; includes Google Signals + advertising features | Default for consumer apps that want full Analytics, audience targeting, and ad-network attribution |
+| **`FirebaseAnalyticsCore`** | `GoogleAppMeasurementCore` | No | Apps that must avoid IDFA collection entirely (e.g., kids apps, restricted enterprise distributions, or apps whose privacy posture rules out any advertising-related data) |
+| **`FirebaseAnalyticsIdentitySupport`** | `GoogleAppMeasurementCore` + `GoogleAppMeasurementIdentitySupport` | No IDFA, but enables privacy-respecting identity features (e.g., requestTrackingAuthorization integration without ad-targeting) | Apps that need user-deletion / identity-management integrations on top of Core but still don't want advertising-tier data collection |
+
+**Rule of thumb:** start with `FirebaseAnalytics` unless your app's privacy or store policy specifically requires you to avoid advertising features. Add `FirebaseAnalyticsCore` or `FirebaseAnalyticsIdentitySupport` instead — not in addition.
+
+All three depend on `FirebaseCore` and `FirebaseInstallations` transitively, so you don't need to add those manually.
+
+For the full setup steps (registering an app, adding the `GoogleService-Info.plist`, calling `FirebaseApp.configure()`), see the [Get started with Google Analytics](https://firebase.google.com/docs/analytics/get-started?platform=ios) guide.
+
+---
+
+## Manual Screen View Logging API
+
 Introduce a manual screen view event logging API that enable developers to log individual views in SwiftUI lifecycle.
 
 ## Code Samples


### PR DESCRIPTION
## Why

Closes #15807.

The Firebase iOS SDK ships three Swift Package products under the Analytics umbrella — \`FirebaseAnalytics\`, \`FirebaseAnalyticsCore\`, and \`FirebaseAnalyticsIdentitySupport\` — and the difference between them is only discoverable by reading \`Package.swift\` and tracing each \`Wrapper\` target back to the underlying \`GoogleAppMeasurement\` product it pulls in. The issue reporter and the integration docs at firebase.google.com/docs/analytics/get-started both say \"choose the analytics library\" without explaining how to choose.

## What

Adds a \"Choosing the Right Analytics Product\" section to \`FirebaseAnalytics/README.md\` with a table mapping each product to:

- the underlying \`GoogleAppMeasurement*\` library it depends on
- its IDFA / advertising-data posture
- the app profile it's intended for

Plus a rule-of-thumb (\"start with \`FirebaseAnalytics\` unless your privacy posture rules out advertising features\") so a developer doesn't need to read \`Package.swift\` to make the call.

The pre-existing \"manual screen view logging API\" content is preserved unchanged below the new section.

## Scope

Docs only. No code, no API surface changes.