### PR TITLE
Revert "Make the Firestore nightly test optional (#16222)"

### DIFF
--- a/.github/workflows/sdk.firestore.yml
+++ b/.github/workflows/sdk.firestore.yml
@@ -679,6 +679,8 @@ jobs:
       - sanitizers-mac
       - sanitizers-ubuntu
       - pod_lib_lint
+      - xcodetest_prod
+      - xcodetest_nightly
     steps:
       - name: Check test matrix
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')


### PR DESCRIPTION
Reverts the temporary change that made integration tests optional in sdk.firestore.yml