### PR TITLE
[Infra] Fix danger workflow failure

### DIFF
--- a/.github/workflows/infra.danger.yml
+++ b/.github/workflows/infra.danger.yml
@@ -26,10 +26,9 @@ jobs:
       with:
         app-id: ${{ secrets.DANGER_APP_ID }}
         private-key: ${{ secrets.DANGER_APP_PRIVATE_KEY }}
-        permissions:
-          contents: read
-          issues: write
-          pull-requests: write
+        permission-contents: read
+        permission-issues: write
+        permission-pull-requests: write
 
     - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler

--- a/.github/workflows/infra.danger.yml
+++ b/.github/workflows/infra.danger.yml
@@ -22,13 +22,10 @@ jobs:
 
     - name: Generate GitHub App Token
       id: generate-token
-      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf #v2.2.1
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         app-id: ${{ secrets.DANGER_APP_ID }}
         private-key: ${{ secrets.DANGER_APP_PRIVATE_KEY }}
-        permission-contents: read
-        permission-issues: write
-        permission-pull-requests: write
 
     - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler


### PR DESCRIPTION
Fixes the syntax and permission issues with the Danger workflow.

### Changes:
* Upgraded `actions/create-github-app-token` from `v2.2.1` to `v3.2.0` to resolve Node 20 deprecation warning.
* Removed specific `permission-*` inputs to let the action default to the GitHub App installation's pre-configured permissions, resolving the `The permissions requested are not granted to this installation` error.