### PR TITLE
refactor: clean up legacy Swift 5.x version checks

### DIFF
--- a/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
+++ b/FirebaseInstallations/Source/Tests/Unit/Swift/InstallationsAPITests.swift
@@ -109,24 +109,22 @@ final class InstallationsAPITests {
       }
     }
 
-    #if swift(>=5.5)
-      if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
-        // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
-        Task {
-          do {
-            _ = try await Installations.installations().delete()
-          } catch let error as NSError
-            where error.domain == InstallationsErrorDomain && error.code == InstallationsErrorCode
-            .unknown.rawValue {
-            // Above is the old way to handle errors.
-          } catch InstallationsErrorCode.unknown {
-            // Above is the new way to handle errors.
-          } catch {
-            // ...
-          }
+    if #available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // async/await is a Swift Concurrency feature available on iOS 13+ and macOS 10.15+
+      Task {
+        do {
+          _ = try await Installations.installations().delete()
+        } catch let error as NSError
+          where error.domain == InstallationsErrorDomain && error.code == InstallationsErrorCode
+          .unknown.rawValue {
+          // Above is the old way to handle errors.
+        } catch InstallationsErrorCode.unknown {
+          // Above is the new way to handle errors.
+        } catch {
+          // ...
         }
       }
-    #endif // swift(>=5.5)
+    }
 
     // MARK: -  InstallationsAuthTokenResult
 

--- a/Firestore/Swift/Tests/Integration/AsyncAwaitIntegrationTests.swift
+++ b/Firestore/Swift/Tests/Integration/AsyncAwaitIntegrationTests.swift
@@ -32,93 +32,91 @@ let emptyBundle = """
 }
 """
 
-#if swift(>=5.5.2)
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  class AsyncAwaitIntegrationTests: FSTIntegrationTestCase {
-    func testAddData() async throws {
-      let collection = collectionRef()
-      let document = try await collection.addDocument(data: [:])
-      let snapshot = try await document.getDocument()
-      XCTAssertTrue(snapshot.exists)
-    }
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+class AsyncAwaitIntegrationTests: FSTIntegrationTestCase {
+  func testAddData() async throws {
+    let collection = collectionRef()
+    let document = try await collection.addDocument(data: [:])
+    let snapshot = try await document.getDocument()
+    XCTAssertTrue(snapshot.exists)
+  }
 
-    func testLoadBundleFromData() async throws {
-      let bundle = "\(emptyBundle.count)\(emptyBundle)"
-      let bundleProgress = try await db.loadBundle(Data(bundle.utf8))
-      XCTAssertEqual(LoadBundleTaskState.success, bundleProgress.state)
-    }
+  func testLoadBundleFromData() async throws {
+    let bundle = "\(emptyBundle.count)\(emptyBundle)"
+    let bundleProgress = try await db.loadBundle(Data(bundle.utf8))
+    XCTAssertEqual(LoadBundleTaskState.success, bundleProgress.state)
+  }
 
-    func testLoadBundleFromEmptyDataFails() async throws {
-      do {
-        _ = try await db.loadBundle(Data())
-        XCTFail("Bundle loading should have failed")
-      } catch {
-        XCTAssertEqual((error as NSError).domain, FirestoreErrorDomain)
-        XCTAssertEqual((error as NSError).code, FirestoreErrorCode.unknown.rawValue)
-      }
-    }
-
-    func testLoadBundleFromStream() async throws {
-      let bundle = "\(emptyBundle.count)\(emptyBundle)"
-      let bundleProgress = try await db
-        .loadBundle(InputStream(data: bundle.data(using: String.Encoding.utf8)!))
-      XCTAssertEqual(LoadBundleTaskState.success, bundleProgress.state)
-    }
-
-    func testRunTransactionDoesNotCrashOnNilSuccess() async throws {
-      let value = try await db.runTransaction { transact, error in
-        nil // should not crash
-      }
-
-      XCTAssertNil(value, "value should be nil on success")
-    }
-
-    func testQuery() async throws {
-      let collRef = collectionRef(
-        withDocuments: ["doc1": ["a": 1, "b": 0],
-                        "doc2": ["a": 2, "b": 1],
-                        "doc3": ["a": 3, "b": 2],
-                        "doc4": ["a": 1, "b": 3],
-                        "doc5": ["a": 1, "b": 1]]
-      )
-
-      // Two equalities: a==1 || b==1.
-      let filter = Filter.orFilter(
-        [Filter.whereField("a", isEqualTo: 1),
-         Filter.whereField("b", isEqualTo: 1)]
-      )
-      let query = collRef.whereFilter(filter)
-      let snapshot = try await query.getDocuments(source: FirestoreSource.server)
-      XCTAssertEqual(FIRQuerySnapshotGetIDs(snapshot),
-                     ["doc1", "doc2", "doc4", "doc5"])
-    }
-
-    func testAutoIndexCreationAfterFailsTermination() async throws {
-      try await db.terminate()
-
-      let enableIndexAutoCreation = {
-        try FSTExceptionCatcher.catchException {
-          self.db.persistentCacheIndexManager?.enableIndexAutoCreation()
-        }
-      }
-      XCTAssertThrowsError(try enableIndexAutoCreation(), "The client has already been terminated.")
-
-      let disableIndexAutoCreation = {
-        try FSTExceptionCatcher.catchException {
-          self.db.persistentCacheIndexManager?.disableIndexAutoCreation()
-        }
-      }
-      XCTAssertThrowsError(
-        try disableIndexAutoCreation(),
-        "The client has already been terminated."
-      )
-
-      let deleteAllIndexes = {
-        try FSTExceptionCatcher.catchException {
-          self.db.persistentCacheIndexManager?.deleteAllIndexes()
-        }
-      }
-      XCTAssertThrowsError(try deleteAllIndexes(), "The client has already been terminated.")
+  func testLoadBundleFromEmptyDataFails() async throws {
+    do {
+      _ = try await db.loadBundle(Data())
+      XCTFail("Bundle loading should have failed")
+    } catch {
+      XCTAssertEqual((error as NSError).domain, FirestoreErrorDomain)
+      XCTAssertEqual((error as NSError).code, FirestoreErrorCode.unknown.rawValue)
     }
   }
-#endif
+
+  func testLoadBundleFromStream() async throws {
+    let bundle = "\(emptyBundle.count)\(emptyBundle)"
+    let bundleProgress = try await db
+      .loadBundle(InputStream(data: bundle.data(using: String.Encoding.utf8)!))
+    XCTAssertEqual(LoadBundleTaskState.success, bundleProgress.state)
+  }
+
+  func testRunTransactionDoesNotCrashOnNilSuccess() async throws {
+    let value = try await db.runTransaction { transact, error in
+      nil // should not crash
+    }
+
+    XCTAssertNil(value, "value should be nil on success")
+  }
+
+  func testQuery() async throws {
+    let collRef = collectionRef(
+      withDocuments: ["doc1": ["a": 1, "b": 0],
+                      "doc2": ["a": 2, "b": 1],
+                      "doc3": ["a": 3, "b": 2],
+                      "doc4": ["a": 1, "b": 3],
+                      "doc5": ["a": 1, "b": 1]]
+    )
+
+    // Two equalities: a==1 || b==1.
+    let filter = Filter.orFilter(
+      [Filter.whereField("a", isEqualTo: 1),
+       Filter.whereField("b", isEqualTo: 1)]
+    )
+    let query = collRef.whereFilter(filter)
+    let snapshot = try await query.getDocuments(source: FirestoreSource.server)
+    XCTAssertEqual(FIRQuerySnapshotGetIDs(snapshot),
+                   ["doc1", "doc2", "doc4", "doc5"])
+  }
+
+  func testAutoIndexCreationAfterFailsTermination() async throws {
+    try await db.terminate()
+
+    let enableIndexAutoCreation = {
+      try FSTExceptionCatcher.catchException {
+        self.db.persistentCacheIndexManager?.enableIndexAutoCreation()
+      }
+    }
+    XCTAssertThrowsError(try enableIndexAutoCreation(), "The client has already been terminated.")
+
+    let disableIndexAutoCreation = {
+      try FSTExceptionCatcher.catchException {
+        self.db.persistentCacheIndexManager?.disableIndexAutoCreation()
+      }
+    }
+    XCTAssertThrowsError(
+      try disableIndexAutoCreation(),
+      "The client has already been terminated."
+    )
+
+    let deleteAllIndexes = {
+      try FSTExceptionCatcher.catchException {
+        self.db.persistentCacheIndexManager?.deleteAllIndexes()
+      }
+    }
+    XCTAssertThrowsError(try deleteAllIndexes(), "The client has already been terminated.")
+  }
+}

--- a/Firestore/Swift/Tests/Integration/DatabaseTests.swift
+++ b/Firestore/Swift/Tests/Integration/DatabaseTests.swift
@@ -20,138 +20,136 @@ import XCTest
 import FirebaseCore
 import FirebaseFirestore
 
-#if swift(>=5.5.2)
-  @available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
-  class DatabaseTests: FSTIntegrationTestCase {
-    func testCanStillUseDisablePersistenceSettings() async throws {
-      let settings = db.settings
-      settings.isPersistenceEnabled = false
-      db.settings = settings
+@available(iOS 13, tvOS 13, macOS 10.15, macCatalyst 13, watchOS 7, *)
+class DatabaseTests: FSTIntegrationTestCase {
+  func testCanStillUseDisablePersistenceSettings() async throws {
+    let settings = db.settings
+    settings.isPersistenceEnabled = false
+    db.settings = settings
 
-      try await db.document("coll/doc").setData(["foo": "bar"])
-      let result = try? await db.document("coll/doc").getDocument(source: .cache)
-      XCTAssertEqual(["foo": "bar"], result?.data() as! [String: String])
-    }
-
-    func testCanStillUseEnablePersistenceSettings() async throws {
-      let settings = db.settings
-      settings.isPersistenceEnabled = true
-      db.settings = settings
-
-      try await db.document("coll/doc").setData(["foo": "bar"])
-      let result = try? await db.document("coll/doc").getDocument(source: .cache)
-      XCTAssertEqual(["foo": "bar"], result?.data() as! [String: String])
-    }
-
-    func testCanUseMemoryCacheSettings() async throws {
-      let settings = db.settings
-      settings.cacheSettings = MemoryCacheSettings()
-      db.settings = settings
-
-      try await db.document("coll/doc").setData(["foo": "bar"])
-      let result = try? await db.document("coll/doc").getDocument(source: .cache)
-      XCTAssertEqual(["foo": "bar"], result?.data() as! [String: String])
-    }
-
-    func testCanGetDocumentWithMemoryLruGCEnabled() async throws {
-      let settings = db.settings
-      settings
-        .cacheSettings =
-        MemoryCacheSettings(
-          garbageCollectorSettings: MemoryLRUGCSettings(sizeBytes: 2_000_000)
-        )
-      db.settings = settings
-
-      try await db.document("coll/doc").setData(["foo": "bar"])
-      let result = try? await db.document("coll/doc").getDocument(source: .cache)
-      XCTAssertEqual(["foo": "bar"], result?.data() as! [String: String])
-    }
-
-    func testCannotGetDocumentWithMemoryEagerGCEnabled() async throws {
-      let settings = db.settings
-      settings
-        .cacheSettings =
-        MemoryCacheSettings(garbageCollectorSettings: MemoryEagerGCSetting())
-      db.settings = settings
-
-      try await db.document("coll/doc").setData(["foo": "bar"])
-      let result = try? await db.document("coll/doc").getDocument(source: .cache)
-      XCTAssertNil(result)
-    }
-
-    func testCanUsePersistentCacheSettings() async throws {
-      let settings = db.settings
-      settings.cacheSettings = PersistentCacheSettings()
-      db.settings = settings
-
-      try await db.document("coll/doc").setData(["foo": "bar"])
-      let result = try? await db.document("coll/doc").getDocument(source: .cache)
-      XCTAssertEqual(["foo": "bar"], result?.data() as! [String: String])
-    }
-
-    func testCanSetCacheSettingsMultipleTimes() async throws {
-      let settings = db.settings
-      settings.cacheSettings = PersistentCacheSettings()
-      settings.cacheSettings = MemoryCacheSettings()
-      db.settings = settings
-
-      try await db.document("coll/doc").setData(["foo": "bar"])
-      let result = try? await db.document("coll/doc").getDocument(source: .cache)
-      XCTAssertEqual(["foo": "bar"], result?.data() as! [String: String])
-    }
-
-    func testGetValidPersistentCacheIndexManager() async throws {
-      // [FIRApp resetApps] is an internal api, while Swift test can only test again public api.
-      // So `FirebaseApp.configure()` can only be called once for the whole test class.
-      FirebaseApp.configure()
-
-      let db1 = Firestore.firestore(database: "SwiftPersistentCacheIndexManagerDB1")
-      let settings1 = db1.settings
-      settings1.cacheSettings = PersistentCacheSettings()
-      db1.settings = settings1
-
-      XCTAssertNotNil(db1.persistentCacheIndexManager)
-
-      // Use persistent disk cache (default)
-      let db2 = Firestore.firestore(database: "SwiftPersistentCacheIndexManagerDB2")
-      XCTAssertNotNil(db2.persistentCacheIndexManager)
-
-      // Disable persistent disk cache
-      let db3 = Firestore.firestore(database: "SwiftMemoryCacheIndexManagerDB1")
-      let settings3 = db3.settings
-      settings3.cacheSettings = MemoryCacheSettings()
-      db3.settings = settings3
-      XCTAssertNil(db3.persistentCacheIndexManager)
-
-      // Disable persistent disk cache (deprecated)
-      let db4 = Firestore.firestore(database: "SwiftPersistentCacheIndexManagerDB4")
-      let settings4 = db4.settings
-      settings4.isPersistenceEnabled = false
-      db4.settings = settings4
-      XCTAssertNil(db4.persistentCacheIndexManager)
-
-      let db5 = Firestore.firestore(database: "SwiftPersistentCacheIndexManagerDB5")
-      let settings5 = db5.settings
-      settings5.cacheSettings = PersistentCacheSettings()
-      db5.settings = settings5
-      XCTAssertEqual(db5.persistentCacheIndexManager, db5.persistentCacheIndexManager)
-
-      // Use persistent disk cache (default)
-      let db6 = Firestore.firestore(database: "SwiftPersistentCacheIndexManagerDB6")
-      XCTAssertEqual(db6.persistentCacheIndexManager, db6.persistentCacheIndexManager)
-
-      let db7 = Firestore.firestore(database: "SwiftMemoryCacheIndexManagerDB2")
-      let settings7 = db7.settings
-      settings7.cacheSettings = PersistentCacheSettings()
-      db7.settings = settings7
-      XCTAssertNotEqual(db5.persistentCacheIndexManager, db7.persistentCacheIndexManager)
-      XCTAssertNotEqual(db6.persistentCacheIndexManager, db7.persistentCacheIndexManager)
-
-      // Use persistent disk cache (default)
-      let db8 = Firestore.firestore(database: "SwiftPersistentCacheIndexManagerDB8")
-      XCTAssertNotEqual(db5.persistentCacheIndexManager, db8.persistentCacheIndexManager)
-      XCTAssertNotEqual(db6.persistentCacheIndexManager, db8.persistentCacheIndexManager)
-      XCTAssertNotEqual(db7.persistentCacheIndexManager, db8.persistentCacheIndexManager)
-    }
+    try await db.document("coll/doc").setData(["foo": "bar"])
+    let result = try? await db.document("coll/doc").getDocument(source: .cache)
+    XCTAssertEqual(["foo": "bar"], result?.data() as! [String: String])
   }
-#endif
+
+  func testCanStillUseEnablePersistenceSettings() async throws {
+    let settings = db.settings
+    settings.isPersistenceEnabled = true
+    db.settings = settings
+
+    try await db.document("coll/doc").setData(["foo": "bar"])
+    let result = try? await db.document("coll/doc").getDocument(source: .cache)
+    XCTAssertEqual(["foo": "bar"], result?.data() as! [String: String])
+  }
+
+  func testCanUseMemoryCacheSettings() async throws {
+    let settings = db.settings
+    settings.cacheSettings = MemoryCacheSettings()
+    db.settings = settings
+
+    try await db.document("coll/doc").setData(["foo": "bar"])
+    let result = try? await db.document("coll/doc").getDocument(source: .cache)
+    XCTAssertEqual(["foo": "bar"], result?.data() as! [String: String])
+  }
+
+  func testCanGetDocumentWithMemoryLruGCEnabled() async throws {
+    let settings = db.settings
+    settings
+      .cacheSettings =
+      MemoryCacheSettings(
+        garbageCollectorSettings: MemoryLRUGCSettings(sizeBytes: 2_000_000)
+      )
+    db.settings = settings
+
+    try await db.document("coll/doc").setData(["foo": "bar"])
+    let result = try? await db.document("coll/doc").getDocument(source: .cache)
+    XCTAssertEqual(["foo": "bar"], result?.data() as! [String: String])
+  }
+
+  func testCannotGetDocumentWithMemoryEagerGCEnabled() async throws {
+    let settings = db.settings
+    settings
+      .cacheSettings =
+      MemoryCacheSettings(garbageCollectorSettings: MemoryEagerGCSetting())
+    db.settings = settings
+
+    try await db.document("coll/doc").setData(["foo": "bar"])
+    let result = try? await db.document("coll/doc").getDocument(source: .cache)
+    XCTAssertNil(result)
+  }
+
+  func testCanUsePersistentCacheSettings() async throws {
+    let settings = db.settings
+    settings.cacheSettings = PersistentCacheSettings()
+    db.settings = settings
+
+    try await db.document("coll/doc").setData(["foo": "bar"])
+    let result = try? await db.document("coll/doc").getDocument(source: .cache)
+    XCTAssertEqual(["foo": "bar"], result?.data() as! [String: String])
+  }
+
+  func testCanSetCacheSettingsMultipleTimes() async throws {
+    let settings = db.settings
+    settings.cacheSettings = PersistentCacheSettings()
+    settings.cacheSettings = MemoryCacheSettings()
+    db.settings = settings
+
+    try await db.document("coll/doc").setData(["foo": "bar"])
+    let result = try? await db.document("coll/doc").getDocument(source: .cache)
+    XCTAssertEqual(["foo": "bar"], result?.data() as! [String: String])
+  }
+
+  func testGetValidPersistentCacheIndexManager() async throws {
+    // [FIRApp resetApps] is an internal api, while Swift test can only test again public api.
+    // So `FirebaseApp.configure()` can only be called once for the whole test class.
+    FirebaseApp.configure()
+
+    let db1 = Firestore.firestore(database: "SwiftPersistentCacheIndexManagerDB1")
+    let settings1 = db1.settings
+    settings1.cacheSettings = PersistentCacheSettings()
+    db1.settings = settings1
+
+    XCTAssertNotNil(db1.persistentCacheIndexManager)
+
+    // Use persistent disk cache (default)
+    let db2 = Firestore.firestore(database: "SwiftPersistentCacheIndexManagerDB2")
+    XCTAssertNotNil(db2.persistentCacheIndexManager)
+
+    // Disable persistent disk cache
+    let db3 = Firestore.firestore(database: "SwiftMemoryCacheIndexManagerDB1")
+    let settings3 = db3.settings
+    settings3.cacheSettings = MemoryCacheSettings()
+    db3.settings = settings3
+    XCTAssertNil(db3.persistentCacheIndexManager)
+
+    // Disable persistent disk cache (deprecated)
+    let db4 = Firestore.firestore(database: "SwiftPersistentCacheIndexManagerDB4")
+    let settings4 = db4.settings
+    settings4.isPersistenceEnabled = false
+    db4.settings = settings4
+    XCTAssertNil(db4.persistentCacheIndexManager)
+
+    let db5 = Firestore.firestore(database: "SwiftPersistentCacheIndexManagerDB5")
+    let settings5 = db5.settings
+    settings5.cacheSettings = PersistentCacheSettings()
+    db5.settings = settings5
+    XCTAssertEqual(db5.persistentCacheIndexManager, db5.persistentCacheIndexManager)
+
+    // Use persistent disk cache (default)
+    let db6 = Firestore.firestore(database: "SwiftPersistentCacheIndexManagerDB6")
+    XCTAssertEqual(db6.persistentCacheIndexManager, db6.persistentCacheIndexManager)
+
+    let db7 = Firestore.firestore(database: "SwiftMemoryCacheIndexManagerDB2")
+    let settings7 = db7.settings
+    settings7.cacheSettings = PersistentCacheSettings()
+    db7.settings = settings7
+    XCTAssertNotEqual(db5.persistentCacheIndexManager, db7.persistentCacheIndexManager)
+    XCTAssertNotEqual(db6.persistentCacheIndexManager, db7.persistentCacheIndexManager)
+
+    // Use persistent disk cache (default)
+    let db8 = Firestore.firestore(database: "SwiftPersistentCacheIndexManagerDB8")
+    XCTAssertNotEqual(db5.persistentCacheIndexManager, db8.persistentCacheIndexManager)
+    XCTAssertNotEqual(db6.persistentCacheIndexManager, db8.persistentCacheIndexManager)
+    XCTAssertNotEqual(db7.persistentCacheIndexManager, db8.persistentCacheIndexManager)
+  }
+}

--- a/ReleaseTooling/Sources/ZipBuilder/HashCalculator.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/HashCalculator.swift
@@ -56,15 +56,9 @@ extension HashCalculator {
   /// Calculates the SHA256 hash of the data given.
   static func sha256(_ data: Data) -> String {
     var digest = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-    #if swift(>=5)
-      _ = data.withUnsafeBytes {
-        CC_SHA256($0.baseAddress, UInt32(data.count), &digest)
-      }
-    #else
-      _ = data.withUnsafeBytes {
-        CC_SHA256($0, UInt32(data.count), &digest)
-      }
-    #endif
+    _ = data.withUnsafeBytes {
+      CC_SHA256($0.baseAddress, UInt32(data.count), &digest)
+    }
 
     let characters = digest.map { String(format: "%02x", $0) }
     return characters.joined()


### PR DESCRIPTION
Recommend hiding whitespace: https://github.com/firebase/firebase-ios-sdk/pull/16305/changes?w=1

Since the minimum supported Swift version across the SDK has been bumped to 5.9, `#if swift(>=5.x)` checks and their corresponding `#else` blocks evaluate to true by default and are no longer necessary. This commit removes the redundant directives.

#no-changelog