### PR TITLE
fix(core): update error messages mentioning init usage

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [changed] Changed error message for missing `FirebaseApp.configure()` to 
+  properly articulate supported methods. (#16294)
+
 # 12.15.0
 - [added] Added a reCAPTCHA attestation provider. Using this provider requires the
   [reCAPTCHA Enterprise SDK to be installed](https://docs.cloud.google.com/recaptcha/docs/instrument-ios-apps#prepare-environment),

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [changed] Changed error message for missing `FirebaseApp.configure()` to 
+- [changed] Changed error message for missing `FirebaseApp.configure()` to
   properly articulate supported methods. (#16294)
 
 # 12.15.0

--- a/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
+++ b/FirebaseAppCheck/Sources/Core/FIRAppCheck.m
@@ -134,8 +134,7 @@ static id<FIRAppCheckProviderFactory> _providerFactory;
                 format:@"The default FirebaseApp instance must be configured before the default"
                        @"AppCheck instance can be initialized. One way to ensure this is to "
                        @"call `FirebaseApp.configure()` in the App Delegate's "
-                       @"`application(_:didFinishLaunchingWithOptions:)` (or the `@main` struct's "
-                       @"initializer in SwiftUI)."];
+                       @"`application(_:didFinishLaunchingWithOptions:)`."];
   }
   return [self appCheckWithApp:defaultApp];
 }

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -4,7 +4,7 @@
   (#16274)
 - [fixed] Fixed an issue where the integrated OAuth sign in UI wasn't
   taking up the full screen when rendered in Mac Catalyst apps. (#16274)
-- [changed] Changed error message for missing `FirebaseApp.configure()` to 
+- [changed] Changed error message for missing `FirebaseApp.configure()` to
   properly articulate supported methods. (#16294)
 
 # 12.12.0

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -4,6 +4,8 @@
   (#16274)
 - [fixed] Fixed an issue where the integrated OAuth sign in UI wasn't
   taking up the full screen when rendered in Mac Catalyst apps. (#16274)
+- [changed] Changed error message for missing `FirebaseApp.configure()` to 
+  properly articulate supported methods. (#16294)
 
 # 12.12.0
 - [added] Added `AsyncSequence` support to `Auth.authStateChanges` and

--- a/FirebaseAuth/Sources/Swift/Auth/Auth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/Auth.swift
@@ -153,8 +153,7 @@ extension Auth: AuthInterop {
       fatalError("The default FirebaseApp instance must be configured before the default Auth " +
         "instance can be initialized. One way to ensure this is to call " +
         "`FirebaseApp.configure()` in the App Delegate's " +
-        "`application(_:didFinishLaunchingWithOptions:)` (or the `@main` struct's " +
-        "initializer in SwiftUI).")
+        "`application(_:didFinishLaunchingWithOptions:)`.")
     }
     return auth(app: defaultApp)
   }

--- a/FirebaseInstallations/CHANGELOG.md
+++ b/FirebaseInstallations/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [changed] Changed error message for missing `FirebaseApp.configure()` to 
+- [changed] Changed error message for missing `FirebaseApp.configure()` to
   properly articulate supported methods. (#16294)
 
 # 9.0.0

--- a/FirebaseInstallations/CHANGELOG.md
+++ b/FirebaseInstallations/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [changed] Changed error message for missing `FirebaseApp.configure()` to 
+  properly articulate supported methods. (#16294)
+
 # 9.0.0
 - [fixed] Swift-only: Updated symbol name kFirebaseInstallationsErrorDomain to
   InstallationsErrorDomain. (#9275)

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -181,8 +181,7 @@ static const NSUInteger kExpectedAPIKeyLength = 39;
                 format:@"The default FirebaseApp instance must be configured before the default"
                        @"FirebaseApp instance can be initialized. One way to ensure this is to "
                        @"call `FirebaseApp.configure()` in the App  Delegate's "
-                       @"`application(_:didFinishLaunchingWithOptions:)` "
-                       @"(or the `@main` struct's initializer in SwiftUI)."];
+                       @"`application(_:didFinishLaunchingWithOptions:)`."];
   }
 
   return [self installationsWithApp:defaultApp];


### PR DESCRIPTION
Per [b/525041208](https://b.corp.google.com/issues/525041208),

This PR updates the error messages in App Check, Auth, and Installations that were displayed when a default firebase instance wasn't configured. More specifically, it removes the mention of doing your configuration in the `@main` struct's initializer.

Initializing firebase in the `init()` method of your app may or may not work depending on the products you're using. Some products require the app to be fully initialized before being configured, and `init()` is called before the app is done launching, so attempting to configure these products would cause crashes.

Folks can continue to initialize firebase in `init()` if it's working for their selected products, but it's not something we should continue to push as a "supported method" if not all of our products support it.

In the future, we should investigate the overhead and requirements it would take to adapt our SDKs to not be so reliant on the application's existence and launch state, but that'd take a large amount of overhead to properly investigate.