### PR TITLE
Update .spi.yml to build documentation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,22 +1,7 @@
 version: 1
-external_links:
-  documentation: "https://firebase.google.com/docs/ios/setup"
 metadata:
   authors: "Google"
 builder:
   configs:
-  - documentation_targets:
-    - FirebaseAILogic
-    - FirebaseAuth
-    - FirebaseAppCheck
-    - FirebaseCore
-    - FirebaseCrashlytics
-    - FirebaseDatabase
-    - FirebaseFirestore
-    - FirebaseFunctions
-    - FirebaseInstallations
-    - FirebaseMessaging
-    - FirebasePerformanceTarget
-    - FirebaseRemoteConfig
-    - FirebaseStorage
+  - documentation_targets: [FirebaseAILogic, FirebaseAuth, FirebaseAppCheck, FirebaseCore, FirebaseCrashlytics, FirebaseDatabase, FirebaseFirestore, FirebaseFunctions, FirebaseInstallations, FirebaseMessaging, FirebasePerformanceTarget, FirebaseRemoteConfig, FirebaseStorage]
     platform: iOS


### PR DESCRIPTION
@morganchen12 @peterfriese I believe the issue with SPI not building documentation after #16262 is either due to a yaml syntax error and/or the definition of a documentation url telling SPI it doesn’t need to build the docs (see [here](https://swiftpackageindex.com/swiftpackageindex/spimanifest/1.12.0/documentation/spimanifest/commonusecases#Configure-a-documentation-URL-for-existing-documentation)). 

This PR matches the syntax to the sample code in the documentation and removes the other documentation url. 