### PR TITLE
fix(ailogic): xcode 27 renaming deprecation

### DIFF
--- a/FirebaseAI/Sources/Types/Public/GenerationOptions.swift
+++ b/FirebaseAI/Sources/Types/Public/GenerationOptions.swift
@@ -180,13 +180,18 @@
 
           // TODO: Remove `else` when Xcode 27 is the min. supported Xcode.
           #if compiler(>=6.4)
-            let initializer = FoundationModels.GenerationOptions
-              .init(samplingMode:temperature:maximumResponseTokens:)
+            return FoundationModels.GenerationOptions(
+              samplingMode: sampling?.samplingMode,
+              temperature: temperature,
+              maximumResponseTokens: maximumResponseTokens
+            )
           #else
-            let initializer = FoundationModels.GenerationOptions
-              .init(sampling:temperature:maximumResponseTokens:)
+            return FoundationModels.GenerationOptions(
+              sampling: sampling?.samplingMode,
+              temperature: temperature,
+              maximumResponseTokens: maximumResponseTokens
+            )
           #endif
-          return initializer(sampling?.samplingMode, temperature, maximumResponseTokens)
         }
       #endif // canImport(FoundationModels)
 

--- a/FirebaseAI/Sources/Types/Public/GenerationOptions.swift
+++ b/FirebaseAI/Sources/Types/Public/GenerationOptions.swift
@@ -160,12 +160,14 @@
           _generationOptions = options
           // TODO: Remove `else` when Xcode 27 is the min. supported Xcode.
           #if compiler(>=6.4)
-            sampling = options.samplingMode
-              .map { SamplingMode(kind: .foundationModelsSamplingMode($0)) }
+            sampling = options.samplingMode.map {
+              SamplingMode(kind: .foundationModelsSamplingMode($0))
+            }
           #else
-            sampling = options.sampling
-              .map { SamplingMode(kind: .foundationModelsSamplingMode($0)) }
-          #endif
+            sampling = options.sampling.map {
+              SamplingMode(kind: .foundationModelsSamplingMode($0))
+            }
+          #endif // compiler(>=6.4)
           temperature = options.temperature
           maximumResponseTokens = options.maximumResponseTokens
         }
@@ -191,7 +193,7 @@
               temperature: temperature,
               maximumResponseTokens: maximumResponseTokens
             )
-          #endif
+          #endif // compiler(>=6.4)
         }
       #endif // canImport(FoundationModels)
 

--- a/FirebaseAI/Sources/Types/Public/GenerationOptions.swift
+++ b/FirebaseAI/Sources/Types/Public/GenerationOptions.swift
@@ -158,7 +158,14 @@
         @available(watchOS, unavailable)
         public init(_ options: FoundationModels.GenerationOptions) {
           _generationOptions = options
-          sampling = options.sampling.map { SamplingMode(kind: .foundationModelsSamplingMode($0)) }
+          // TODO: Remove `else` when Xcode 27 is the min. supported Xcode.
+          #if compiler(>=6.4)
+            sampling = options.samplingMode
+              .map { SamplingMode(kind: .foundationModelsSamplingMode($0)) }
+          #else
+            sampling = options.sampling
+              .map { SamplingMode(kind: .foundationModelsSamplingMode($0)) }
+          #endif
           temperature = options.temperature
           maximumResponseTokens = options.maximumResponseTokens
         }
@@ -171,11 +178,15 @@
             return generationOptions
           }
 
-          return FoundationModels.GenerationOptions(
-            sampling: sampling?.samplingMode,
-            temperature: temperature,
-            maximumResponseTokens: maximumResponseTokens
-          )
+          // TODO: Remove `else` when Xcode 27 is the min. supported Xcode.
+          #if compiler(>=6.4)
+            let initializer = FoundationModels.GenerationOptions
+              .init(samplingMode:temperature:maximumResponseTokens:)
+          #else
+            let initializer = FoundationModels.GenerationOptions
+              .init(sampling:temperature:maximumResponseTokens:)
+          #endif
+          return initializer(sampling?.samplingMode, temperature, maximumResponseTokens)
         }
       #endif // canImport(FoundationModels)
 


### PR DESCRIPTION
Param name for sampling is slightly different. Old: `sampling` New: `samplingMode`

```diff
- sampling:
+ samplingMode:
```

<img width="1164" height="147" alt="Screenshot 2026-06-18 at 4 55 40 PM" src="https://github.com/user-attachments/assets/d042ba0d-afc4-4a61-a53d-495c578180ca" />

https://github.com/firebase/firebase-ios-sdk/pull/16297/changes?w=1

#no-changelog