### PR TITLE
ci: Upgrade setup-ruby and retry actions to versions supporting Node.js 24

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -122,11 +122,11 @@ jobs:
         '
       env:
         CUSTOM_ENV_VARS: ${{ inputs.env_vars }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
       if: inputs.method != 'spm' && inputs.method != 'spmbuildonly' && inputs.method != 'cmake'
     - name: Setup Bundler
       if: inputs.method != 'spm' && inputs.method != 'spmbuildonly' && inputs.method != 'cmake'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 5
@@ -140,7 +140,7 @@ jobs:
       if: inputs.platform != 'macOS' && inputs.platform != 'catalyst'
       env:
         PLATFORM_INPUT: ${{ inputs.platform }}
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -156,7 +156,7 @@ jobs:
       if: inputs.setup_command != ''
       run: ${{ inputs.setup_command }}
     - name: Build
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: ${{ inputs.timeout_minutes }}
         max_attempts: ${{ inputs.max_attempts }}

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -126,7 +126,7 @@ jobs:
       if: inputs.method != 'spm' && inputs.method != 'spmbuildonly' && inputs.method != 'cmake'
     - name: Setup Bundler
       if: inputs.method != 'spm' && inputs.method != 'spmbuildonly' && inputs.method != 'cmake'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 10
         max_attempts: 5
@@ -140,7 +140,7 @@ jobs:
       if: inputs.platform != 'macOS' && inputs.platform != 'catalyst'
       env:
         PLATFORM_INPUT: ${{ inputs.platform }}
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -156,7 +156,7 @@ jobs:
       if: inputs.setup_command != ''
       run: ${{ inputs.setup_command }}
     - name: Build
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: ${{ inputs.timeout_minutes }}
         max_attempts: ${{ inputs.max_attempts }}

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -126,7 +126,7 @@ jobs:
       if: inputs.method != 'spm' && inputs.method != 'spmbuildonly' && inputs.method != 'cmake'
     - name: Setup Bundler
       if: inputs.method != 'spm' && inputs.method != 'spmbuildonly' && inputs.method != 'cmake'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 5
@@ -140,7 +140,7 @@ jobs:
       if: inputs.platform != 'macOS' && inputs.platform != 'catalyst'
       env:
         PLATFORM_INPUT: ${{ inputs.platform }}
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -156,7 +156,7 @@ jobs:
       if: inputs.setup_command != ''
       run: ${{ inputs.setup_command }}
     - name: Build
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: ${{ inputs.timeout_minutes }}
         max_attempts: ${{ inputs.max_attempts }}

--- a/.github/workflows/_catalyst.yml
+++ b/.github/workflows/_catalyst.yml
@@ -35,7 +35,7 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/workflows/_catalyst.yml
+++ b/.github/workflows/_catalyst.yml
@@ -30,12 +30,12 @@ jobs:
     runs-on: macos-26
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/workflows/_catalyst.yml
+++ b/.github/workflows/_catalyst.yml
@@ -35,7 +35,7 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
-    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/workflows/_cocoapods.cron.yml
+++ b/.github/workflows/_cocoapods.cron.yml
@@ -68,7 +68,7 @@ jobs:
         persist-credentials: false
     - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 5
@@ -80,7 +80,7 @@ jobs:
       run: sudo xcode-select -s /Applications/"$XCODE_VERSION".app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.platform != 'macos'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -96,7 +96,7 @@ jobs:
         plist_secret: ${{ secrets.plist_secret }}
       run: ${{ inputs.setup_command }}
     - name: PodLibLint Cron
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 3

--- a/.github/workflows/_cocoapods.cron.yml
+++ b/.github/workflows/_cocoapods.cron.yml
@@ -66,9 +66,9 @@ jobs:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         persist-credentials: false
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 5
@@ -80,7 +80,7 @@ jobs:
       run: sudo xcode-select -s /Applications/"$XCODE_VERSION".app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.platform != 'macos'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -96,7 +96,7 @@ jobs:
         plist_secret: ${{ secrets.plist_secret }}
       run: ${{ inputs.setup_command }}
     - name: PodLibLint Cron
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 3

--- a/.github/workflows/_cocoapods.cron.yml
+++ b/.github/workflows/_cocoapods.cron.yml
@@ -68,7 +68,7 @@ jobs:
         persist-credentials: false
     - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 10
         max_attempts: 5
@@ -80,7 +80,7 @@ jobs:
       run: sudo xcode-select -s /Applications/"$XCODE_VERSION".app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.platform != 'macos'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -96,7 +96,7 @@ jobs:
         plist_secret: ${{ secrets.plist_secret }}
       run: ${{ inputs.setup_command }}
     - name: PodLibLint Cron
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 3

--- a/.github/workflows/_cocoapods.yml
+++ b/.github/workflows/_cocoapods.yml
@@ -140,9 +140,9 @@ jobs:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         persist-credentials: false
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 5
@@ -152,7 +152,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.platform != 'macOS'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -173,7 +173,7 @@ jobs:
         plist_secret: ${{ secrets.plist_secret }}
       run: ${{ inputs.setup_command }}
     - name: Lint ${{ inputs.product }}.podspec for ${{ matrix.platform }}
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       if: contains(inputs.platforms, matrix.platform)
       with:
         timeout_minutes: ${{ inputs.timeout_minutes }}

--- a/.github/workflows/_cocoapods.yml
+++ b/.github/workflows/_cocoapods.yml
@@ -142,7 +142,7 @@ jobs:
         persist-credentials: false
     - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 10
         max_attempts: 5
@@ -152,7 +152,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.platform != 'macOS'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -173,7 +173,7 @@ jobs:
         plist_secret: ${{ secrets.plist_secret }}
       run: ${{ inputs.setup_command }}
     - name: Lint ${{ inputs.product }}.podspec for ${{ matrix.platform }}
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       if: contains(inputs.platforms, matrix.platform)
       with:
         timeout_minutes: ${{ inputs.timeout_minutes }}

--- a/.github/workflows/_cocoapods.yml
+++ b/.github/workflows/_cocoapods.yml
@@ -142,7 +142,7 @@ jobs:
         persist-credentials: false
     - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 5
@@ -152,7 +152,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.platform != 'macOS'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -173,7 +173,7 @@ jobs:
         plist_secret: ${{ secrets.plist_secret }}
       run: ${{ inputs.setup_command }}
     - name: Lint ${{ inputs.product }}.podspec for ${{ matrix.platform }}
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       if: contains(inputs.platforms, matrix.platform)
       with:
         timeout_minutes: ${{ inputs.timeout_minutes }}

--- a/.github/workflows/_quickstart.framework.yml
+++ b/.github/workflows/_quickstart.framework.yml
@@ -70,13 +70,13 @@ jobs:
         name: ${{ inputs.artifact_name }}
         run-id: ${{ inputs.zip_run_id }}
         github-token: ${{ secrets.github_token }}
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Xcode
       env:
         XCODE_VERSION: ${{ inputs.xcode }}
       run: sudo xcode-select -s /Applications/"$XCODE_VERSION".app/Contents/Developer
     - name: Install simulators
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -99,7 +99,7 @@ jobs:
       run: scripts/decrypt_gha_secret.sh "$PLIST_SRC_PATH" \
         "$PLIST_DST_PATH" "$plist_secret"
     - name: Test Quickstart
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 2

--- a/.github/workflows/_quickstart.framework.yml
+++ b/.github/workflows/_quickstart.framework.yml
@@ -76,7 +76,7 @@ jobs:
         XCODE_VERSION: ${{ inputs.xcode }}
       run: sudo xcode-select -s /Applications/"$XCODE_VERSION".app/Contents/Developer
     - name: Install simulators
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -99,7 +99,7 @@ jobs:
       run: scripts/decrypt_gha_secret.sh "$PLIST_SRC_PATH" \
         "$PLIST_DST_PATH" "$plist_secret"
     - name: Test Quickstart
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 2

--- a/.github/workflows/_quickstart.framework.yml
+++ b/.github/workflows/_quickstart.framework.yml
@@ -76,7 +76,7 @@ jobs:
         XCODE_VERSION: ${{ inputs.xcode }}
       run: sudo xcode-select -s /Applications/"$XCODE_VERSION".app/Contents/Developer
     - name: Install simulators
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -99,7 +99,7 @@ jobs:
       run: scripts/decrypt_gha_secret.sh "$PLIST_SRC_PATH" \
         "$PLIST_DST_PATH" "$plist_secret"
     - name: Test Quickstart
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 2

--- a/.github/workflows/_quickstart.yml
+++ b/.github/workflows/_quickstart.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install simulators
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -99,7 +99,7 @@ jobs:
             "$PLIST_DST_PATH" \
             "$plist_secret"
     - name: Build ${{ inputs.product }} Quickstart
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       env:
         PRODUCT: ${{ inputs.product }}
         RUN_TESTS: ${{ inputs.run_tests }}

--- a/.github/workflows/_quickstart.yml
+++ b/.github/workflows/_quickstart.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install simulators
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -99,7 +99,7 @@ jobs:
             "$PLIST_DST_PATH" \
             "$plist_secret"
     - name: Build ${{ inputs.product }} Quickstart
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       env:
         PRODUCT: ${{ inputs.product }}
         RUN_TESTS: ${{ inputs.run_tests }}

--- a/.github/workflows/_quickstart.yml
+++ b/.github/workflows/_quickstart.yml
@@ -74,13 +74,13 @@ jobs:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         persist-credentials: false
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Prereqs
       run: gem install xcpretty
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install simulators
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -99,7 +99,7 @@ jobs:
             "$PLIST_DST_PATH" \
             "$plist_secret"
     - name: Build ${{ inputs.product }} Quickstart
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       env:
         PRODUCT: ${{ inputs.product }}
         RUN_TESTS: ${{ inputs.run_tests }}

--- a/.github/workflows/_spm.yml
+++ b/.github/workflows/_spm.yml
@@ -162,7 +162,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.platform != 'macOS' && matrix.platform != 'catalyst'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -174,7 +174,7 @@ jobs:
       run: ${{ inputs.setup_command }}
     - name: Initialize xcodebuild
       run: scripts/setup_spm_tests.sh
-    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       if: contains(inputs.platforms, matrix.platform)
       env:
         FIREBASE_IS_NIGHTLY_TESTING: ${{ inputs.is_nightly && '1' || '' }}

--- a/.github/workflows/_spm.yml
+++ b/.github/workflows/_spm.yml
@@ -162,7 +162,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.platform != 'macOS' && matrix.platform != 'catalyst'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -174,7 +174,7 @@ jobs:
       run: ${{ inputs.setup_command }}
     - name: Initialize xcodebuild
       run: scripts/setup_spm_tests.sh
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       if: contains(inputs.platforms, matrix.platform)
       env:
         FIREBASE_IS_NIGHTLY_TESTING: ${{ inputs.is_nightly && '1' || '' }}

--- a/.github/workflows/infra.archiving.yml
+++ b/.github/workflows/infra.archiving.yml
@@ -32,18 +32,18 @@ jobs:
     - name: Set Xcode version
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install iOS SDK
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
         retry_wait_seconds: 120
         continue_on_error: true
         command: xcodebuild -downloadPlatform iOS
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and archive
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 20
         max_attempts: 3
@@ -67,7 +67,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install SDK
       if: matrix.target != 'macos'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -79,11 +79,11 @@ jobs:
           elif [[ "${{ matrix.target }}" == "tvos" ]]; then
             xcodebuild -downloadPlatform tvOS
           fi
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and archive
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         # Firestore gets a 60 min. timeout, everything else gets 20 min.
         timeout_minutes: ${{ matrix.pod == 'FirebaseFirestore' && 60 || 20 }}

--- a/.github/workflows/infra.archiving.yml
+++ b/.github/workflows/infra.archiving.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set Xcode version
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install iOS SDK
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -43,7 +43,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and archive
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 20
         max_attempts: 3
@@ -67,7 +67,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install SDK
       if: matrix.target != 'macos'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -83,7 +83,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and archive
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         # Firestore gets a 60 min. timeout, everything else gets 20 min.
         timeout_minutes: ${{ matrix.pod == 'FirebaseFirestore' && 60 || 20 }}

--- a/.github/workflows/infra.archiving.yml
+++ b/.github/workflows/infra.archiving.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set Xcode version
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install iOS SDK
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -43,7 +43,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and archive
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 20
         max_attempts: 3
@@ -67,7 +67,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install SDK
       if: matrix.target != 'macos'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -83,7 +83,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and archive
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         # Firestore gets a 60 min. timeout, everything else gets 20 min.
         timeout_minutes: ${{ matrix.pod == 'FirebaseFirestore' && 60 || 20 }}

--- a/.github/workflows/infra.cocoapods.integration.yml
+++ b/.github/workflows/infra.cocoapods.integration.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Get realpath
       run: brew install coreutils
     - name: Build and test
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/workflows/infra.cocoapods.integration.yml
+++ b/.github/workflows/infra.cocoapods.integration.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Get realpath
       run: brew install coreutils
     - name: Build and test
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/workflows/infra.danger.yml
+++ b/.github/workflows/infra.danger.yml
@@ -27,7 +27,7 @@ jobs:
         app-id: ${{ secrets.DANGER_APP_ID }}
         private-key: ${{ secrets.DANGER_APP_PRIVATE_KEY }}
 
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
 

--- a/.github/workflows/infra.ftl.nightly.yml
+++ b/.github/workflows/infra.ftl.nightly.yml
@@ -77,7 +77,7 @@ jobs:
           #   build_command: scripts/test_quickstart_ftl.sh RemoteConfig
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Install xcpretty

--- a/.github/workflows/infra.samples.watchos.yml
+++ b/.github/workflows/infra.samples.watchos.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Prereqs

--- a/.github/workflows/infra.spm_global.yml
+++ b/.github/workflows/infra.spm_global.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -89,7 +89,7 @@ jobs:
       run: scripts/setup_spm_tests.sh
     - name: Functions Integration Test Server
       run: FirebaseFunctions/Backend/start.sh synchronous
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 30
         max_attempts: 3
@@ -124,7 +124,7 @@ jobs:
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -166,7 +166,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5

--- a/.github/workflows/infra.spm_global.yml
+++ b/.github/workflows/infra.spm_global.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -89,7 +89,7 @@ jobs:
       run: scripts/setup_spm_tests.sh
     - name: Functions Integration Test Server
       run: FirebaseFunctions/Backend/start.sh synchronous
-    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 30
         max_attempts: 3
@@ -124,7 +124,7 @@ jobs:
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -166,7 +166,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5

--- a/.github/workflows/release.spm.prerelease.yml
+++ b/.github/workflows/release.spm.prerelease.yml
@@ -112,7 +112,7 @@ jobs:
           quickstart-ios/${{ matrix.product }}/GoogleService-Info.plist \
           "$plist_secret"
     - name: Build Quickstart
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: ${{ matrix.timeout_minutes || 15 }}
         max_attempts: 3

--- a/.github/workflows/release.spm.prerelease.yml
+++ b/.github/workflows/release.spm.prerelease.yml
@@ -112,7 +112,7 @@ jobs:
           quickstart-ios/${{ matrix.product }}/GoogleService-Info.plist \
           "$plist_secret"
     - name: Build Quickstart
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: ${{ matrix.timeout_minutes || 15 }}
         max_attempts: 3

--- a/.github/workflows/release.spm.prerelease.yml
+++ b/.github/workflows/release.spm.prerelease.yml
@@ -35,7 +35,7 @@ jobs:
     # runs-on: macos-12
     # steps:
     # - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    # - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    # - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     # - name: Xcode
     #   run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
     # - name: Setup testing repo and quickstart
@@ -98,7 +98,7 @@ jobs:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Prereqs
       run: gem install xcpretty
     - name: Xcode
@@ -112,7 +112,7 @@ jobs:
           quickstart-ios/${{ matrix.product }}/GoogleService-Info.plist \
           "$plist_secret"
     - name: Build Quickstart
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: ${{ matrix.timeout_minutes || 15 }}
         max_attempts: 3

--- a/.github/workflows/release.spm.yml
+++ b/.github/workflows/release.spm.yml
@@ -107,7 +107,7 @@ jobs:
         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-${{ matrix.product }}.plist.gpg \
           quickstart-ios/${{ matrix.product }}/GoogleService-Info.plist "$plist_secret"
     - name: Build Quickstart
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 3

--- a/.github/workflows/release.spm.yml
+++ b/.github/workflows/release.spm.yml
@@ -33,7 +33,7 @@ jobs:
   #   runs-on: macos-12
   #   steps:
   #   - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-  #   - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+  #   - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
   #   - name: Setup testing repo and quickstart
   #     run: BOT_TOKEN="${botaccess}" scripts/setup_quickstart.sh functions nightly_release_testing
   #   - name: install secret googleservice-info.plist
@@ -97,7 +97,7 @@ jobs:
         fetch-depth: 0 # Required for pulling down repo tags.
     - name: Set Xcode version
       run: sudo xcode-select -s /Applications/Xcode_26.2.app
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Prereqs
       run: gem install xcpretty
     - name: Setup testing repo and quickstart
@@ -107,7 +107,7 @@ jobs:
         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-${{ matrix.product }}.plist.gpg \
           quickstart-ios/${{ matrix.product }}/GoogleService-Info.plist "$plist_secret"
     - name: Build Quickstart
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 3

--- a/.github/workflows/release.spm.yml
+++ b/.github/workflows/release.spm.yml
@@ -107,7 +107,7 @@ jobs:
         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-${{ matrix.product }}.plist.gpg \
           quickstart-ios/${{ matrix.product }}/GoogleService-Info.plist "$plist_secret"
     - name: Build Quickstart
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 3

--- a/.github/workflows/release.zip.yml
+++ b/.github/workflows/release.zip.yml
@@ -89,7 +89,7 @@ jobs:
         persist-credentials: false
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ env.MIN_XCODE }}.app/Contents/Developer
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
       run: ./scripts/setup_bundler.sh
     - name: ZipBuildingTest
@@ -140,7 +140,7 @@ jobs:
         persist-credentials: false
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ env.MIN_XCODE }}.app/Contents/Developer
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
       run: ./scripts/setup_bundler.sh
     - name: ZipBuildingTest
@@ -203,7 +203,7 @@ jobs:
           name: Firebase-actions-dir
           run-id: ${{ needs.packaging_done.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+      - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
       - name: Setup Bundler
         run: ./scripts/setup_bundler.sh
       - name: Install xcpretty

--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -116,7 +116,7 @@ jobs:
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5

--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -116,7 +116,7 @@ jobs:
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5

--- a/.github/workflows/sdk.analytics.yml
+++ b/.github/workflows/sdk.analytics.yml
@@ -41,7 +41,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macos'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5

--- a/.github/workflows/sdk.analytics.yml
+++ b/.github/workflows/sdk.analytics.yml
@@ -34,14 +34,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macos'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5

--- a/.github/workflows/sdk.analytics.yml
+++ b/.github/workflows/sdk.analytics.yml
@@ -41,7 +41,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macos'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5

--- a/.github/workflows/sdk.auth.yml
+++ b/.github/workflows/sdk.auth.yml
@@ -87,13 +87,13 @@ jobs:
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install simulators in case they are missing.
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
         retry_wait_seconds: 120
         command: xcodebuild -downloadPlatform iOS
-    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 3

--- a/.github/workflows/sdk.auth.yml
+++ b/.github/workflows/sdk.auth.yml
@@ -87,13 +87,13 @@ jobs:
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install simulators in case they are missing.
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
         retry_wait_seconds: 120
         command: xcodebuild -downloadPlatform iOS
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 3

--- a/.github/workflows/sdk.firestore.yml
+++ b/.github/workflows/sdk.firestore.yml
@@ -279,7 +279,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+      - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
 
       - name: Install Secret GoogleService-Info.plist for prod
         run: |
@@ -291,7 +291,7 @@ jobs:
 
       - name: Install simulators in case they are missing.
         if: matrix.target != 'macOS'
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 5
@@ -311,7 +311,7 @@ jobs:
         run: scripts/install_prereqs.sh Firestore ${{ matrix.target }} xcodebuild
 
       - name: Build
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 60
           command: scripts/build.sh ${{ matrix.scheme }} ${{ matrix.target }} xcodebuild
@@ -344,7 +344,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+      - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
 
       - name: Install Secret GoogleService-Info.plist for nightly
         run: |
@@ -356,7 +356,7 @@ jobs:
 
       - name: Install simulators in case they are missing.
         if: matrix.target != 'macOS'
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 5
@@ -389,7 +389,7 @@ jobs:
           '
 
       - name: Build
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 60
           command: scripts/build.sh ${{ matrix.scheme }} ${{ matrix.target }} xcodebuild
@@ -421,14 +421,14 @@ jobs:
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
 
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
 
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -448,7 +448,7 @@ jobs:
       run: scripts/install_prereqs.sh Firestore ${{ matrix.target }} xcodebuild
 
     - name: Build
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 60
         command: scripts/build.sh ${{ matrix.scheme }} ${{ matrix.target }} xcodebuild
@@ -510,7 +510,7 @@ jobs:
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-    - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1
+    - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
       run: ./scripts/setup_bundler.sh
     - name: Xcode
@@ -518,7 +518,7 @@ jobs:
 
     - name: Install simulators in case they are missing.
       if: matrix.platforms != 'macos'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -597,7 +597,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -630,7 +630,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -654,7 +654,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5

--- a/.github/workflows/sdk.firestore.yml
+++ b/.github/workflows/sdk.firestore.yml
@@ -291,7 +291,7 @@ jobs:
 
       - name: Install simulators in case they are missing.
         if: matrix.target != 'macOS'
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 15
           max_attempts: 5
@@ -311,7 +311,7 @@ jobs:
         run: scripts/install_prereqs.sh Firestore ${{ matrix.target }} xcodebuild
 
       - name: Build
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 60
           command: scripts/build.sh ${{ matrix.scheme }} ${{ matrix.target }} xcodebuild
@@ -356,7 +356,7 @@ jobs:
 
       - name: Install simulators in case they are missing.
         if: matrix.target != 'macOS'
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 15
           max_attempts: 5
@@ -389,7 +389,7 @@ jobs:
           '
 
       - name: Build
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 60
           command: scripts/build.sh ${{ matrix.scheme }} ${{ matrix.target }} xcodebuild
@@ -428,7 +428,7 @@ jobs:
 
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -448,7 +448,7 @@ jobs:
       run: scripts/install_prereqs.sh Firestore ${{ matrix.target }} xcodebuild
 
     - name: Build
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 60
         command: scripts/build.sh ${{ matrix.scheme }} ${{ matrix.target }} xcodebuild
@@ -518,7 +518,7 @@ jobs:
 
     - name: Install simulators in case they are missing.
       if: matrix.platforms != 'macos'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -597,7 +597,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -630,7 +630,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -654,7 +654,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
       with:
         timeout_minutes: 15
         max_attempts: 5

--- a/.github/workflows/sdk.firestore.yml
+++ b/.github/workflows/sdk.firestore.yml
@@ -291,7 +291,7 @@ jobs:
 
       - name: Install simulators in case they are missing.
         if: matrix.target != 'macOS'
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 5
@@ -311,7 +311,7 @@ jobs:
         run: scripts/install_prereqs.sh Firestore ${{ matrix.target }} xcodebuild
 
       - name: Build
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 60
           command: scripts/build.sh ${{ matrix.scheme }} ${{ matrix.target }} xcodebuild
@@ -356,7 +356,7 @@ jobs:
 
       - name: Install simulators in case they are missing.
         if: matrix.target != 'macOS'
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 5
@@ -389,7 +389,7 @@ jobs:
           '
 
       - name: Build
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 60
           command: scripts/build.sh ${{ matrix.scheme }} ${{ matrix.target }} xcodebuild
@@ -428,7 +428,7 @@ jobs:
 
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -448,7 +448,7 @@ jobs:
       run: scripts/install_prereqs.sh Firestore ${{ matrix.target }} xcodebuild
 
     - name: Build
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 60
         command: scripts/build.sh ${{ matrix.scheme }} ${{ matrix.target }} xcodebuild
@@ -518,7 +518,7 @@ jobs:
 
     - name: Install simulators in case they are missing.
       if: matrix.platforms != 'macos'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -597,7 +597,7 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -630,7 +630,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5
@@ -654,7 +654,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     - name: Install simulators in case they are missing.
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 5


### PR DESCRIPTION
Addresses CI build warnings regarding Node.js 20 actions deprecation. Upgrades setup-ruby and nick-fields/retry actions to newer commit hashes that support Node.js 24.