### PR TITLE
chore(m183): update changelogs

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.16.0
 - [fixed] Fixed a decoding failure in `GenerateContentResponse` when the Vertex AI
   backend returns citation metadata with a missing `endIndex`. (#16328)
 - [fixed] Fixed an issue where `generateContentStream` could stall indefinitely

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.16.0
 - [changed] Changed error message for missing `FirebaseApp.configure()` to
   properly articulate supported methods. (#16294)
 

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.16.0
 - [fixed] Refactored the integrated OAuth sign in UI to not rely on
   the deprecated `UIScreen.main.bounds` API for Mac Catalyst rendering.
   (#16274)

--- a/FirebaseInstallations/CHANGELOG.md
+++ b/FirebaseInstallations/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.16.0
 - [changed] Changed error message for missing `FirebaseApp.configure()` to
   properly articulate supported methods. (#16294)
 

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.16.0
 - [fixed] Fixed a crash in `FPRMemoryGaugeCollector` by collecting memory usage
   with `task_info(TASK_VM_INFO)` instead of `malloc_zone_statistics()`, which
   could abort the process inside the malloc subsystem on devices using the XZM

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.16.0
 - [changed] Migrates the network connectivity monitoring implementation for
   Apple platforms from the legacy SCNetworkReachability API to the modern
   NWPathMonitor API.


### PR DESCRIPTION
This PR updates the changelogs for the m183 release, such that all the releasing changes have been moved into the `12.16.0` section to be ready for release note generation.