### PR TITLE
fix(ai): Resolve unstructured throwing task warnings on XC 27

### DIFF
--- a/FirebaseAI/Sources/GenerativeAIService.swift
+++ b/FirebaseAI/Sources/GenerativeAIService.swift
@@ -72,7 +72,7 @@ struct GenerativeAIService {
   func loadRequestStream<T: GenerativeAIRequest>(request: T)
     -> AsyncThrowingStream<T.Response, Error> where T: Sendable {
     return AsyncThrowingStream { continuation in
-      Task {
+      let task = Task {
         let urlRequest: URLRequest
         do {
           urlRequest = try await self.urlRequest(request: request)
@@ -160,6 +160,7 @@ struct GenerativeAIService {
 
         continuation.finish(throwing: nil)
       }
+      continuation.onTermination = { _ in task.cancel() }
     }
   }
 

--- a/FirebaseAI/Tests/Unit/MockURLProtocol.swift
+++ b/FirebaseAI/Tests/Unit/MockURLProtocol.swift
@@ -64,26 +64,25 @@ class MockURLProtocol: URLProtocol, @unchecked Sendable {
     let requestHandler = MockURLProtocol.requestHandlersQueue.removeFirst()
 
     Task {
-      let (response, stream) = try requestHandler(self.request)
-      client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-      if let stream = stream {
-        do {
+      do {
+        let (response, stream) = try requestHandler(self.request)
+        client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let stream {
           for try await line in stream {
             guard let data = line.data(using: .utf8) else {
               fatalError("Failed to convert \"\(line)\" to UTF8 data.")
             }
             client.urlProtocol(self, didLoad: data)
             // Add a newline character since AsyncLineSequence strips them when reading line by
-            // line;
-            // without the following, the whole file is delivered as a single line.
+            // line; without the following, the whole file is delivered as a single line.
             client.urlProtocol(self, didLoad: "\n".data(using: .utf8)!)
           }
-        } catch {
-          client.urlProtocol(self, didFailWithError: error)
-          XCTFail("Unexpected failure reading lines from stream: \(error.localizedDescription)")
         }
+        client.urlProtocolDidFinishLoading(self)
+      } catch {
+        client.urlProtocol(self, didFailWithError: error)
+        XCTFail("MockURLProtocol failed with error: \(error.localizedDescription)")
       }
-      client.urlProtocolDidFinishLoading(self)
     }
   }
 

--- a/FirebaseAI/Tests/Unit/ResponseStreamTests.swift
+++ b/FirebaseAI/Tests/Unit/ResponseStreamTests.swift
@@ -104,20 +104,24 @@
           }
         } errorHandler: { error in
           // Assert that the error is one of the expected decoding failure types.
-          if let genError = error as? GenerativeModelSession.GenerationError,
-             case .decodingFailure = genError {
-            // Expected error.
-          } else if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *),
-                    let foundationError = error as? FoundationModels.LanguageModelSession
-                    .GenerationError,
-                    case .decodingFailure = foundationError {
-            // TODO: Remove this else-if after wrapping `FoundationModels.GenerationError` errors
-            //       into equivalent `GenerativeModelSession.GenerationError` values.
+          #if compiler(>=6.4)
+            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *),
+               error is FoundationModels.GeneratedContent.ParsingError {
+              return // Expected error.
+            }
+          #else
+            if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *),
+               let foundationError = error as? FoundationModels.LanguageModelSession
+               .GenerationError,
+               case .decodingFailure = foundationError {
+              return // Expected error.
+            } else if let generationError = error as? GenerativeModelSession.GenerationError,
+                      case .decodingFailure = generationError {
+              return // Expected error.
+            }
+          #endif // compiler(>=6.4)
 
-            // Expected error.
-          } else {
-            XCTFail("Expected a decoding failure error, but got \(error) instead.")
-          }
+          XCTFail("Expected a decoding failure error, but got \(error) instead.")
         }
       }
     #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM


### PR DESCRIPTION
Resolved the warnings `"Unstructured throwing task created by 'init(name:priority:operation:)' is not used, which may accidentally ignore errors thrown inside the task"` that are emitted in Xcode 27. This is an alternative to https://github.com/firebase/firebase-ios-sdk/pull/16298 where the AI decided it was better to throw the errors instead of calling `continuation.finish(throwing: error)`.

#no-changelog