### PR TITLE
try building docc docs on swift package index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -3,3 +3,20 @@ external_links:
   documentation: "https://firebase.google.com/docs/ios/setup"
 metadata:
   authors: "Google"
+builder:
+  configs:
+  - documentation_targets:
+    - FirebaseAILogic
+    - FirebaseAuth
+    - FirebaseAppCheck
+    - FirebaseCore
+    - FirebaseCrashlytics
+    - FirebaseDatabase
+    - FirebaseFirestore
+    - FirebaseFunctions
+    - FirebaseInstallations
+    - FirebaseMessaging
+    - FirebasePerformanceTarget
+    - FirebaseRemoteConfig
+    - FirebaseStorage
+    platform: iOS


### PR DESCRIPTION
Our external_link sends users to the getting started guide, but this way we can hopefully host documentation on Swift Package Index as well.

https://swiftpackageindex.com/swiftpackageindex/spimanifest/main/documentation/spimanifest/commonusecases#Host-DocC-documentation-in-the-Swift-Package-Index