### PR TITLE
fix(ailogic): stream errors should not be ignored

### DIFF
--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -18,9 +18,9 @@ on:
     - cron:  '0 7 * * *'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+#  cancel-in-progress: true
 
 permissions:
   contents: read  # Needed for actions/checkout

--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -18,9 +18,9 @@ on:
     - cron:  '0 7 * * *'
   workflow_dispatch:
 
-#concurrency:
-#  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-#  cancel-in-progress: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read  # Needed for actions/checkout

--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+- [fixed] Fixed an issue where `generateContentStream` could hang indefinitely
+  on mid-stream network drops. (#16298)
+- [fixed] Fixed a resource leak where background network requests would
+  continue downloading if the stream consumer terminated early. (#16298)
+
 # 12.15.0
 - [changed] Made Firebase App Check a dependency of Firebase AI Logic to
   simplify App Check setup. (#16185)

--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [fixed] Fixed an issue where `generateContentStream` could hang indefinitely
+- [fixed] Fixed an issue where `generateContentStream` could stall indefinitely
   on mid-stream network drops. (#16298)
 - [fixed] Fixed a resource leak where background network requests would
   continue downloading if the stream consumer terminated early. (#16298)

--- a/FirebaseAI/Sources/GenerativeAIService.swift
+++ b/FirebaseAI/Sources/GenerativeAIService.swift
@@ -72,93 +72,70 @@ struct GenerativeAIService {
   func loadRequestStream<T: GenerativeAIRequest>(request: T)
     -> AsyncThrowingStream<T.Response, Error> where T: Sendable {
     return AsyncThrowingStream { continuation in
-      Task {
-        let urlRequest: URLRequest
+      let task = Task {
         do {
-          urlRequest = try await self.urlRequest(request: request)
-        } catch {
-          continuation.finish(throwing: error)
-          return
-        }
+          let urlRequest = try await self.urlRequest(request: request)
 
-        #if DEBUG
-          printCURLCommand(from: urlRequest)
-        #endif
+          #if DEBUG
+            printCURLCommand(from: urlRequest)
+          #endif
 
-        let stream: URLSession.AsyncBytes
-        let rawResponse: URLResponse
-        do {
+          let stream: URLSession.AsyncBytes
+          let rawResponse: URLResponse
           (stream, rawResponse) = try await urlSession.bytes(for: urlRequest)
-        } catch {
-          continuation.finish(throwing: error)
-          return
-        }
 
-        // Verify the status code is 200
-        let response: HTTPURLResponse
-        do {
-          response = try httpResponse(urlResponse: rawResponse)
-        } catch {
-          continuation.finish(throwing: error)
-          return
-        }
+          let response = try httpResponse(urlResponse: rawResponse)
 
-        // Verify the status code is 200
-        guard response.statusCode == 200 else {
-          AILog.error(
-            code: .loadRequestStreamResponseError,
-            "The server responded with an error: \(response)"
-          )
-          var responseBody = ""
-          for try await line in stream.lines {
-            responseBody += line + "\n"
-          }
-
-          AILog.error(
-            code: .loadRequestStreamResponseErrorPayload,
-            "Response payload: \(responseBody)"
-          )
-          continuation.finish(throwing: parseError(responseBody: responseBody))
-
-          return
-        }
-
-        // Received lines that are not server-sent events (SSE); these are not prefixed with "data:"
-        var extraLines = ""
-
-        for try await line in stream.lines {
-          AILog.debug(code: .loadRequestStreamResponseLine, "Stream response: \(line)")
-
-          if line.hasPrefix("data:") {
-            // We can assume 5 characters since it's utf-8 encoded, removing `data:`.
-            let jsonText = String(line.dropFirst(5))
-            let data: Data
-            do {
-              data = try jsonData(jsonText: jsonText)
-            } catch {
-              continuation.finish(throwing: error)
-              return
+          // Verify the status code is 200
+          guard response.statusCode == 200 else {
+            AILog.error(
+              code: .loadRequestStreamResponseError,
+              "The server responded with an error: \(response)"
+            )
+            var responseBody = ""
+            for try await line in stream.lines {
+              responseBody += line + "\n"
             }
 
-            // Handle the content.
-            do {
+            AILog.error(
+              code: .loadRequestStreamResponseErrorPayload,
+              "Response payload: \(responseBody)"
+            )
+            continuation.finish(throwing: parseError(responseBody: responseBody))
+            return
+          }
+
+          // Received lines that are not server-sent events (SSE); these are not prefixed with
+          // "data:"
+          var extraLines = ""
+
+          for try await line in stream.lines {
+            AILog.debug(code: .loadRequestStreamResponseLine, "Stream response: \(line)")
+
+            if line.hasPrefix("data:") {
+              // We can assume 5 characters since it's utf-8 encoded, removing `data:`.
+              let jsonText = String(line.dropFirst(5))
+              let data = try jsonData(jsonText: jsonText)
               let content = try parseResponse(T.Response.self, from: data)
               continuation.yield(content)
-            } catch {
-              continuation.finish(throwing: error)
-              return
+            } else {
+              extraLines += line
             }
-          } else {
-            extraLines += line
           }
-        }
 
-        if extraLines.count > 0 {
-          continuation.finish(throwing: parseError(responseBody: extraLines))
-          return
-        }
+          if extraLines.count > 0 {
+            continuation.finish(throwing: parseError(responseBody: extraLines))
+            return
+          }
 
-        continuation.finish(throwing: nil)
+          continuation.finish(throwing: nil)
+        } catch {
+          continuation.finish(throwing: error)
+        }
+      }
+
+      continuation.onTermination = { @Sendable _ in
+        task.cancel()
       }
     }
   }

--- a/FirebaseAI/Sources/GenerativeModel.swift
+++ b/FirebaseAI/Sources/GenerativeModel.swift
@@ -322,7 +322,7 @@ public final class GenerativeModel: Sendable {
 
     return AsyncThrowingStream { continuation in
       let responseStream = generativeAIService.loadRequestStream(request: generateContentRequest)
-      Task {
+      let task = Task {
         do {
           var didYieldResponse = false
           for try await response in responseStream {
@@ -365,8 +365,11 @@ public final class GenerativeModel: Sendable {
           }
         } catch {
           continuation.finish(throwing: GenerativeModel.generateContentError(from: error))
-          return
         }
+      }
+
+      continuation.onTermination = { @Sendable _ in
+        task.cancel()
       }
     }
   }

--- a/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift
@@ -89,10 +89,8 @@ import XCTest
 
     func testGenerateContentStream_failure_midStreamError_throwsError() async throws {
       let expectedStatusCode = 200
-      // Send a large amount of data so URLSession doesn't buffer it and delay returning
-      // urlSession.bytes
       let validJSON = "{\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Hello\"}]}}]}"
-      let responseBody = String(repeating: "data: \(validJSON)\n\n", count: 2000)
+      let responseBody = String(repeating: "data: \(validJSON)\n\n", count: 1)
 
       let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
       addTeardownBlock {
@@ -145,10 +143,8 @@ import XCTest
 
     func testGenerateContentStream_failure_midStreamError_badResponse_throwsError() async throws {
       let expectedStatusCode = 400
-      // Send a massive string so URLSession returns the stream immediately without waiting for more
-      // data.
       let validJSON = "{\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Hello\"}]}}]}"
-      let responseBody = String(repeating: "data: \(validJSON)\n\n", count: 2000)
+      let responseBody = String(repeating: "data: \(validJSON)\n\n", count: 1)
 
       let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
       addTeardownBlock {

--- a/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift
@@ -90,7 +90,7 @@ import XCTest
     func testGenerateContentStream_failure_midStreamError_throwsError() async throws {
       let expectedStatusCode = 200
       let validJSON = "{\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Hello\"}]}}]}"
-      let responseBody = String(repeating: "data: \(validJSON)\n\n", count: 1)
+      let responseBody = String(repeating: "data: \(validJSON)\n\n", count: 100)
 
       let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
       addTeardownBlock {
@@ -130,7 +130,7 @@ import XCTest
           throwsExpectation.fulfill()
         } catch let GenerateContentError.internalError(underlying: urlError as URLError)
           where urlError.code == .networkConnectionLost {
-          // This is the expected behavior!
+          // This is the expected behavior.
           throwsExpectation.fulfill()
         } catch {
           XCTFail("Stream threw unexpected error: \(error)")
@@ -144,7 +144,7 @@ import XCTest
     func testGenerateContentStream_failure_midStreamError_badResponse_throwsError() async throws {
       let expectedStatusCode = 400
       let validJSON = "{\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Hello\"}]}}]}"
-      let responseBody = String(repeating: "data: \(validJSON)\n\n", count: 1)
+      let responseBody = String(repeating: "data: \(validJSON)\n\n", count: 100)
 
       let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
       addTeardownBlock {
@@ -184,7 +184,7 @@ import XCTest
           throwsExpectation.fulfill()
         } catch let GenerateContentError.internalError(underlying: urlError as URLError)
           where urlError.code == .networkConnectionLost {
-          // This is the expected behavior!
+          // This is the expected behavior.
           throwsExpectation.fulfill()
         } catch {
           XCTFail("Stream threw unexpected error: \(error)")

--- a/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift
@@ -130,7 +130,8 @@ import XCTest
             "Stream should not finish successfully; it should throw a mid-stream network error."
           )
           throwsExpectation.fulfill()
-        } catch let urlError as URLError where urlError.code == .networkConnectionLost {
+        } catch let GenerateContentError.internalError(underlying: urlError as URLError)
+          where urlError.code == .networkConnectionLost {
           // This is the expected behavior!
           throwsExpectation.fulfill()
         } catch {
@@ -185,7 +186,8 @@ import XCTest
             "Stream should not finish successfully; it should throw a mid-stream network error."
           )
           throwsExpectation.fulfill()
-        } catch let urlError as URLError where urlError.code == .networkConnectionLost {
+        } catch let GenerateContentError.internalError(underlying: urlError as URLError)
+          where urlError.code == .networkConnectionLost {
           // This is the expected behavior!
           throwsExpectation.fulfill()
         } catch {

--- a/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift
@@ -246,11 +246,8 @@ import XCTest
         XCTFail("Unexpected error: \(error)")
       }
 
-      // Now that we've stopped listening to the stream, the internal task *should* be cancelled,
-      // which would instantly fulfill the expectation.
-      // Because the current implementation is buggy, it leaks the background task and never
-      // cancels the URLSession task. Therefore, `stopLoading` is never called, and the expectation
-      // times out (passing the test because it is inverted).
+      // Dropping the iterator cancels the stream. This cancellation should propagate
+      // down to the underlying URLSession task, instantly calling stopLoading().
 
       await fulfillment(of: [stopLoadingExpectation], timeout: 2.0)
     }

--- a/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift
@@ -87,7 +87,7 @@ import XCTest
       }
     }
 
-    func testGenerateContentStream_failure_midStreamError_swallowsError() async throws {
+    func testGenerateContentStream_failure_midStreamError_throwsError() async throws {
       let expectedStatusCode = 200
       // Send a large amount of data so URLSession doesn't buffer it and delay returning
       // urlSession.bytes
@@ -117,9 +117,8 @@ import XCTest
 
       let localModel = model!
 
-      let swallowsExpectation =
-        XCTestExpectation(description: "Stream should swallow the error without finishing")
-      swallowsExpectation.isInverted = true // We expect this to NEVER be fulfilled!
+      let throwsExpectation =
+        XCTestExpectation(description: "Stream should throw URLError(.networkConnectionLost)")
 
       Task {
         do {
@@ -127,18 +126,23 @@ import XCTest
           for try await _ in stream {
             // Read lines
           }
-          print("TEST LOG: Stream finished successfully without error!")
-          swallowsExpectation.fulfill()
+          XCTFail(
+            "Stream should not finish successfully; it should throw a mid-stream network error."
+          )
+          throwsExpectation.fulfill()
+        } catch let urlError as URLError where urlError.code == .networkConnectionLost {
+          // This is the expected behavior!
+          throwsExpectation.fulfill()
         } catch {
-          XCTFail("TEST LOG: Stream threw error: \(error)")
-          swallowsExpectation.fulfill()
+          XCTFail("Stream threw unexpected error: \(error)")
+          throwsExpectation.fulfill()
         }
       }
 
-      await fulfillment(of: [swallowsExpectation], timeout: 4.0)
+      await fulfillment(of: [throwsExpectation], timeout: 4.0)
     }
 
-    func testGenerateContentStream_failure_midStreamError_badResponse_swallowsError() async throws {
+    func testGenerateContentStream_failure_midStreamError_badResponse_throwsError() async throws {
       let expectedStatusCode = 400
       // Send a massive string so URLSession returns the stream immediately without waiting for more
       // data.
@@ -168,9 +172,8 @@ import XCTest
 
       let localModel = model!
 
-      let swallowsExpectation =
-        XCTestExpectation(description: "Stream should swallow the error without finishing")
-      swallowsExpectation.isInverted = true // We expect this to NEVER be fulfilled!
+      let throwsExpectation =
+        XCTestExpectation(description: "Stream should throw URLError(.networkConnectionLost)")
 
       Task {
         do {
@@ -178,15 +181,20 @@ import XCTest
           for try await _ in stream {
             // Read lines
           }
-          print("TEST LOG: Stream finished successfully without error!")
-          swallowsExpectation.fulfill()
+          XCTFail(
+            "Stream should not finish successfully; it should throw a mid-stream network error."
+          )
+          throwsExpectation.fulfill()
+        } catch let urlError as URLError where urlError.code == .networkConnectionLost {
+          // This is the expected behavior!
+          throwsExpectation.fulfill()
         } catch {
-          XCTFail("TEST LOG: Stream threw error: \(error)")
-          swallowsExpectation.fulfill()
+          XCTFail("Stream threw unexpected error: \(error)")
+          throwsExpectation.fulfill()
         }
       }
 
-      await fulfillment(of: [swallowsExpectation], timeout: 4.0)
+      await fulfillment(of: [throwsExpectation], timeout: 4.0)
     }
 
     func testGenerateContentStream_cancellation_resourceLeak() async throws {
@@ -223,8 +231,6 @@ import XCTest
 
       let stopLoadingExpectation =
         XCTestExpectation(description: "stopLoading should be called when task is cancelled")
-      stopLoadingExpectation
-        .isInverted = true // We expect this to NEVER be fulfilled on the buggy implementation!
       MockURLProtocol.stopLoadingExpectation = stopLoadingExpectation
 
       let localModel = model!

--- a/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift
@@ -47,6 +47,9 @@ import XCTest
 
     override func tearDown() {
       MockURLProtocol.requestHandler = nil
+      MockURLProtocol.errorToThrowMidStream = nil
+      MockURLProtocol.stopLoadingExpectation = nil
+      MockURLProtocol.neverFinishes = false
     }
 
     func testGenerateContent_failure_unrecognizedErrorPayload() async throws {
@@ -82,6 +85,166 @@ import XCTest
       } catch {
         XCTFail("Caught unexpected error: \(error)")
       }
+    }
+
+    func testGenerateContentStream_failure_midStreamError_swallowsError() async throws {
+      let expectedStatusCode = 200
+      // Send a large amount of data so URLSession doesn't buffer it and delay returning
+      // urlSession.bytes
+      let validJSON = "{\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Hello\"}]}}]}"
+      let responseBody = String(repeating: "data: \(validJSON)\n\n", count: 2000)
+
+      let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+      addTeardownBlock {
+        try? FileManager.default.removeItem(at: tempURL)
+      }
+
+      MockURLProtocol.requestHandler = { request in
+        let response = HTTPURLResponse(
+          url: request.url!,
+          statusCode: expectedStatusCode,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+
+        try responseBody.write(to: tempURL, atomically: true, encoding: .utf8)
+        let stream = URL(fileURLWithPath: tempURL.path).lines
+        return (response, stream)
+      }
+
+      // Simulate a network drop mid-stream
+      MockURLProtocol.errorToThrowMidStream = URLError(.networkConnectionLost)
+
+      let localModel = model!
+
+      let swallowsExpectation =
+        XCTestExpectation(description: "Stream should swallow the error without finishing")
+      swallowsExpectation.isInverted = true // We expect this to NEVER be fulfilled!
+
+      Task {
+        do {
+          let stream = try localModel.generateContentStream("test")
+          for try await _ in stream {
+            // Read lines
+          }
+          print("TEST LOG: Stream finished successfully without error!")
+          swallowsExpectation.fulfill()
+        } catch {
+          XCTFail("TEST LOG: Stream threw error: \(error)")
+          swallowsExpectation.fulfill()
+        }
+      }
+
+      await fulfillment(of: [swallowsExpectation], timeout: 4.0)
+    }
+
+    func testGenerateContentStream_failure_midStreamError_badResponse_swallowsError() async throws {
+      let expectedStatusCode = 400
+      // Send a massive string so URLSession returns the stream immediately without waiting for more
+      // data.
+      let validJSON = "{\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Hello\"}]}}]}"
+      let responseBody = String(repeating: "data: \(validJSON)\n\n", count: 2000)
+
+      let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+      addTeardownBlock {
+        try? FileManager.default.removeItem(at: tempURL)
+      }
+
+      MockURLProtocol.requestHandler = { request in
+        let response = HTTPURLResponse(
+          url: request.url!,
+          statusCode: expectedStatusCode,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+
+        try responseBody.write(to: tempURL, atomically: true, encoding: .utf8)
+        let stream = URL(fileURLWithPath: tempURL.path).lines
+        return (response, stream)
+      }
+
+      // Simulate a network drop mid-stream while reading the error payload
+      MockURLProtocol.errorToThrowMidStream = URLError(.networkConnectionLost)
+
+      let localModel = model!
+
+      let swallowsExpectation =
+        XCTestExpectation(description: "Stream should swallow the error without finishing")
+      swallowsExpectation.isInverted = true // We expect this to NEVER be fulfilled!
+
+      Task {
+        do {
+          let stream = try localModel.generateContentStream("test")
+          for try await _ in stream {
+            // Read lines
+          }
+          print("TEST LOG: Stream finished successfully without error!")
+          swallowsExpectation.fulfill()
+        } catch {
+          XCTFail("TEST LOG: Stream threw error: \(error)")
+          swallowsExpectation.fulfill()
+        }
+      }
+
+      await fulfillment(of: [swallowsExpectation], timeout: 4.0)
+    }
+
+    func testGenerateContentStream_cancellation_resourceLeak() async throws {
+      let expectedStatusCode = 200
+
+      // We don't use responseBody here because we want to manually yield lines slowly
+      // to test that the mock continues sending them even after the stream is cancelled.
+      // But MockURLProtocol currently doesn't support manual line yielding.
+      // Let's rely on the fact that if it's NOT cancelled, the Task continues doing work.
+      // We can use a large payload and assert that MockURLProtocol finishes its sleep.
+
+      let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+      addTeardownBlock {
+        try? FileManager.default.removeItem(at: tempURL)
+      }
+
+      MockURLProtocol.requestHandler = { request in
+        let response = HTTPURLResponse(
+          url: request.url!,
+          statusCode: expectedStatusCode,
+          httpVersion: nil,
+          headerFields: nil
+        )!
+
+        let validJSON = "{\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Hello\"}]}}]}"
+        let responseBody = String(repeating: "data: \(validJSON)\n\n", count: 100)
+        try responseBody.write(to: tempURL, atomically: true, encoding: .utf8)
+        let stream = URL(fileURLWithPath: tempURL.path).lines
+        return (response, stream)
+      }
+
+      // Prevent the mock server from finishing naturally so it keeps the connection open.
+      MockURLProtocol.neverFinishes = true
+
+      let stopLoadingExpectation =
+        XCTestExpectation(description: "stopLoading should be called when task is cancelled")
+      stopLoadingExpectation
+        .isInverted = true // We expect this to NEVER be fulfilled on the buggy implementation!
+      MockURLProtocol.stopLoadingExpectation = stopLoadingExpectation
+
+      let localModel = model!
+
+      do {
+        let stream = try localModel.generateContentStream("test")
+        var iterator = stream.makeAsyncIterator()
+        // Read just one item, then stop (which drops the iterator and cancels the stream)
+        _ = try await iterator.next()
+      } catch {
+        XCTFail("Unexpected error: \(error)")
+      }
+
+      // Now that we've stopped listening to the stream, the internal task *should* be cancelled,
+      // which would instantly fulfill the expectation.
+      // Because the current implementation is buggy, it leaks the background task and never
+      // cancels the URLSession task. Therefore, `stopLoading` is never called, and the expectation
+      // times out (passing the test because it is inverted).
+
+      await fulfillment(of: [stopLoadingExpectation], timeout: 2.0)
     }
   }
 #endif // !os(watchOS)

--- a/FirebaseAI/Tests/Unit/MockURLProtocol.swift
+++ b/FirebaseAI/Tests/Unit/MockURLProtocol.swift
@@ -24,6 +24,10 @@ class MockURLProtocol: URLProtocol, @unchecked Sendable {
 
   private nonisolated(unsafe) static var _requestHandlers = [MockURLRequestHandler]()
 
+  nonisolated(unsafe) static var errorToThrowMidStream: Error?
+  nonisolated(unsafe) static var stopLoadingExpectation: XCTestExpectation?
+  nonisolated(unsafe) static var neverFinishes: Bool = false
+
   nonisolated(unsafe) static var requestHandler: MockURLRequestHandler? {
     get {
       assert(
@@ -83,9 +87,20 @@ class MockURLProtocol: URLProtocol, @unchecked Sendable {
           XCTFail("Unexpected failure reading lines from stream: \(error.localizedDescription)")
         }
       }
-      client.urlProtocolDidFinishLoading(self)
+      if let errorToThrow = MockURLProtocol.errorToThrowMidStream {
+        // Sleep guarantees the error is thrown mid-stream (after URLSession yields the stream to
+        // the consumer)
+        // rather than pre-stream, preventing test coupling to undocumented URLSession internal
+        // buffer sizes.
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        client.urlProtocol(self, didFailWithError: errorToThrow)
+      } else if !MockURLProtocol.neverFinishes {
+        client.urlProtocolDidFinishLoading(self)
+      }
     }
   }
 
-  override func stopLoading() {}
+  override func stopLoading() {
+    MockURLProtocol.stopLoadingExpectation?.fulfill()
+  }
 }

--- a/FirebaseAI/Tests/Unit/MockURLProtocol.swift
+++ b/FirebaseAI/Tests/Unit/MockURLProtocol.swift
@@ -72,7 +72,6 @@ class MockURLProtocol: URLProtocol, @unchecked Sendable {
       client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
       if let stream = stream {
         do {
-          var lineCount = 0
           for try await line in stream {
             guard let data = line.data(using: .utf8) else {
               fatalError("Failed to convert \"\(line)\" to UTF8 data.")
@@ -82,19 +81,19 @@ class MockURLProtocol: URLProtocol, @unchecked Sendable {
             // line;
             // without the following, the whole file is delivered as a single line.
             client.urlProtocol(self, didLoad: "\n".data(using: .utf8)!)
-
-            lineCount += 1
-            if lineCount == 1, let errorToThrow = MockURLProtocol.errorToThrowMidStream {
-              client.urlProtocol(self, didFailWithError: errorToThrow)
-              return
-            }
           }
         } catch {
           client.urlProtocol(self, didFailWithError: error)
           XCTFail("Unexpected failure reading lines from stream: \(error.localizedDescription)")
         }
       }
-      if !MockURLProtocol.neverFinishes {
+      if let errorToThrow = MockURLProtocol.errorToThrowMidStream {
+        // Sleep guarantees the error is thrown mid-stream (after URLSession yields the stream to
+        // the consumer) rather than pre-stream, preventing test coupling to undocumented URLSession
+        // internal buffer sizes.
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        client.urlProtocol(self, didFailWithError: errorToThrow)
+      } else if !MockURLProtocol.neverFinishes {
         client.urlProtocolDidFinishLoading(self)
       }
     }

--- a/FirebaseAI/Tests/Unit/MockURLProtocol.swift
+++ b/FirebaseAI/Tests/Unit/MockURLProtocol.swift
@@ -72,6 +72,7 @@ class MockURLProtocol: URLProtocol, @unchecked Sendable {
       client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
       if let stream = stream {
         do {
+          var lineCount = 0
           for try await line in stream {
             guard let data = line.data(using: .utf8) else {
               fatalError("Failed to convert \"\(line)\" to UTF8 data.")
@@ -81,20 +82,19 @@ class MockURLProtocol: URLProtocol, @unchecked Sendable {
             // line;
             // without the following, the whole file is delivered as a single line.
             client.urlProtocol(self, didLoad: "\n".data(using: .utf8)!)
+
+            lineCount += 1
+            if lineCount == 1, let errorToThrow = MockURLProtocol.errorToThrowMidStream {
+              client.urlProtocol(self, didFailWithError: errorToThrow)
+              return
+            }
           }
         } catch {
           client.urlProtocol(self, didFailWithError: error)
           XCTFail("Unexpected failure reading lines from stream: \(error.localizedDescription)")
         }
       }
-      if let errorToThrow = MockURLProtocol.errorToThrowMidStream {
-        // Sleep guarantees the error is thrown mid-stream (after URLSession yields the stream to
-        // the consumer)
-        // rather than pre-stream, preventing test coupling to undocumented URLSession internal
-        // buffer sizes.
-        try? await Task.sleep(nanoseconds: 2_000_000_000)
-        client.urlProtocol(self, didFailWithError: errorToThrow)
-      } else if !MockURLProtocol.neverFinishes {
+      if !MockURLProtocol.neverFinishes {
         client.urlProtocolDidFinishLoading(self)
       }
     }


### PR DESCRIPTION
Recommend hide whitespace and see inline comments: https://github.com/firebase/firebase-ios-sdk/pull/16298/changes?w=1

### Description
Fixes infinite stalls and resource leaks when streaming responses.

This surfaced as a warning.
<img width="1168" height="229" alt="Screenshot 2026-06-18 at 5 33 51 PM" src="https://github.com/user-attachments/assets/06344775-0ae6-43fa-b635-20cdfc887a9b" />

**1. Swallowed Mid-Stream Errors (Stall)**
- **Issue:** Network errors during `URLSession.AsyncBytes` iteration threw silently because the unstructured `Task` in `loadRequestStream` lacked a `do-catch` block. This caused the continuation to stall infinitely.
- **Fix:** Wrapped the `Task` logic in a top-level `do-catch` that properly forwards errors via `continuation.finish(throwing: error)`.

**2. Missing Cancellation (Resource Leak)**
- **Issue:** If a consumer broke out of the stream early, the `AsyncThrowingStream` continuation terminated, but the internal network request silently continued downloading and parsing in the background.
- **Fix:** Added an `onTermination` handler to the continuation (`continuation.onTermination = { task.cancel() }`) in both `GenerativeAIService.swift` and `GenerativeModel.swift` to explicitly cancel the underlying `Task` and abort the network connection.

### Testing
- `testGenerateContentStream_failure_midStreamError_throwsError`: Verifies mid-stream drops throw correctly.
- `testGenerateContentStream_cancellation_resourceLeak`: Verifies early exit correctly invokes `URLProtocol.stopLoading()`.

These failures are expected and expose the two types of bugs.

From https://github.com/firebase/firebase-ios-sdk/actions/runs/27791049770/job/82239809505?pr=16298

```text
      - NOTE  | [OSX] xcodebuild:  /Users/runner/work/firebase-ios-sdk/firebase-ios-sdk/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift:253: error: -[FirebaseAILogic_Unit_unit.GenerativeAIServiceTests testGenerateContentStream_cancellation_resourceLeak] : Asynchronous wait failed: Exceeded timeout of 2 seconds, with unfulfilled expectations: "stopLoading should be called when task is cancelled".
      - NOTE  | [OSX] xcodebuild:  2026-06-18 21:45:41.407428+0000 xctest[12573:40480] [[FirebaseAI]] 12.16.0 - [FirebaseAI][I-VTX002003] The server responded with an error: <NSHTTPURLResponse: 0x600002cdd7a0> { URL: https://firebasevertexai.googleapis.com/v1beta/projects/test-project-id/locations/test-location/publishers/google/models/test-model:streamGenerateContent?alt=sse } { Status Code: 400, Headers {
      - NOTE  | [OSX] xcodebuild:  /Users/runner/work/firebase-ios-sdk/firebase-ios-sdk/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift:197: error: -[FirebaseAILogic_Unit_unit.GenerativeAIServiceTests testGenerateContentStream_failure_midStreamError_badResponse_throwsError] : Asynchronous wait failed: Exceeded timeout of 4 seconds, with unfulfilled expectations: "Stream should throw URLError(.networkConnectionLost)".
      - NOTE  | [OSX] xcodebuild:  /Users/runner/work/firebase-ios-sdk/firebase-ios-sdk/FirebaseAI/Tests/Unit/GenerativeAIServiceTests.swift:142: error: -[FirebaseAILogic_Unit_unit.GenerativeAIServiceTests testGenerateContentStream_failure_midStreamError_throwsError] : Asynchronous wait failed: Exceeded timeout of 4 seconds, with unfulfilled expectations: "Stream should throw URLError(.networkConnectionLost)".
```
