### PR TITLE
fix(auth): handle external sign-in callbacks when using scene delegates in sample app

### DIFF
--- a/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/SceneDelegate.swift
+++ b/FirebaseAuth/Tests/SampleSwift/AuthenticationExample/SceneDelegate.swift
@@ -14,6 +14,8 @@
 
 import FirebaseAuth
 import UIKit
+import GoogleSignIn
+import FacebookCore
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   var window: UIWindow?
@@ -53,10 +55,24 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
     for urlContext in URLContexts {
       let url = urlContext.url
-      _ = Auth.auth().canHandle(url)
+      if Auth.auth().canHandle(url) {
+        continue;
+      }
+      // Handle Google signins
+      if GIDSignIn.sharedInstance.handle(url) {
+        continue;
+      }
+      // Handle Facebook signins
+      if ApplicationDelegate.shared.application(
+        UIApplication.shared,
+        open: url,
+        sourceApplication: urlContext.options.sourceApplication,
+        annotation: urlContext.options.annotation
+      ) {
+        continue
+      }
+      // URL not auth, Google, or Facebook related; it should be handled separately.
     }
-
-    // URL not auth related; it should be handled separately.
   }
 
   func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {


### PR DESCRIPTION
Per [b/522347894](https://b.corp.google.com/issues/522347894),

This fixes the issue within one of the Firebase Auth sample apps, where usage of scene delegates would break the external sign-in flow.

More specifically, within the `AuthenticationExample` sample app that auth has, the handling of Google sign-in/Facebook sign-in is properly done for the App delegate path. But the scene delegate path does not call either of these methods.

When an app is using scene delegates, certain app delegate methods won't be called. In this case, it's the `application:openURL:options:` method. The scene delegate already has a corresponding `scene:openURLContexts:`, but it needs to be updated to call the external sign-in callbacks.

This PR adds those callbacks to the scene delegate.

#no-changelog