### PR TITLE
Fix absl::string_view nullptr crash and binary truncation in StringFormat

### DIFF
--- a/Firestore/core/src/util/string_format.cc
+++ b/Firestore/core/src/util/string_format.cc
@@ -57,8 +57,7 @@ __attribute__((no_sanitize_address)) std::string StringFormatPieces(
     if (pieces_iter == pieces_end) {
       dest->append(kMissing);
     } else {
-      std::string hex =
-          absl::BytesToHexString(absl::string_view(pieces_iter->data()));
+      std::string hex = absl::BytesToHexString(*pieces_iter);
       dest->append(hex.data(), hex.size());
       ++pieces_iter;
     }

--- a/Firestore/core/test/unit/util/string_format_test.cc
+++ b/Firestore/core/test/unit/util/string_format_test.cc
@@ -101,6 +101,7 @@ TEST(StringFormatTest, Bool) {
 TEST(StringFormatTest, NullPointer) {
   // pointers implicitly convert to bool. Make sure this doesn't happen here.
   EXPECT_EQ("Hello null", StringFormat("Hello %s", nullptr));
+  EXPECT_EQ("test=6e756c6c", StringFormat("test=%x", nullptr));
 }
 
 TEST(StringFormatTest, NonNullPointer) {
@@ -125,6 +126,8 @@ TEST(StringFormatTest, Mixed) {
 
 TEST(StringFormatTest, Hex) {
   EXPECT_EQ("test=42", StringFormat("test=%x", "B"));
+  EXPECT_EQ("test=", StringFormat("test=%x", absl::string_view()));
+  EXPECT_EQ("test=0041", StringFormat("test=%x", absl::string_view("\0A", 2)));
 }
 
 TEST(StringFormatTest, Literal) {

--- a/Firestore/core/test/unit/util/string_format_test.cc
+++ b/Firestore/core/test/unit/util/string_format_test.cc
@@ -20,8 +20,8 @@
 #include <sstream>
 #include <string>
 
-#include "absl/strings/string_view.h"
 #include "absl/strings/escaping.h"
+#include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -130,7 +130,7 @@ TEST(StringFormatTest, Hex) {
   EXPECT_EQ("test=", StringFormat("test=%x", absl::string_view()));
   EXPECT_EQ("test=0041", StringFormat("test=%x", absl::string_view("\0A", 2)));
 
-  char buffer[] = {'A', 'B'}; // no null terminator
+  char buffer[] = {'A', 'B'};  // no null terminator
   absl::string_view slice(buffer, 2);
   EXPECT_EQ("test=4142", StringFormat("test=%x", slice));
 }

--- a/Firestore/core/test/unit/util/string_format_test.cc
+++ b/Firestore/core/test/unit/util/string_format_test.cc
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "absl/strings/string_view.h"
+#include "absl/strings/escaping.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -128,6 +129,16 @@ TEST(StringFormatTest, Hex) {
   EXPECT_EQ("test=42", StringFormat("test=%x", "B"));
   EXPECT_EQ("test=", StringFormat("test=%x", absl::string_view()));
   EXPECT_EQ("test=0041", StringFormat("test=%x", absl::string_view("\0A", 2)));
+
+  char buffer[] = {'A', 'B'}; // no null terminator
+  absl::string_view slice(buffer, 2);
+  EXPECT_EQ("test=4142", StringFormat("test=%x", slice));
+}
+
+TEST(StringFormatTest, BytesToHexStringEmpty) {
+  absl::string_view empty;
+  std::string hex = absl::BytesToHexString(empty);
+  EXPECT_EQ("", hex);
 }
 
 TEST(StringFormatTest, Literal) {


### PR DESCRIPTION
#no-changelog

Fixes a crash and correctness bug in Firestore C++ core's StringFormat utility when using the `%x` (hex) specifier.

#### Problem
The hex formatting logic constructed a temporary `absl::string_view` from `pieces_iter->data()` without specifying its length. This caused:
1. **Crashes:** Empty string views (`data() == nullptr`) crashed due to construction from `nullptr`.
2. **Data Truncation:** Binary data containing null bytes (`\0`) was truncated prematurely by implicit `strlen` checks.
3. **Over-reads:** Sliced string views without null-terminators triggered out-of-bounds reads.

#### Solution
Directly pass the existing string view object (`*pieces_iter`) to `absl::BytesToHexString` to preserve its size metadata.

#### Testing
Added test cases to `string_format_test.cc` and verified the `Firestore_Tests_iOS` test suite passes.