### PR TITLE
fix(perf): avoid unsafe NSProxy delegate ivar lookup

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fixed a crash when Firebase Performance instruments NSProxy NSURLSession delegates
+  that report a wrapped object's class. (#16254)
+
 # 12.14.0
 - [fixed] Fixed a race condition crash in `FPRConfigurations` by making
   `remoteConfigFlags` atomic and explicitly nullable. (#16144)

--- a/FirebasePerformance/Sources/Instrumentation/FPRProxyObjectHelper.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRProxyObjectHelper.m
@@ -14,14 +14,39 @@
 
 #import "FirebasePerformance/Sources/Instrumentation/FPRProxyObjectHelper.h"
 
-#import <GoogleUtilities/GULSwizzler.h>
+#import <objc/runtime.h>
+#import <string.h>
+
+FOUNDATION_STATIC_INLINE NSArray<id> *FPRIvarObjectsForProxy(id proxy) {
+  NSMutableArray<id> *array = [NSMutableArray array];
+  // NSProxy subclasses can forward -class to a wrapped object, so use the runtime class.
+  Class currentClass = object_getClass(proxy);
+  while (currentClass && currentClass != [NSProxy class]) {
+    unsigned int count = 0;
+    Ivar *ivars = class_copyIvarList(currentClass, &count);
+    if (ivars) {
+      for (NSUInteger i = 0; i < count; i++) {
+        const char *typeEncoding = ivar_getTypeEncoding(ivars[i]);
+        if (typeEncoding && strncmp(typeEncoding, "@", 1) == 0) {
+          id ivarObject = object_getIvar(proxy, ivars[i]);
+          if (ivarObject) {
+            [array addObject:ivarObject];
+          }
+        }
+      }
+      free(ivars);
+    }
+    currentClass = class_getSuperclass(currentClass);
+  }
+  return array;
+}
 
 @implementation FPRProxyObjectHelper
 
 + (void)registerProxyObject:(id)proxy
               forSuperclass:(Class)superclass
             varFoundHandler:(void (^)(id ivar))varFoundHandler {
-  NSArray<id> *ivars = [GULSwizzler ivarObjectsForObject:proxy];
+  NSArray<id> *ivars = FPRIvarObjectsForProxy(proxy);
   for (id ivar in ivars) {
     if ([ivar isKindOfClass:superclass]) {
       varFoundHandler(ivar);
@@ -32,7 +57,7 @@
 + (void)registerProxyObject:(id)proxy
                 forProtocol:(Protocol *)protocol
             varFoundHandler:(void (^)(id ivar))varFoundHandler {
-  NSArray *ivars = [GULSwizzler ivarObjectsForObject:proxy];
+  NSArray *ivars = FPRIvarObjectsForProxy(proxy);
   for (id ivar in ivars) {
     if ([ivar conformsToProtocol:protocol]) {
       varFoundHandler(ivar);

--- a/FirebasePerformance/Tests/Unit/Instruments/FPRNSURLSessionInstrumentTest.m
+++ b/FirebasePerformance/Tests/Unit/Instruments/FPRNSURLSessionInstrumentTest.m
@@ -70,6 +70,9 @@
 /** @return an instance of the delegate proxy. */
 - (instancetype)initWithDelegate:(id)delegate;
 
+/** @return the wrapped delegate object. */
+- (id)delegate;
+
 @end
 
 @implementation FPRNSURLSessionDelegateProxy
@@ -89,8 +92,23 @@
   return [_delegate respondsToSelector:aSelector];
 }
 
+- (id)delegate {
+  return _delegate;
+}
+
 - (void)forwardInvocation:(NSInvocation *)invocation {
   [invocation invokeWithTarget:_delegate];
+}
+
+@end
+
+@interface FPRNSURLSessionDelegateClassReportingProxy : FPRNSURLSessionDelegateProxy
+@end
+
+@implementation FPRNSURLSessionDelegateClassReportingProxy
+
+- (Class)class {
+  return [[self delegate] class];
 }
 
 @end
@@ -629,6 +647,23 @@
   XCTAssertEqual(instrument.delegateInstrument.instrumentedClasses.count, 1);
   XCTAssertTrue(
       [instrument.delegateInstrument.instrumentedClasses containsObject:[delegate class]]);
+  [instrument deregisterInstrumentors];
+}
+
+/** Tests that proxy delegate lookup uses the proxy's runtime class instead of -class. */
+- (void)testProxyDelegateUsesRuntimeClassWhenProxyReportsWrappedDelegateClass {
+  FPRNSURLSessionTestDelegate *delegate = [[FPRNSURLSessionTestDelegate alloc] init];
+  FPRNSURLSessionDelegateClassReportingProxy *proxyDelegate =
+      [[FPRNSURLSessionDelegateClassReportingProxy alloc] initWithDelegate:delegate];
+  FPRNSURLSessionInstrument *instrument = [[FPRNSURLSessionInstrument alloc] init];
+  [instrument registerInstrumentors];
+  NSURLSessionConfiguration *configuration =
+      [NSURLSessionConfiguration defaultSessionConfiguration];
+  XCTAssertFalse([delegate respondsToSelector:@selector(URLSession:task:didCompleteWithError:)]);
+  XCTAssertNoThrow([NSURLSession sessionWithConfiguration:configuration
+                                                 delegate:proxyDelegate
+                                            delegateQueue:nil]);
+  XCTAssertTrue([delegate respondsToSelector:@selector(URLSession:task:didCompleteWithError:)]);
   [instrument deregisterInstrumentors];
 }
 


### PR DESCRIPTION
### Discussion
Fixes #16254.

Firebase Performance unwraps NSProxy NSURLSession delegates so it can instrument the wrapped delegate. That lookup previously used generic ivar scanning, which can consult `-class`. Some NSProxy implementations forward `-class` to the wrapped object, so the ivar list can come from a class that does not match the proxy runtime layout.

This change uses the proxy object runtime class when scanning ivars, avoiding forwarded `-class` and preserving the existing NSProxy delegate instrumentation behavior.

### Testing
- `FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT=1 xcodebuild -scheme PerformanceUnit -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' -skipPackageUpdates build`