### PR TITLE
validate structuredQuery shape before json access in bundle decoder

### DIFF
--- a/Firestore/core/src/bundle/bundle_serializer.cc
+++ b/Firestore/core/src/bundle/bundle_serializer.cc
@@ -278,9 +278,11 @@ int32_t DecodeLimit(JsonReader& reader, const json& query) {
     // "limit" can be encoded as integer or "{"value": integer}".
     if (limit_object.is_number_integer()) {
       return limit_object.get<int32_t>();
-    } else if (limit_object.is_object() && limit_object.contains("value") &&
-               limit_object.at("value").is_number_integer()) {
-      return limit_object.at("value").get<int32_t>();
+    } else if (limit_object.is_object()) {
+      auto value = limit_object.find("value");
+      if (value != limit_object.end() && value->is_number_integer()) {
+        return value->get<int32_t>();
+      }
     }
     reader.Fail("'limit' is not encoded as a valid integer");
     return limit;

--- a/Firestore/core/src/bundle/bundle_serializer.cc
+++ b/Firestore/core/src/bundle/bundle_serializer.cc
@@ -145,6 +145,10 @@ void DecodeCollectionSource(JsonReader& reader,
                             const json& from_json,
                             ResourcePath& parent,
                             std::string& group) {
+  if (!from_json.is_array()) {
+    reader.Fail("'from' clause is not an array as expected.");
+    return;
+  }
   const auto& from = from_json.get_ref<const std::vector<json>&>();
   if (from.size() != 1) {
     reader.Fail(
@@ -274,10 +278,9 @@ int32_t DecodeLimit(JsonReader& reader, const json& query) {
     // "limit" can be encoded as integer or "{"value": integer}".
     if (limit_object.is_number_integer()) {
       return limit_object.get<int32_t>();
-    } else if (limit_object.is_object()) {
-      if (limit_object.at("value").is_number_integer()) {
-        return limit_object.at("value").get<int32_t>();
-      }
+    } else if (limit_object.is_object() && limit_object.contains("value") &&
+               limit_object.at("value").is_number_integer()) {
+      return limit_object.at("value").get<int32_t>();
     }
     reader.Fail("'limit' is not encoded as a valid integer");
     return limit;

--- a/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
+++ b/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
@@ -698,6 +698,24 @@ TEST_F(BundleSerializerTest, DecodeQueriesFromOtherProjectsFails) {
   }
 }
 
+TEST_F(BundleSerializerTest, DecodeFromClauseWithWrongTypeFails) {
+  std::string json_string = NamedQueryJsonString(testutil::Query("colls"));
+  json parsed = Parse(json_string);
+  parsed["bundledQuery"]["structuredQuery"]["from"] = "colls";
+  JsonReader reader;
+  bundle_serializer.DecodeNamedQuery(reader, parsed);
+  EXPECT_NOT_OK(reader.status());
+}
+
+TEST_F(BundleSerializerTest, DecodeLimitObjectWithoutValueFails) {
+  std::string json_string = NamedQueryJsonString(testutil::Query("colls"));
+  json parsed = Parse(json_string);
+  parsed["bundledQuery"]["structuredQuery"]["limit"] = json::object();
+  JsonReader reader;
+  bundle_serializer.DecodeNamedQuery(reader, parsed);
+  EXPECT_NOT_OK(reader.status());
+}
+
 TEST_F(BundleSerializerTest, DecodesCollectionGroupQuery) {
   core::Query original = testutil::CollectionGroupQuery("bundles/docs/colls");
   VerifyNamedQueryRoundtrip(original);


### PR DESCRIPTION
`Firestore` bundle query decoding (reached via `loadBundle`, where the bundle is commonly fetched from a CDN) reads parsed JSON without checking its shape, so a malformed bundle throws an uncaught `nlohmann` exception instead of failing the reader.

Repro: load a named query whose `structuredQuery.from` is a non-array, e.g. `"from":"colls"`, or whose `limit` is an object with no `value`, e.g. `"limit":{}`.
Expected: the reader reports a decode failure.
Actual: `DecodeCollectionSource` calls `get_ref<const std::vector<json>&>()` with no `is_array()` guard and throws `type_error.303`; `DecodeLimit` calls `limit_object.at("value")` with no presence guard and throws `out_of_range.403`. Neither is caught on the decode path, so the process terminates.
Fix: guard both reads the way every sibling accessor in this file and in `json_reader.cc` already does, so malformed input fails the reader instead of throwing.

Added two regressions in `bundle_serializer_test.cc`.
