### PR TITLE
chore(gemfile): concurrent-ruby >= 1.3.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,5 @@ source 'https://rubygems.org'
 gem 'cocoapods', '1.16.2'
 gem 'cocoapods-generate', '2.2.5'
 gem 'danger', '9.5.3'
+
+gem "concurrent-ruby", ">= 1.3.7"

--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,3 @@ source 'https://rubygems.org'
 gem 'cocoapods', '1.16.2'
 gem 'cocoapods-generate', '2.2.5'
 gem 'danger', '9.5.3'
-
-gem "concurrent-ruby", ">= 1.3.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (2.5.5)
     cork (0.3.0)
       colored2 (~> 3.1)
@@ -162,6 +162,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (= 1.16.2)
   cocoapods-generate (= 2.2.5)
+  concurrent-ruby (>= 1.3.7)
   danger (= 9.5.3)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,6 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (= 1.16.2)
   cocoapods-generate (= 2.2.5)
-  concurrent-ruby (>= 1.3.7)
   danger (= 9.5.3)
 
 BUNDLED WITH


### PR DESCRIPTION
#no-changelog