### PR TITLE
Add missing ABSL_CONST_INIT to variable definitions

### DIFF
--- a/Firestore/core/src/core/direction.cc
+++ b/Firestore/core/src/core/direction.cc
@@ -18,12 +18,16 @@
 
 #include <ostream>
 
+#include "absl/base/attributes.h"
+
 namespace firebase {
 namespace firestore {
 namespace core {
 
-const Direction Direction::Ascending(Direction::AscendingModifier);
-const Direction Direction::Descending(Direction::DescendingModifier);
+ABSL_CONST_INIT const Direction
+    Direction::Ascending(Direction::AscendingModifier);
+ABSL_CONST_INIT const Direction
+    Direction::Descending(Direction::DescendingModifier);
 
 std::string Direction::CanonicalId() const {
   return comparison_modifier_ == AscendingModifier ? "asc" : "desc";

--- a/Firestore/core/src/local/lru_garbage_collector.cc
+++ b/Firestore/core/src/local/lru_garbage_collector.cc
@@ -17,9 +17,11 @@
 #include "Firestore/core/src/local/lru_garbage_collector.h"
 
 #include <chrono>
+
 #include <queue>
 #include <string>
 #include <utility>
+#include "absl/base/attributes.h"
 
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
 #include "Firestore/core/src/api/settings.h"
@@ -89,7 +91,7 @@ class RollingSequenceNumberBuffer {
 
 }  // namespace
 
-const ListenSequenceNumber kListenSequenceNumberInvalid = -1;
+ABSL_CONST_INIT const ListenSequenceNumber kListenSequenceNumberInvalid = -1;
 
 LruParams LruParams::Default() {
   return LruParams{100 * 1024 * 1024, 10, 1000};

--- a/Firestore/core/test/unit/testutil/testutil.cc
+++ b/Firestore/core/test/unit/testutil/testutil.cc
@@ -17,8 +17,11 @@
 #include "Firestore/core/test/unit/testutil/testutil.h"
 
 #include <algorithm>
+#include <cstdint>
+
 #include <chrono>
 #include <set>
+#include "absl/base/attributes.h"
 
 #include "Firestore/core/include/firebase/firestore/geo_point.h"
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
@@ -93,7 +96,7 @@ constexpr const char* kDeleteSentinel = "<DELETE>";
 // the JDK (which is defined to normalize all NaNs to this value). This also
 // happens to be a common value for NAN in C++, but C++ does not require this
 // specific NaN value to be used, so we normalize.
-const uint64_t kCanonicalNanBits = 0x7ff8000000000000ULL;
+ABSL_CONST_INIT const uint64_t kCanonicalNanBits = 0x7ff8000000000000ULL;
 
 namespace details {
 


### PR DESCRIPTION
#no-changelog

This LSC is a safe update to prepare for enabling `constinit` for
`ABSL_CONST_INIT`.  See [b/193065534](http://b/193065534) (ABSL_CONST_INIT should use constinit when
C++20 is available).

C++20 `constinit` is a specifier, not an attribute, and must appear on both
declarations and definitions, unlike the attribute
`[[clang::require_constant_initialization]]`. Placed on a declaration but not
on the definition, it triggers `-Wmissing-constinit` in C++20 mode.

This CL adds `ABSL_CONST_INIT` to definitions of variables that are
declared with `ABSL_CONST_INIT`.  This macro currently expands to
`[[require_constant_initialization]]`; this CL allows it to expand to
`constinit` without triggering errors.

In some cases, if a variable was declared `ABSL_CONST_INIT const`, but defined
`constexpr`, the definition has also been changed to `ABSL_CONST_INIT const`.
This is less invasive than defining it `constexpr` and having to move the
definition to the header file.  In general, `constexpr` is preferred, but
switching to that is a larger change and out of scope for this fix.
