### PR TITLE
fix(firestore): fix var warning

### DIFF
--- a/Firestore/Swift/Source/ExpressionImplementation.swift
+++ b/Firestore/Swift/Source/ExpressionImplementation.swift
@@ -1450,7 +1450,7 @@ public extension Expression {
                maxSnippetWidth: Int? = nil,
                maxSnippets: Int? = nil,
                separator: String? = nil) -> Expression {
-    var args: [Expression] = [self, Constant(rquery)]
+    let args: [Expression] = [self, Constant(rquery)]
 
     var options: [String: Sendable] = [:]
     if let maxSnippetWidth = maxSnippetWidth {


### PR DESCRIPTION
Repro'd in Xcode 27 beta.
<img width="1156" height="90" alt="Screenshot 2026-06-17 at 3 00 51 PM" src="https://github.com/user-attachments/assets/9c77e6cf-ca12-4408-be8d-2380e58076d8" />

#no-changelog