### PR TITLE
fix(ci): prioritize SpecsStaging over SpecsTesting in NOTICES generation

### DIFF
--- a/.github/workflows/infra.notice_generation.yml
+++ b/.github/workflows/infra.notice_generation.yml
@@ -43,7 +43,7 @@ jobs:
       uses: ./.github/actions/notices_generation/
       with:
         pods: ${{ env.PODS }}
-        sources: "https://github.com/firebase/SpecsTesting,https://github.com/firebase/SpecsStaging,https://cdn.cocoapods.org"
+        sources: "https://github.com/firebase/SpecsStaging,https://github.com/firebase/SpecsTesting,https://cdn.cocoapods.org"
         # This should match the highest minimum supported iOS version.
         min-ios-version: "15.0"
         search-local-pod-version: true

--- a/ReleaseTooling/Sources/PodspecsTester/main.swift
+++ b/ReleaseTooling/Sources/PodspecsTester/main.swift
@@ -63,7 +63,7 @@ struct PodspecsTester: ParsableCommand {
       }
     }.joined(separator: " ")
     let command =
-      "pod spec lint \(spec) \(arguments) --sources=https://github.com/firebase/SpecsTesting,https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/"
+      "pod spec lint \(spec) \(arguments) --sources=https://github.com/firebase/SpecsStaging.git,https://github.com/firebase/SpecsTesting,https://cdn.cocoapods.org/"
     print(command)
     let result = Shell.executeCommandFromScript(
       command,


### PR DESCRIPTION
When CocoaPods resolves a version string that exists in multiple remote repositories, it breaks the tie by trusting the repository that appears first in its sources list. By listing SpecsStaging first, we guarantee that whenever an artifact is officially promoted to staging, it immediately shadows any automated, experimental, or malformed artifacts of the exact same version lingering in SpecsTesting. Newer preview versions in SpecsTesting are unharmed and still resolved.

Test run in #16345

After this merges, I'll manually trigger a clean run of the NOTICES generator.

#no-changelog