### PR TITLE
fix(spm): Include FirebaseRemoteConfigInternal in RemoteConfig product

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 - [changed] Firebase now requires Swift tools version 6.1 for the Swift Package.
   The package will no longer resolve in Xcode versions older than 16.3. Note that
   the minimum officially supported version for the SDK remains Xcode 26.2+.
+- [fixed] Include `FirebaseRemoteConfigInternal` in the `FirebaseRemoteConfig`
+  SwiftPM product to fix builds that fail to resolve the internal clang module
+  when Swift explicit modules are enabled (e.g. Xcode 26+ and Tuist).
 
 # Firebase 12.14.0
 - [fixed] Remove extra comma in Package.swift that caused SPM resolution

--- a/Package.swift
+++ b/Package.swift
@@ -125,7 +125,7 @@ let package = Package(
     ),
     .library(
       name: "FirebaseRemoteConfig",
-      targets: ["FirebaseRemoteConfig"]
+      targets: ["FirebaseRemoteConfig", "FirebaseRemoteConfigInternal"]
     ),
     .library(
       name: "FirebaseStorage",


### PR DESCRIPTION
### Discussion

- Read the contribution guidelines (CONTRIBUTING.md).
- This PR addresses a SwiftPM packaging issue that breaks consumers building with **Swift explicit modules** enabled (default in Xcode 26+), particularly when using project generators such as **Tuist**.

#### Problem

`FirebaseRemoteConfig` is split across two SwiftPM targets because SwiftPM does not support mixed-language targets:

| Target | Role |
|--------|------|
| `FirebaseRemoteConfigInternal` | Objective-C implementation |
| `FirebaseRemoteConfig` | Swift API (`@_exported import FirebaseRemoteConfigInternal`) |

The public `FirebaseRemoteConfig` library product previously listed only the Swift target. When explicit modules are enabled, consumers fail to resolve the internal clang module (`FirebaseRemoteConfigInternal`), producing errors such as:

```
Unable to find module dependency: 'FirebaseRemoteConfigInternal'
```

This forces workarounds like disabling `SWIFT_ENABLE_EXPLICIT_MODULES` or manually declaring the internal clang module in Tuist's `importedClangModules`.

#### Solution

Include `FirebaseRemoteConfigInternal` in the `FirebaseRemoteConfig` library product:

```swift
.library(
  name: "FirebaseRemoteConfig",
  targets: ["FirebaseRemoteConfig", "FirebaseRemoteConfigInternal"]
),
```

This mirrors the existing pattern used by the `FirebaseAI` product, which bundles multiple targets in a single library product.

#### Why this is the best option now

- **Minimal change**: one-line `Package.swift` update with no public API changes.
- **No new public surface**: unlike exposing `FirebaseRemoteConfigInternal` as a standalone product, this does not encourage direct dependency on an internal module.
- **Fixes the root cause for SPM consumers**: the internal clang module is built and linked as part of the `FirebaseRemoteConfig` product dependency graph.
- **CocoaPods unaffected**: CocoaPods already ships Remote Config as a single mixed-language pod with an umbrella header.
- **Definitive long-term fix deferred**: merging ObjC + Swift into one target (as CocoaPods does) depends on broader SwiftPM mixed-language support (SE-0403).

### Testing

- [x] Verified locally that a Tuist + SPM consumer can build with explicit modules enabled after this change.
- [ ] Existing repository tests (CI).

No new unit tests were added because this is a SwiftPM product packaging change with no runtime or API behavior changes.

### API Changes

- [x] No public API changes.

### Changelog

- Updated `FirebaseCore/CHANGELOG.md` under Firebase 12.15.0.


Made with [Cursor](https://cursor.com)