### PR TITLE
test: Increase timeout in testListenForChildChangedWithLimitEnsureEventsFireProperly

### DIFF
--- a/FirebaseDatabase/Tests/Integration/FIRDatabaseQueryTests.m
+++ b/FirebaseDatabase/Tests/Integration/FIRDatabaseQueryTests.m
@@ -3576,7 +3576,11 @@
         done = YES;
       }];
 
-  [self waitUntil:^BOOL{ return done; } timeout:30];
+  [self
+      waitUntil:^BOOL {
+        return done;
+      }
+        timeout:30];
 
   __block int count = 0;
   [reader
@@ -3600,7 +3604,11 @@
   toSet = @{@"a" : @1, @"b" : @"b", @"c" : @{@"deep" : @"path", @"of" : @{@"stuff" : @YES}}};
   [writer setValue:toSet];
 
-  [self waitUntil:^BOOL{ return count == 3; } timeout:30];
+  [self
+      waitUntil:^BOOL {
+        return count == 3;
+      }
+        timeout:30];
 }
 
 - (void)testListenForChildRemovedWithLimitEnsureEventsFireProperly {

--- a/FirebaseDatabase/Tests/Integration/FIRDatabaseQueryTests.m
+++ b/FirebaseDatabase/Tests/Integration/FIRDatabaseQueryTests.m
@@ -3576,7 +3576,7 @@
         done = YES;
       }];
 
-  WAIT_FOR(done);
+  [self waitUntil:^BOOL{ return done; } timeout:30];
 
   __block int count = 0;
   [reader
@@ -3600,7 +3600,7 @@
   toSet = @{@"a" : @1, @"b" : @"b", @"c" : @{@"deep" : @"path", @"of" : @{@"stuff" : @YES}}};
   [writer setValue:toSet];
 
-  WAIT_FOR(count == 3);
+  [self waitUntil:^BOOL{ return count == 3; } timeout:30];
 }
 
 - (void)testListenForChildRemovedWithLimitEnsureEventsFireProperly {


### PR DESCRIPTION
Addresses CI database integration test timeout flakiness by increasing the event waiting timeout from 10 seconds to 30 seconds.

This test that failed in multiple runs of #16278 now passes. 