### PR TITLE
[Firebase AI Logic] Fix GenerateContentResponse decode failure when citation endIndex is missing

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- [fixed] Fixed a decoding failure in `GenerateContentResponse` when the Vertex AI
+  backend returns citation metadata with a missing `endIndex`. (#16328)
 - [fixed] Fixed an issue where `generateContentStream` could stall indefinitely
   on mid-stream network drops. (#16298)
 - [fixed] Fixed a resource leak where background network requests would

--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -684,14 +684,9 @@ extension CitationMetadata: Decodable {
   public init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
-    // Decode for Google API if `citationSources` key is present.
-    let decodedCitations: [Citation]
-    if container.contains(.citationSources) {
-      decodedCitations = try container.decode([Citation].self, forKey: .citationSources)
-    } else { // Fallback to default Vertex AI decoding.
-      decodedCitations = try container.decode([Citation].self, forKey: .citations)
-    }
-    citations = decodedCitations.filter { !$0.isEmpty }
+    let sources = try container.decodeIfPresent([Citation].self, forKey: .citationSources)
+    let vertexCitations = try container.decodeIfPresent([Citation].self, forKey: .citations)
+    citations = (sources ?? vertexCitations ?? []).filter { !$0.isEmpty }
   }
 }
 

--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -684,9 +684,10 @@ extension CitationMetadata: Decodable {
   public init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
-    let sources = try container.decodeIfPresent([Citation].self, forKey: .citationSources)
-    let vertexCitations = try container.decodeIfPresent([Citation].self, forKey: .citations)
-    citations = (sources ?? vertexCitations ?? []).filter { !$0.isEmpty }
+    let decodedCitations = try container.decodeIfPresent([Citation].self, forKey: .citationSources)
+      ?? container.decodeIfPresent([Citation].self, forKey: .citations)
+      ?? []
+    citations = decodedCitations.filter { !$0.isEmpty }
   }
 }
 

--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -685,13 +685,13 @@ extension CitationMetadata: Decodable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
     // Decode for Google API if `citationSources` key is present.
+    let decodedCitations: [Citation]
     if container.contains(.citationSources) {
-      let decodedCitations = try container.decode([Citation].self, forKey: .citationSources)
-      citations = decodedCitations.filter { !$0.isEmpty }
+      decodedCitations = try container.decode([Citation].self, forKey: .citationSources)
     } else { // Fallback to default Vertex AI decoding.
-      let decodedCitations = try container.decode([Citation].self, forKey: .citations)
-      citations = decodedCitations.filter { !$0.isEmpty }
+      decodedCitations = try container.decode([Citation].self, forKey: .citations)
     }
+    citations = decodedCitations.filter { !$0.isEmpty }
   }
 }
 
@@ -706,7 +706,7 @@ extension Citation: Decodable {
   }
 
   var isEmpty: Bool {
-    return startIndex == 0 &&
+    startIndex == 0 &&
       endIndex == 0 &&
       uri == nil &&
       title == nil &&
@@ -716,9 +716,8 @@ extension Citation: Decodable {
 
   public init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    let parsedStartIndex = try container.decodeIfPresent(Int.self, forKey: .startIndex) ?? 0
-    startIndex = parsedStartIndex
-    endIndex = try container.decodeIfPresent(Int.self, forKey: .endIndex) ?? parsedStartIndex
+    startIndex = try container.decodeIfPresent(Int.self, forKey: .startIndex) ?? 0
+    endIndex = try container.decodeIfPresent(Int.self, forKey: .endIndex) ?? startIndex
 
     if let uri = try container.decodeIfPresent(String.self, forKey: .uri), !uri.isEmpty {
       self.uri = uri

--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -706,7 +706,7 @@ extension Citation: Decodable {
   public init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     startIndex = try container.decodeIfPresent(Int.self, forKey: .startIndex) ?? 0
-    endIndex = try container.decode(Int.self, forKey: .endIndex)
+    endIndex = try container.decodeIfPresent(Int.self, forKey: .endIndex) ?? 0
 
     if let uri = try container.decodeIfPresent(String.self, forKey: .uri), !uri.isEmpty {
       self.uri = uri

--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -686,9 +686,11 @@ extension CitationMetadata: Decodable {
 
     // Decode for Google API if `citationSources` key is present.
     if container.contains(.citationSources) {
-      citations = try container.decode([Citation].self, forKey: .citationSources)
+      let decodedCitations = try container.decode([Citation].self, forKey: .citationSources)
+      citations = decodedCitations.filter { !$0.isEmpty }
     } else { // Fallback to default Vertex AI decoding.
-      citations = try container.decode([Citation].self, forKey: .citations)
+      let decodedCitations = try container.decode([Citation].self, forKey: .citations)
+      citations = decodedCitations.filter { !$0.isEmpty }
     }
   }
 }
@@ -703,10 +705,20 @@ extension Citation: Decodable {
     case publicationDate
   }
 
+  var isEmpty: Bool {
+    return startIndex == 0 &&
+      endIndex == 0 &&
+      uri == nil &&
+      title == nil &&
+      license == nil &&
+      publicationDate == nil
+  }
+
   public init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    startIndex = try container.decodeIfPresent(Int.self, forKey: .startIndex) ?? 0
-    endIndex = try container.decodeIfPresent(Int.self, forKey: .endIndex) ?? 0
+    let parsedStartIndex = try container.decodeIfPresent(Int.self, forKey: .startIndex) ?? 0
+    startIndex = parsedStartIndex
+    endIndex = try container.decodeIfPresent(Int.self, forKey: .endIndex) ?? parsedStartIndex
 
     if let uri = try container.decodeIfPresent(String.self, forKey: .uri), !uri.isEmpty {
       self.uri = uri

--- a/FirebaseAI/Tests/Unit/Types/CitationTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/CitationTests.swift
@@ -99,7 +99,7 @@ final class CitationTests: XCTestCase {
     XCTAssertNil(citation.publicationDate)
   }
 
-  func testDecodeCitation_missingEndIndex_throws() throws {
+  func testDecodeCitation_missingEndIndex_success() throws {
     let json = """
     {
       "startIndex" : 10
@@ -107,6 +107,8 @@ final class CitationTests: XCTestCase {
     """
     let jsonData = try XCTUnwrap(json.data(using: .utf8))
 
-    XCTAssertThrowsError(try decoder.decode(Citation.self, from: jsonData))
+    let citation = try decoder.decode(Citation.self, from: jsonData)
+    XCTAssertEqual(citation.startIndex, 10)
+    XCTAssertEqual(citation.endIndex, 0)
   }
 }

--- a/FirebaseAI/Tests/Unit/Types/CitationTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/CitationTests.swift
@@ -109,6 +109,6 @@ final class CitationTests: XCTestCase {
 
     let citation = try decoder.decode(Citation.self, from: jsonData)
     XCTAssertEqual(citation.startIndex, 10)
-    XCTAssertEqual(citation.endIndex, 0)
+    XCTAssertEqual(citation.endIndex, 10)
   }
 }

--- a/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
@@ -395,10 +395,8 @@ final class GenerateContentResponseTests: XCTestCase {
 
     XCTAssertEqual(response.candidates.count, 1)
     let candidate = try XCTUnwrap(response.candidates.first)
-    let citation = try XCTUnwrap(candidate.citationMetadata?.citations.first)
-    XCTAssertNil(citation.uri)
-    XCTAssertEqual(citation.endIndex, 0)
-    XCTAssertEqual(citation.startIndex, 0)
+    let citations = try XCTUnwrap(candidate.citationMetadata?.citations)
+    XCTAssertTrue(citations.isEmpty)
   }
 
   // MARK: - Candidate.isEmpty

--- a/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GenerateContentResponseTests.swift
@@ -343,6 +343,64 @@ final class GenerateContentResponseTests: XCTestCase {
     }
   }
 
+  func testDecodeGenerateContentResponse_missingCitationEndIndex_success() throws {
+    let json = """
+    {
+      "candidates": [
+        {
+          "content": { "role": "model", "parts": [ { "text": "Some text." } ] },
+          "finishReason": "STOP",
+          "citationMetadata": {
+            "citations": [
+              {
+                "uri": "https://example.com/source"
+              }
+            ]
+          }
+        }
+      ]
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try jsonDecoder.decode(GenerateContentResponse.self, from: jsonData)
+
+    XCTAssertEqual(response.candidates.count, 1)
+    let candidate = try XCTUnwrap(response.candidates.first)
+    let citation = try XCTUnwrap(candidate.citationMetadata?.citations.first)
+    XCTAssertEqual(citation.uri, "https://example.com/source")
+    XCTAssertEqual(citation.endIndex, 0)
+    XCTAssertEqual(citation.startIndex, 0)
+  }
+
+  func testDecodeGenerateContentResponse_emptyCitation_success() throws {
+    let json = """
+    {
+      "candidates": [
+        {
+          "content": { "role": "model", "parts": [ { "text": "Some text." } ] },
+          "finishReason": "STOP",
+          "citationMetadata": {
+            "citations": [
+              {}
+            ]
+          }
+        }
+      ]
+    }
+    """
+    let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try jsonDecoder.decode(GenerateContentResponse.self, from: jsonData)
+
+    XCTAssertEqual(response.candidates.count, 1)
+    let candidate = try XCTUnwrap(response.candidates.first)
+    let citation = try XCTUnwrap(candidate.citationMetadata?.citations.first)
+    XCTAssertNil(citation.uri)
+    XCTAssertEqual(citation.endIndex, 0)
+    XCTAssertEqual(citation.startIndex, 0)
+  }
+
   // MARK: - Candidate.isEmpty
 
   func testCandidateIsEmpty_allEmpty_isTrue() throws {


### PR DESCRIPTION
Fixes #16328

### Description
When using `generateContent` with the Vertex AI backend, the SDK fails to decode the entire `GenerateContentResponse` if the response includes citation metadata whose citation entries omit `endIndex`. This happens because `Citation.endIndex` was decoded as a required key, throwing a `DecodingError.keyNotFound` error and aborting the entire response decoding.

This PR makes `Citation.endIndex` optional by decoding it using `decodeIfPresent(...) ?? 0`, matching the behavior of `startIndex` and grounding `Segment.endIndex`.

### Proposed Changes:
* Update `Citation` decodable initializer in `GenerateContentResponse.swift` to decode `endIndex` with `decodeIfPresent(...) ?? 0`.
* Add unit tests to `GenerateContentResponseTests.swift` to verify decoding behavior when `endIndex` is missing or when citation is empty.
* Update `FirebaseAI/CHANGELOG.md`.