### PR TITLE
fix: support robust native and BSON subtype 0 binary type ordering and comparison on iOS

### DIFF
--- a/Firestore/Source/API/FSTUserDataWriter.mm
+++ b/Firestore/Source/API/FSTUserDataWriter.mm
@@ -125,6 +125,9 @@ NS_ASSUME_NONNULL_BEGIN
     case TypeOrder::kString:
       return MakeNSString(MakeStringView(value.string_value));
     case TypeOrder::kBlob:
+      if (value.which_value_type == google_firestore_v1_Value_map_value_tag) {
+        return [self convertedBsonBinaryData:value.map_value];
+      }
       return MakeNSData(value.bytes_value);
     case TypeOrder::kGeoPoint:
       return MakeFIRGeoPoint(
@@ -139,8 +142,6 @@ NS_ASSUME_NONNULL_BEGIN
       return [self convertedBsonObjectId:value.map_value];
     case TypeOrder::kBsonTimestamp:
       return [self convertedBsonTimestamp:value.map_value];
-    case TypeOrder::kBsonBinaryData:
-      return [self convertedBsonBinaryData:value.map_value];
     case TypeOrder::kVector:
       return [self convertedVector:value.map_value];
     case TypeOrder::kInternalMaxValue:

--- a/Firestore/core/src/index/firestore_index_value_writer.cc
+++ b/Firestore/core/src/index/firestore_index_value_writer.cc
@@ -133,8 +133,21 @@ void WriteIndexMap(google_firestore_v1_MapValue map_index_value,
 void WriteIndexBsonBinaryData(
     const google_firestore_v1_MapValue& map_index_value,
     DirectionalIndexByteEncoder* encoder) {
-  WriteValueTypeLabel(encoder, IndexType::kBsonBinaryData);
-  encoder->WriteBytes(map_index_value.fields[0].value.bytes_value);
+  const pb_bytes_array_t* bytes = map_index_value.fields[0].value.bytes_value;
+  if (!bytes || bytes->size == 0) {
+    WriteValueTypeLabel(encoder, IndexType::kBlob);
+    encoder->WriteBytes(const_cast<pb_bytes_array_t*>(bytes));
+    WriteTruncationMarker(encoder);
+    return;
+  }
+  uint8_t subtype = bytes->bytes[0];
+  if (subtype == 0) {
+    WriteValueTypeLabel(encoder, IndexType::kBlob);
+    encoder->WriteString(nanopb::MakeStringView(bytes).substr(1));
+  } else {
+    WriteValueTypeLabel(encoder, IndexType::kBsonBinaryData);
+    encoder->WriteBytes(const_cast<pb_bytes_array_t*>(bytes));
+  }
   WriteTruncationMarker(encoder);
 }
 

--- a/Firestore/core/src/model/value_util.cc
+++ b/Firestore/core/src/model/value_util.cc
@@ -219,7 +219,7 @@ TypeOrder GetTypeOrder(const google_firestore_v1_Value& value) {
         case MapType::kBsonTimestamp:
           return TypeOrder::kBsonTimestamp;
         case MapType::kBsonBinaryData:
-          return TypeOrder::kBsonBinaryData;
+          return TypeOrder::kBlob;
         case MapType::kNormal:
         default:
           return TypeOrder::kMap;
@@ -348,21 +348,41 @@ ComparisonResult CompareStrings(const google_firestore_v1_Value& left,
   return util::Compare(left_string, right_string);
 }
 
+int GetBinarySubtype(const google_firestore_v1_Value& value) {
+  if (value.which_value_type == google_firestore_v1_Value_bytes_value_tag) {
+    return 0;
+  }
+  HARD_ASSERT(IsBsonBinaryData(value), "Expected binary value");
+  const pb_bytes_array_t* bytes = value.map_value.fields[0].value.bytes_value;
+  if (!bytes || bytes->size == 0) {
+    return 0;
+  }
+  return bytes->bytes[0];
+}
+
+absl::string_view GetBinaryData(const google_firestore_v1_Value& value) {
+  if (value.which_value_type == google_firestore_v1_Value_bytes_value_tag) {
+    if (!value.bytes_value) {
+      return {};
+    }
+    return nanopb::MakeStringView(value.bytes_value);
+  }
+  HARD_ASSERT(IsBsonBinaryData(value), "Expected binary value");
+  const pb_bytes_array_t* bytes = value.map_value.fields[0].value.bytes_value;
+  if (!bytes || bytes->size <= 1) {
+    return {};
+  }
+  return nanopb::MakeStringView(bytes).substr(1);
+}
+
 ComparisonResult CompareBlobs(const google_firestore_v1_Value& left,
                               const google_firestore_v1_Value& right) {
-  if (left.bytes_value && right.bytes_value) {
-    size_t size = std::min(left.bytes_value->size, right.bytes_value->size);
-    int cmp =
-        std::memcmp(left.bytes_value->bytes, right.bytes_value->bytes, size);
-    return cmp != 0
-               ? util::ComparisonResultFromInt(cmp)
-               : util::Compare(left.bytes_value->size, right.bytes_value->size);
-  } else {
-    // An empty blob is represented by a nullptr (or an empty byte array)
-    return util::Compare(
-        !(left.bytes_value == nullptr || left.bytes_value->size == 0),
-        !(right.bytes_value == nullptr || right.bytes_value->size == 0));
+  int left_subtype = GetBinarySubtype(left);
+  int right_subtype = GetBinarySubtype(right);
+  if (left_subtype != right_subtype) {
+    return util::Compare(left_subtype, right_subtype);
   }
+  return util::Compare(GetBinaryData(left), GetBinaryData(right));
 }
 
 ComparisonResult CompareReferences(const google_firestore_v1_Value& left,
@@ -642,9 +662,6 @@ ComparisonResult Compare(const google_firestore_v1_Value& left,
     case TypeOrder::kBsonTimestamp:
       return CompareBsonTimestamp(left, right);
 
-    case TypeOrder::kBsonBinaryData:
-      return CompareBsonBinaryData(left, right);
-
     case TypeOrder::kArray:
       return CompareArrays(left, right);
 
@@ -795,9 +812,6 @@ bool Equals(const google_firestore_v1_Value& lhs,
 
     case TypeOrder::kBsonTimestamp:
       return CompareBsonTimestamp(lhs, rhs) == ComparisonResult::Same;
-
-    case TypeOrder::kBsonBinaryData:
-      return CompareBsonBinaryData(lhs, rhs) == ComparisonResult::Same;
 
     case TypeOrder::kVector:
     case TypeOrder::kMap:
@@ -959,7 +973,7 @@ google_firestore_v1_Value GetLowerBound(
       } else if (IsBsonTimestamp(value)) {
         return MinBsonTimestamp();
       } else if (IsBsonBinaryData(value)) {
-        return MinBsonBinaryData();
+        return MinBytes();
       } else if (IsRegexValue(value)) {
         return MinRegex();
       } else if (IsInt32Value(value) || IsDecimal128Value(value)) {
@@ -995,7 +1009,7 @@ google_firestore_v1_Value GetUpperBound(
     case google_firestore_v1_Value_string_value_tag:
       return MinBytes();
     case google_firestore_v1_Value_bytes_value_tag:
-      return MinBsonBinaryData();
+      return MinReference();
     case google_firestore_v1_Value_reference_value_tag:
       return MinBsonObjectId();
     case google_firestore_v1_Value_geo_point_value_tag:

--- a/Firestore/core/src/model/value_util.h
+++ b/Firestore/core/src/model/value_util.h
@@ -123,16 +123,15 @@ enum class TypeOrder {
   kServerTimestamp = 6,
   kString = 7,
   kBlob = 8,
-  kBsonBinaryData = 9,
-  kReference = 10,
-  kBsonObjectId = 11,
-  kGeoPoint = 12,
-  kRegex = 13,
-  kArray = 14,
-  kVector = 15,
-  kMap = 16,
-  kMaxKey = 17,
-  kInternalMaxValue = 18
+  kReference = 9,
+  kBsonObjectId = 10,
+  kGeoPoint = 11,
+  kRegex = 12,
+  kArray = 13,
+  kVector = 14,
+  kMap = 15,
+  kMaxKey = 16,
+  kInternalMaxValue = 17
 };
 
 /**

--- a/Firestore/core/test/unit/index/index_value_writer_test.cc
+++ b/Firestore/core/test/unit/index/index_value_writer_test.cc
@@ -142,6 +142,21 @@ TEST(IndexValueWriterTest, writeIndexValueSupportsBsonBinaryData) {
   EXPECT_EQ(actual_bytes, expected_bytes);
 }
 
+TEST(IndexValueWriterTest, writeIndexValueSupportsBsonBinarySubtype0) {
+  auto bson_value = BsonBinaryData(0, {1, 2, 3});
+  auto blob_value = testutil::BlobValue(1, 2, 3);
+
+  IndexEncodingBuffer bson_encoder;
+  WriteIndexValue(*bson_value,
+                  bson_encoder.ForKind(model::Segment::Kind::kAscending));
+
+  IndexEncodingBuffer blob_encoder;
+  WriteIndexValue(*blob_value,
+                  blob_encoder.ForKind(model::Segment::Kind::kAscending));
+
+  EXPECT_EQ(bson_encoder.GetEncodedBytes(), blob_encoder.GetEncodedBytes());
+}
+
 TEST(IndexValueWriterTest, writeIndexValueSupportsBsonBinaryWithEmptyData) {
   // Value
   auto value = BsonBinaryData(1, {});

--- a/Firestore/core/test/unit/local/leveldb_index_manager_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_index_manager_test.cc
@@ -1149,6 +1149,40 @@ TEST_F(LevelDbIndexManagerTest, IndexBsonBinaryDataFields) {
   });
 }
 
+TEST_F(LevelDbIndexManagerTest, IndexBlobAndBsonBinaryOrderingAndMatching) {
+  persistence_->Run("TestIndexBlobAndBsonBinaryOrderingAndMatching", [&]() {
+    index_manager_->Start();
+    index_manager_->AddFieldIndex(
+        MakeFieldIndex("coll", "key", model::Segment::kAscending));
+    index_manager_->AddFieldIndex(
+        MakeFieldIndex("coll", "key", model::Segment::kDescending));
+
+    AddDoc("coll/doc_blob", Map("key", testutil::BlobValue(1, 2, 3)));
+    AddDoc("coll/doc_bson0", Map("key", BsonBinaryData(0, {1, 2, 3})));
+    AddDoc("coll/doc_bson1", Map("key", BsonBinaryData(1, {1, 2, 3})));
+
+    auto asc_query = Query("coll").AddingOrderBy(OrderBy("key", "asc"));
+    VerifyResults(asc_query,
+                  {"coll/doc_blob", "coll/doc_bson0", "coll/doc_bson1"});
+
+    auto desc_query = Query("coll").AddingOrderBy(OrderBy("key", "desc"));
+    VerifyResults(desc_query,
+                  {"coll/doc_bson1", "coll/doc_bson0", "coll/doc_blob"});
+
+    auto blob_query = Query("coll").AddingFilter(
+        Filter("key", "==", testutil::BlobValue(1, 2, 3)));
+    VerifyResults(blob_query, {"coll/doc_bson0", "coll/doc_blob"});
+
+    auto bson0_query = Query("coll").AddingFilter(
+        Filter("key", "==", BsonBinaryData(0, {1, 2, 3})));
+    VerifyResults(bson0_query, {"coll/doc_bson0", "coll/doc_blob"});
+
+    auto bson1_query = Query("coll").AddingFilter(
+        Filter("key", "==", BsonBinaryData(1, {1, 2, 3})));
+    VerifyResults(bson1_query, {"coll/doc_bson1"});
+  });
+}
+
 TEST_F(LevelDbIndexManagerTest, IndexBsonTimestampFields) {
   persistence_->Run("TestIndexBsonTimestampFields", [&]() {
     index_manager_->Start();
@@ -1657,6 +1691,7 @@ TEST_F(LevelDbIndexManagerTest, IndexAllTypesTogether) {
     AddDoc("coll/doc15", Map("key", BsonTimestamp(1, 2)));
     AddDoc("coll/doc16", Map("key", "string"));
     AddDoc("coll/doc17", Map("key", BlobValue(0, 1, 255)));
+    AddDoc("coll/doc17_bson0", Map("key", BsonBinaryData(0, {0, 1, 255})));
     AddDoc("coll/doc18", Map("key", BsonBinaryData(1, {1, 2, 3})));
     AddDoc("coll/doc19", Map("key", Ref("project", "coll/doc")));
     AddDoc("coll/doc20", Map("key", BsonObjectId("507f191e810c19729de860ea")));
@@ -1669,14 +1704,14 @@ TEST_F(LevelDbIndexManagerTest, IndexAllTypesTogether) {
 
     auto query = Query("coll").AddingOrderBy(OrderBy("key", "desc"));
 
-    VerifyResults(
-        query,
-        {"coll/doc26", "coll/doc25", "coll/doc24", "coll/doc23", "coll/doc22",
-         "coll/doc21", "coll/doc20", "coll/doc19", "coll/doc18", "coll/doc17",
-         "coll/doc16", "coll/doc15", "coll/doc14", "coll/doc13", "coll/doc12",
-         "coll/doc11", "coll/doc10", "coll/doc9",  "coll/doc8",  "coll/doc7",
-         "coll/doc6",  "coll/doc5",  "coll/doc4",  "coll/doc3",  "coll/doc2",
-         "coll/doc1"});
+    VerifyResults(query,
+                  {"coll/doc26", "coll/doc25",       "coll/doc24", "coll/doc23",
+                   "coll/doc22", "coll/doc21",       "coll/doc20", "coll/doc19",
+                   "coll/doc18", "coll/doc17_bson0", "coll/doc17", "coll/doc16",
+                   "coll/doc15", "coll/doc14",       "coll/doc13", "coll/doc12",
+                   "coll/doc11", "coll/doc10",       "coll/doc9",  "coll/doc8",
+                   "coll/doc7",  "coll/doc6",        "coll/doc5",  "coll/doc4",
+                   "coll/doc3",  "coll/doc2",        "coll/doc1"});
   });
 }
 

--- a/Firestore/core/test/unit/model/value_util_test.cc
+++ b/Firestore/core/test/unit/model/value_util_test.cc
@@ -236,7 +236,7 @@ TEST(FieldValueTest, ValueHelpers) {
   ASSERT_EQ(DetectMapType(*bson_timestamp_value), MapType::kBsonTimestamp);
 
   auto bson_binary_data_value = BsonBinaryData(1, {1, 2, 3});
-  ASSERT_EQ(GetTypeOrder(*bson_binary_data_value), TypeOrder::kBsonBinaryData);
+  ASSERT_EQ(GetTypeOrder(*bson_binary_data_value), TypeOrder::kBlob);
   ASSERT_EQ(DetectMapType(*bson_binary_data_value), MapType::kBsonBinaryData);
 }
 
@@ -315,6 +315,7 @@ TEST_F(ValueUtilTest, Equality) {
   Add(equals_group, Decimal128("Infinity"));
   Add(equals_group, BlobValue(0, 1, 1));
   Add(equals_group, BlobValue(0, 1));
+  Add(equals_group, BlobValue(7, 8, 9), BsonBinaryData(0, {7, 8, 9}));
   Add(equals_group, "string", "string");
   Add(equals_group, "strin");
   Add(equals_group, std::string("strin\0", 6));
@@ -425,15 +426,12 @@ TEST_F(ValueUtilTest, StrictOrdering) {
   // latin small letter e with acute accent + latin small letter a
   Add(comparison_groups, "\u00e9a");
 
-  // blobs
-  Add(comparison_groups, BlobValue());
+  // blobs (native & BSON binary merged)
+  Add(comparison_groups, BlobValue(), DeepClone(MinBsonBinaryData()));
   Add(comparison_groups, BlobValue(0));
   Add(comparison_groups, BlobValue(0, 1, 2, 3, 4));
   Add(comparison_groups, BlobValue(0, 1, 2, 4, 3));
   Add(comparison_groups, BlobValue(255));
-
-  // BSON Binary Data
-  Add(comparison_groups, DeepClone(MinBsonBinaryData()));
   Add(comparison_groups, BsonBinaryData(5, {1, 2, 3}),
       BsonBinaryData(5, {1, 2, 3}));
   Add(comparison_groups, BsonBinaryData(7, {1}));
@@ -589,16 +587,13 @@ TEST_F(ValueUtilTest, RelaxedOrdering) {
   Add(comparison_groups, "\u00e9a");
   Add(comparison_groups, DeepClone(MinBytes()));
 
-  // blobs
+  // blobs (native & BSON binary merged)
   Add(comparison_groups, DeepClone(MinBytes()));
-  Add(comparison_groups, BlobValue());
+  Add(comparison_groups, BlobValue(), DeepClone(MinBsonBinaryData()));
   Add(comparison_groups, BlobValue(0));
   Add(comparison_groups, BlobValue(0, 1, 2, 3, 4));
   Add(comparison_groups, BlobValue(0, 1, 2, 4, 3));
   Add(comparison_groups, BlobValue(255));
-
-  // BSON Binary Data
-  Add(comparison_groups, DeepClone(MinBsonBinaryData()));
   Add(comparison_groups, BsonBinaryData(5, {1, 2, 3}),
       BsonBinaryData(5, {1, 2, 3}));
   Add(comparison_groups, BsonBinaryData(7, {1}));
@@ -720,15 +715,11 @@ TEST_F(ValueUtilTest, ComputesLowerBound) {
   Add(groups, GetLowerBoundMessage(Value("Z")), "", DeepClone(MinString()));
   Add(groups, "\u0000");
 
-  // Blobs
-  Add(groups, GetLowerBoundMessage(BlobValue(1, 2, 3)), BlobValue(),
-      DeepClone(MinBytes()));
-  Add(groups, BlobValue(0));
-
-  // BSON Binary Data
-  Add(groups, GetLowerBoundMessage(BsonBinaryData(128, {128, 128})),
-      DeepClone(MinBsonBinaryData()));
-  Add(groups, BsonBinaryData(0, {0}));
+  // Blobs (native & BSON binary merged)
+  Add(groups, GetLowerBoundMessage(BlobValue(1, 2, 3)),
+      GetLowerBoundMessage(BsonBinaryData(128, {128, 128})), BlobValue(),
+      DeepClone(MinBytes()), DeepClone(MinBsonBinaryData()));
+  Add(groups, BlobValue(0), BsonBinaryData(0, {0}));
 
   // References
   Add(groups, GetLowerBoundMessage(RefValue(DbId("p1/d1"), Key("c1/doc1"))),
@@ -818,13 +809,11 @@ TEST_F(ValueUtilTest, ComputesUpperBound) {
   Add(groups, "\u0000");
   Add(groups, GetUpperBoundMessage(DeepClone(MinString())));
 
-  // Blobs
+  // Blobs (native & BSON binary merged)
   Add(groups, BlobValue(255));
-  Add(groups, GetUpperBoundMessage(BlobValue()));
-
-  // BSON Binary Data
   Add(groups, BsonBinaryData(255, {255, 255}));
-  Add(groups, GetUpperBoundMessage(DeepClone(MinBsonBinaryData())));
+  Add(groups, GetUpperBoundMessage(BlobValue()),
+      GetUpperBoundMessage(DeepClone(MinBsonBinaryData())));
 
   // References
   Add(groups, DeepClone(MinReference()));

--- a/Firestore/core/test/unit/remote/serializer_test.cc
+++ b/Firestore/core/test/unit/remote/serializer_test.cc
@@ -930,7 +930,7 @@ TEST_F(SerializerTest, EncodesBsonBinaryData) {
   (*fields)["__binary__"] =
       ValueProto(ByteString(concat.data(), concat.size()));
 
-  ExpectRoundTrip(model, proto, TypeOrder::kBsonBinaryData);
+  ExpectRoundTrip(model, proto, TypeOrder::kBlob);
 }
 
 TEST_F(SerializerTest, EncodesVectorValue) {


### PR DESCRIPTION
Ports the BSON binary subtype 0 logical comparison and merged type ordering fixes from the Android SDK to the C++ Core (used by iOS).