### PR TITLE
refactor(crashlytics): remove obsolete OS availability checks

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSMetricKitManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSMetricKitManager.m
@@ -58,7 +58,7 @@
  * last run of the app, this promise is immediately resolved so that the upload of any nonfatal
  * events can proceed.
  */
-- (void)registerMetricKitManager API_AVAILABLE(ios(14)) {
+- (void)registerMetricKitManager {
   [[MXMetricManager sharedManager] addSubscriber:self];
   self.metricKitDataAvailable = [FBLPromise pendingPromise];
 
@@ -97,8 +97,7 @@
  * immediately after the event. Since we send nonfatal events on the next run of the app, we can
  * write out the information but won't need to resolve the promise.
  */
-- (void)didReceiveDiagnosticPayloads:(NSArray<MXDiagnosticPayload *> *)payloads
-    API_AVAILABLE(ios(14)) {
+- (void)didReceiveDiagnosticPayloads:(NSArray<MXDiagnosticPayload *> *)payloads {
   BOOL processedFatalPayload = NO;
   for (MXDiagnosticPayload *diagnosticPayload in payloads) {
     if (!diagnosticPayload) {
@@ -121,7 +120,7 @@
 
 // Helper method to write a MetricKit payload's data to file.
 - (BOOL)processMetricKitPayload:(MXDiagnosticPayload *)diagnosticPayload
-                 skipCrashEvent:(BOOL)skipCrashEvent API_AVAILABLE(ios(14)) {
+                 skipCrashEvent:(BOOL)skipCrashEvent {
   BOOL writeFailed = NO;
 
   // Write out each type of diagnostic if it exists in the report
@@ -352,7 +351,7 @@
  * Required for MXMetricManager subscribers. Since we aren't currently collecting any MetricKit
  * metrics, this method is left empty.
  */
-- (void)didReceiveMetricPayloads:(NSArray<MXMetricPayload *> *)payloads API_AVAILABLE(ios(13)) {
+- (void)didReceiveMetricPayloads:(NSArray<MXMetricPayload *> *)payloads {
 }
 
 - (FBLPromise *)waitForMetricKitDataAvailable {
@@ -366,7 +365,7 @@
 /*
  * Helper method to convert threads for a MetricKit fatal diagnostic event to an array of threads.
  */
-- (NSArray *)convertThreadsToArray:(MXCallStackTree *)mxCallStackTree API_AVAILABLE(ios(14)) {
+- (NSArray *)convertThreadsToArray:(MXCallStackTree *)mxCallStackTree {
   FIRCLSCallStackTree *tree = [[FIRCLSCallStackTree alloc] initWithMXCallStackTree:mxCallStackTree];
   return [tree getArrayRepresentation];
 }
@@ -374,8 +373,7 @@
 /*
  * Helper method to convert threads for a MetricKit nonfatal diagnostic event to an array of frames.
  */
-- (NSArray *)convertThreadsToArrayForNonfatal:(MXCallStackTree *)mxCallStackTree
-    API_AVAILABLE(ios(14)) {
+- (NSArray *)convertThreadsToArrayForNonfatal:(MXCallStackTree *)mxCallStackTree {
   FIRCLSCallStackTree *tree = [[FIRCLSCallStackTree alloc] initWithMXCallStackTree:mxCallStackTree];
   return [tree getFramesOfBlamedThread];
 }
@@ -384,7 +382,7 @@
  * Helper method to convert metadata for a MetricKit diagnostic event to a dictionary. MXMetadata
  * has a dictionaryRepresentation method but it is deprecated.
  */
-- (NSDictionary *)convertMetadataToDictionary:(MXMetaData *)metadata API_AVAILABLE(ios(14)) {
+- (NSDictionary *)convertMetadataToDictionary:(MXMetaData *)metadata {
   NSError *error = nil;
   NSDictionary *metadataDictionary =
       [NSJSONSerialization JSONObjectWithData:[metadata JSONRepresentation] options:0 error:&error];

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -192,13 +192,11 @@ typedef NSNumber FIRCLSWrappedReportAction;
   [self.settings reloadFromCacheWithGoogleAppID:self.googleAppID currentTimestamp:currentTimestamp];
 
 #if CLS_METRICKIT_SUPPORTED
-  if (@available(iOS 15, *)) {
-    if (self.settings.metricKitCollectionEnabled) {
-      FIRCLSDebugLog(@"MetricKit data collection enabled.");
-      _metricKitManager = [[FIRCLSMetricKitManager alloc] initWithManagerData:managerData
-                                                        existingReportManager:existingReportManager
-                                                                  fileManager:_fileManager];
-    }
+  if (self.settings.metricKitCollectionEnabled) {
+    FIRCLSDebugLog(@"MetricKit data collection enabled.");
+    _metricKitManager = [[FIRCLSMetricKitManager alloc] initWithManagerData:managerData
+                                                      existingReportManager:existingReportManager
+                                                                fileManager:_fileManager];
   }
 #endif
 
@@ -238,10 +236,8 @@ typedef NSNumber FIRCLSWrappedReportAction;
   // since no MetricKit diagnostics will be available.
   FBLPromise *promise = [FBLPromise resolvedWith:nil];
 #if CLS_METRICKIT_SUPPORTED
-  if (@available(iOS 15, *)) {
-    if (self.settings.metricKitCollectionEnabled) {
-      promise = [self.metricKitManager waitForMetricKitDataAvailable];
-    }
+  if (self.settings.metricKitCollectionEnabled) {
+    promise = [self.metricKitManager waitForMetricKitDataAvailable];
   }
   return promise;
 #endif
@@ -311,10 +307,8 @@ typedef NSNumber FIRCLSWrappedReportAction;
       }];
 
 #if CLS_METRICKIT_SUPPORTED
-  if (@available(iOS 15, *)) {
-    if (self.settings.metricKitCollectionEnabled) {
-      [self.metricKitManager registerMetricKitManager];
-    }
+  if (self.settings.metricKitCollectionEnabled) {
+    [self.metricKitManager registerMetricKitManager];
   }
 #endif
 

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSCallStackTree.h
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSCallStackTree.h
@@ -28,7 +28,7 @@
  */
 @interface FIRCLSCallStackTree : NSObject
 
-- (instancetype)initWithMXCallStackTree:(MXCallStackTree *)callStackTree API_AVAILABLE(ios(14.0));
+- (instancetype)initWithMXCallStackTree:(MXCallStackTree *)callStackTree;
 - (NSArray *)getArrayRepresentation;
 - (NSArray *)getFramesOfBlamedThread;
 - (instancetype)init NS_UNAVAILABLE;

--- a/Crashlytics/UnitTests/FIRCLSMetricKitManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSMetricKitManagerTests.m
@@ -51,7 +51,6 @@
 
 #define TEST_GOOGLE_APP_ID (@"1:632950151350:ios:d5b0d08d4f00f4b1")
 
-API_AVAILABLE(ios(14))
 @interface FIRCLSMetricKitManagerTests : XCTestCase
 
 @property(nonatomic, strong) FIRCLSMockReportManager *reportManager;

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockMXCPUExceptionDiagnostic.h
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockMXCPUExceptionDiagnostic.h
@@ -24,7 +24,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-API_AVAILABLE(ios(14))
 @interface FIRCLSMockMXCPUExceptionDiagnostic : MXCPUExceptionDiagnostic
 
 - (instancetype)initWithCallStackTree:(FIRCLSMockMXCallStackTree *)callStackTree

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockMXCallStackTree.h
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockMXCallStackTree.h
@@ -22,7 +22,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-API_AVAILABLE(ios(14))
 @interface FIRCLSMockMXCallStackTree : MXCallStackTree
 
 - (instancetype)initWithStringData:(NSString *)stringData;

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockMXCrashDiagnostic.h
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockMXCrashDiagnostic.h
@@ -24,7 +24,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-API_AVAILABLE(ios(14))
 @interface FIRCLSMockMXCrashDiagnostic : MXCrashDiagnostic
 
 - (instancetype)initWithCallStackTree:(FIRCLSMockMXCallStackTree *)callStackTree

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockMXDiagnosticPayload.h
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockMXDiagnosticPayload.h
@@ -24,7 +24,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-API_AVAILABLE(ios(14))
 @interface FIRCLSMockMXDiagnosticPayload : MXDiagnosticPayload
 
 - (instancetype)initWithDiagnostics:(NSDictionary *)diagnostics

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockMXDiskWriteExceptionDiagnostic.h
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockMXDiskWriteExceptionDiagnostic.h
@@ -24,7 +24,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-API_AVAILABLE(ios(14))
 @interface FIRCLSMockMXDiskWriteExceptionDiagnostic : MXDiskWriteExceptionDiagnostic
 
 - (instancetype)initWithCallStackTree:(FIRCLSMockMXCallStackTree *)callStackTree

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockMXHangDiagnostic.h
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockMXHangDiagnostic.h
@@ -24,7 +24,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-API_AVAILABLE(ios(14))
 @interface FIRCLSMockMXHangDiagnostic : MXHangDiagnostic
 
 - (instancetype)initWithCallStackTree:(FIRCLSMockMXCallStackTree *)callStackTree

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockMXHangDiagnostic.m
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockMXHangDiagnostic.m
@@ -33,7 +33,7 @@
 - (instancetype)initWithCallStackTree:(FIRCLSMockMXCallStackTree *)callStackTree
                          hangDuration:(NSMeasurement<NSUnitDuration *> *)hangDuration
                              metaData:(FIRCLSMockMXMetadata *)metaData
-                   applicationVersion:(NSString *)applicationVersion API_AVAILABLE(ios(14)) {
+                   applicationVersion:(NSString *)applicationVersion {
   self = [super init];
   _callStackTree = callStackTree;
   _hangDuration = hangDuration;

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockMXMetadata.h
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockMXMetadata.h
@@ -22,7 +22,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-API_AVAILABLE(ios(13))
 @interface FIRCLSMockMXMetadata : MXMetaData
 
 - (instancetype)initWithRegionFormat:(NSString *)regionFormat

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockMetricKitManager.m
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockMetricKitManager.m
@@ -46,7 +46,7 @@
 
 // This mock skips the normal flow of resolving the metricKitDataAvailable promise if there are no
 // fatal reports available on the device but otherwise registers as normal.
-- (void)registerMetricKitManager API_AVAILABLE(ios(14)) {
+- (void)registerMetricKitManager {
   [[MXMetricManager sharedManager] addSubscriber:self];
   self.metricKitDataAvailable = [FBLPromise pendingPromise];
 


### PR DESCRIPTION
Recommend hiding whitespace: https://github.com/firebase/firebase-ios-sdk/pull/16309/changes?w=1

Remove availability checks that are no longer needed since our deployment targets have since been raised to iOS 15.

#no-changelog