### PR TITLE
fix(ai): Handle Xcode 27 `LanguageModelSession.Error` collision

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 12.15.0
+- [fixed] Fixed a namespace collision with the new
+  `FoundationModels.LanguageModelSession.Error` type introduced in Xcode 27 Beta. (#16252)
+
 # 12.14.0
 - [fixed] Fixed an issue in `GenerativeModelSession` where `String` generation
   used the wrong overload for `respond(to:)` and `streamResponse(to:)`,

--- a/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
@@ -92,7 +92,7 @@
     public func _streamResponse(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
                                 includeSchemaInPrompt: Bool,
                                 options: any GenerationOptionsRepresentable)
-      -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
+      -> sending AsyncThrowingStream<_ModelSessionResponse, any Swift.Error> {
       return AsyncThrowingStream { continuation in
         let foundationModelsPrompt: Prompt
         do {


### PR DESCRIPTION
Explicitly qualified the `any Error` as `any Swift.Error` in the `FoundationModels.LanguageModelSession` extension for `_ModelSession` conformance to fix the namespace collision with the built-in Swift `Error` protocol and the `FoundationModels.LanguageModelSession.Error` type introduced in Xcode 27. This resolves #16252.

<details>
<summary>Error Details</summary>

```
This is due to an ambiguity between `Error` and and [`FoundationModels.LanguageModelSession.Error`](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/error) since the extension is declared on `FoundationModels.LanguageModelSession`.

FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift:95:61: error: 'any' has no effect on concrete type 'LanguageModelSession.Error'
 93 |                                 includeSchemaInPrompt: Bool,
 94 |                                 options: any GenerationOptionsRepresentable)
 95 |       -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
    |                                                             `- error: 'any' has no effect on concrete type 'LanguageModelSession.Error'
 96 |       return AsyncThrowingStream { continuation in
 97 |         let foundationModelsPrompt: Prompt

FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift:95:65: error: 'Error' is only available in iOS 27.0 or newer
 90 |     ///     `false`, structured output (JSON) is requested but the schema is not strictly enforced.
 91 |     ///   - options: A set of options, represented as a ``GenerationOptionsRepresentable`` type.
 92 |     public func _streamResponse(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
    |                 `- note: add '@available' attribute to enclosing instance method
 93 |                                 includeSchemaInPrompt: Bool,
 94 |                                 options: any GenerationOptionsRepresentable)
 95 |       -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
    |                                                                 `- error: 'Error' is only available in iOS 27.0 or newer
 96 |       return AsyncThrowingStream { continuation in
 97 |         let foundationModelsPrompt: Prompt

FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift:22:3: error: type 'LanguageModelSession' does not conform to protocol '_ModelSession'
 20 |   @available(tvOS, unavailable)
 21 |   @available(watchOS, unavailable)
 22 |   extension FoundationModels.LanguageModelSession: _ModelSession {
    |   |- error: type 'LanguageModelSession' does not conform to protocol '_ModelSession'
    |   `- note: add stubs for conformance
 23 |     /// Returns `true` if the session has history (i.e., it has already had one or more chat turns).
 24 |     ///
    :
 90 |     ///     `false`, structured output (JSON) is requested but the schema is not strictly enforced.
 91 |     ///   - options: A set of options, represented as a ``GenerationOptionsRepresentable`` type.
 92 |     public func _streamResponse(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
    |                 `- note: candidate has non-matching type '([any Part], FirebaseAI.GenerationSchema?, Bool, any GenerationOptionsRepresentable) -> sending AsyncThrowingStream<_ModelSessionResponse, LanguageModelSession.Error>'
 93 |                                 includeSchemaInPrompt: Bool,
 94 |                                 options: any GenerationOptionsRepresentable)

FirebaseAI/Sources/Protocols/Public/ModelSession.swift:50:10: note: protocol requires function '_streamResponse(to:schema:includeSchemaInPrompt:options:)' with type '([any Part], FirebaseAI.GenerationSchema?, Bool, any GenerationOptionsRepresentable) -> sending AsyncThrowingStream<_ModelSessionResponse, any Error>'
48 |     ///   - options: A set of options, represented as a ``GenerationOptionsRepresentable`` type.
49 |     @available(macOS 12.0, watchOS 8.0, *)
50 |     func _streamResponse(to prompt: [any Part],
   |          `- note: protocol requires function '_streamResponse(to:schema:includeSchemaInPrompt:options:)' with type '([any Part], FirebaseAI.GenerationSchema?, Bool, any GenerationOptionsRepresentable) -> sending AsyncThrowingStream<_ModelSessionResponse, any Error>'
51 |                          schema: FirebaseAI.GenerationSchema?,
52 |                          includeSchemaInPrompt: Bool,

FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift:96:14: error: initializer 'init(_:bufferingPolicy:_:)' requires the types 'LanguageModelSession.Error' and 'any Error' be equivalent
 94 |                                 options: any GenerationOptionsRepresentable)
 95 |       -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
 96 |       return AsyncThrowingStream { continuation in
    |              `- error: initializer 'init(_:bufferingPolicy:_:)' requires the types 'LanguageModelSession.Error' and 'any Error' be equivalent
 97 |         let foundationModelsPrompt: Prompt
 98 |         do {

_Concurrency.AsyncThrowingStream.init:2:8: note: where 'Failure' = 'LanguageModelSession.Error'
1 | generic struct AsyncThrowingStream {
2 | public init(_ elementType: Element.Type = Element.self, bufferingPolicy limit: AsyncThrowingStream<Element, Failure>.Continuation.BufferingPolicy = .unbounded, _ build: (AsyncThrowingStream<Element, Failure>.Continuation) -> Void) where Failure == any Error}
  |        `- note: where 'Failure' = 'LanguageModelSession.Error'
3 | 

FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift:101:41: error: cannot convert value of type 'any Error' to expected argument type 'LanguageModelSession.Error'
 99 |           foundationModelsPrompt = try prompt.toFoundationModelsPrompt()
100 |         } catch {
101 |           continuation.finish(throwing: error)
    |                                         `- error: cannot convert value of type 'any Error' to expected argument type 'LanguageModelSession.Error'
102 |           return
103 |         }

FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift:95:61: error: 'any' has no effect on concrete type 'LanguageModelSession.Error'
 93 |                                 includeSchemaInPrompt: Bool,
 94 |                                 options: any GenerationOptionsRepresentable)
 95 |       -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
    |                                                             `- error: 'any' has no effect on concrete type 'LanguageModelSession.Error'
 96 |       return AsyncThrowingStream { continuation in
 97 |         let foundationModelsPrompt: Prompt

FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift:95:65: error: 'Error' is only available in iOS 27.0 or newer
 90 |     ///     `false`, structured output (JSON) is requested but the schema is not strictly enforced.
 91 |     ///   - options: A set of options, represented as a ``GenerationOptionsRepresentable`` type.
 92 |     public func _streamResponse(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
    |                 `- note: add '@available' attribute to enclosing instance method
 93 |                                 includeSchemaInPrompt: Bool,
 94 |                                 options: any GenerationOptionsRepresentable)
 95 |       -> sending AsyncThrowingStream<_ModelSessionResponse, any Error> {
    |                                                                 `- error: 'Error' is only available in iOS 27.0 or newer
 96 |       return AsyncThrowingStream { continuation in
 97 |         let foundationModelsPrompt: Prompt

FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift:22:3: error: type 'LanguageModelSession' does not conform to protocol '_ModelSession'
 20 |   @available(tvOS, unavailable)
 21 |   @available(watchOS, unavailable)
 22 |   extension FoundationModels.LanguageModelSession: _ModelSession {
    |   |- error: type 'LanguageModelSession' does not conform to protocol '_ModelSession'
    |   `- note: add stubs for conformance
 23 |     /// Returns `true` if the session has history (i.e., it has already had one or more chat turns).
 24 |     ///
    :
 90 |     ///     `false`, structured output (JSON) is requested but the schema is not strictly enforced.
 91 |     ///   - options: A set of options, represented as a ``GenerationOptionsRepresentable`` type.
 92 |     public func _streamResponse(to prompt: [any Part], schema: FirebaseAI.GenerationSchema?,
    |                 `- note: candidate has non-matching type '([any Part], FirebaseAI.GenerationSchema?, Bool, any GenerationOptionsRepresentable) -> sending AsyncThrowingStream<_ModelSessionResponse, LanguageModelSession.Error>'
 93 |                                 includeSchemaInPrompt: Bool,
 94 |                                 options: any GenerationOptionsRepresentable)

FirebaseAI/Sources/Protocols/Public/ModelSession.swift:50:10: note: protocol requires function '_streamResponse(to:schema:includeSchemaInPrompt:options:)' with type '([any Part], FirebaseAI.GenerationSchema?, Bool, any GenerationOptionsRepresentable) -> sending AsyncThrowingStream<_ModelSessionResponse, any Error>'
48 |     ///   - options: A set of options, represented as a ``GenerationOptionsRepresentable`` type.
49 |     @available(macOS 12.0, watchOS 8.0, *)
50 |     func _streamResponse(to prompt: [any Part],
   |          `- note: protocol requires function '_streamResponse(to:schema:includeSchemaInPrompt:options:)' with type '([any Part], FirebaseAI.GenerationSchema?, Bool, any GenerationOptionsRepresentable) -> sending AsyncThrowingStream<_ModelSessionResponse, any Error>'
51 |                          schema: FirebaseAI.GenerationSchema?,
52 |                          includeSchemaInPrompt: Bool,
```

</details>