### PR TITLE
[ML] Deprecate FirebaseMlModelDownloader

### DIFF
--- a/.github/workflows/sdk.mlmodeldownloader.yml
+++ b/.github/workflows/sdk.mlmodeldownloader.yml
@@ -39,6 +39,7 @@ jobs:
     uses: ./.github/workflows/_cocoapods.yml
     with:
       product: FirebaseMLModelDownloader
+      allow_warnings: true
       setup_command: |
         mkdir FirebaseMLModelDownloader/Tests/Integration/Resources
         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/MLModelDownloader/GoogleService-Info.plist.gpg \
@@ -53,7 +54,7 @@ jobs:
     with:
       product: FirebaseMLModelDownloader
       platforms: '[ "ios", "tvos", "macos" ]'
-      flags: '[ "--use-static-frameworks" ]'
+      flags: '[ "--use-static-frameworks --allow-warnings" ]'
       setup_command: |
         scripts/configure_test_keychain.sh
         mkdir FirebaseMLModelDownloader/Tests/Integration/Resources

--- a/FirebaseMLModelDownloader.podspec
+++ b/FirebaseMLModelDownloader.podspec
@@ -2,6 +2,7 @@ Pod::Spec.new do |s|
   s.name             = 'FirebaseMLModelDownloader'
   s.version          = '12.16.0-beta'
   s.summary          = 'Firebase ML Model Downloader'
+  s.deprecated       = true
 
   s.description      = <<-DESC
   This is the new ML Model Downloader CocoaPod.

--- a/FirebaseMLModelDownloader/CHANGELOG.md
+++ b/FirebaseMLModelDownloader/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [deprecated] FirebaseMLModelDownloader has been deprecated. The service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml.
+- [deprecated] Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage.
 
 # 12.8.0
 - [fixed] Remove unused legacy telemetry along with the large swift-protobuf dependency.

--- a/FirebaseMLModelDownloader/CHANGELOG.md
+++ b/FirebaseMLModelDownloader/CHANGELOG.md
@@ -1,2 +1,5 @@
+# Unreleased
+- [deprecated] FirebaseMLModelDownloader has been deprecated. The service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml.
+
 # 12.8.0
 - [fixed] Remove unused legacy telemetry along with the large swift-protobuf dependency.

--- a/FirebaseMLModelDownloader/Sources/CustomModel.swift
+++ b/FirebaseMLModelDownloader/Sources/CustomModel.swift
@@ -15,6 +15,11 @@
 import Foundation
 
 /// A custom model that is stored remotely on the server and downloaded to the device.
+@available(
+  *,
+  deprecated,
+  message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+)
 public struct CustomModel: Hashable {
   /// Name of the model.
   public let name: String

--- a/FirebaseMLModelDownloader/Sources/CustomModel.swift
+++ b/FirebaseMLModelDownloader/Sources/CustomModel.swift
@@ -18,7 +18,7 @@ import Foundation
 @available(
   *,
   deprecated,
-  message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+  message: "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
 )
 public struct CustomModel: Hashable {
   /// Name of the model.

--- a/FirebaseMLModelDownloader/Sources/ModelDownloadConditions.swift
+++ b/FirebaseMLModelDownloader/Sources/ModelDownloadConditions.swift
@@ -18,7 +18,7 @@ import Foundation
 @available(
   *,
   deprecated,
-  message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+  message: "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
 )
 public struct ModelDownloadConditions {
   let allowsCellularAccess: Bool

--- a/FirebaseMLModelDownloader/Sources/ModelDownloadConditions.swift
+++ b/FirebaseMLModelDownloader/Sources/ModelDownloadConditions.swift
@@ -15,12 +15,22 @@
 import Foundation
 
 /// Model download conditions.
+@available(
+  *,
+  deprecated,
+  message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+)
 public struct ModelDownloadConditions {
   let allowsCellularAccess: Bool
 
   /// Conditions that need to be met to start a model file download.
   /// - Parameter allowsCellularAccess: Allow model downloading on a cellular connection. Default is
   /// `true`.
+  @available(
+    *,
+    deprecated,
+    message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+  )
   public init(allowsCellularAccess: Bool = true) {
     self.allowsCellularAccess = allowsCellularAccess
   }

--- a/FirebaseMLModelDownloader/Sources/ModelDownloadConditions.swift
+++ b/FirebaseMLModelDownloader/Sources/ModelDownloadConditions.swift
@@ -26,11 +26,6 @@ public struct ModelDownloadConditions {
   /// Conditions that need to be met to start a model file download.
   /// - Parameter allowsCellularAccess: Allow model downloading on a cellular connection. Default is
   /// `true`.
-  @available(
-    *,
-    deprecated,
-    message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
-  )
   public init(allowsCellularAccess: Bool = true) {
     self.allowsCellularAccess = allowsCellularAccess
   }

--- a/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
+++ b/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
@@ -22,6 +22,11 @@ import Foundation
 #endif // SWIFT_PACKAGE
 
 /// Possible ways to get a custom model.
+@available(
+  *,
+  deprecated,
+  message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+)
 public enum ModelDownloadType {
   /// Get local model stored on device if available. If no local model on device, this is the same
   /// as `latestModel`.
@@ -35,6 +40,11 @@ public enum ModelDownloadType {
 }
 
 /// Downloader to manage custom model downloads.
+@available(
+  *,
+  deprecated,
+  message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+)
 public class ModelDownloader {
   /// Name of the app associated with this instance of ModelDownloader.
   private let appName: String
@@ -99,6 +109,11 @@ public class ModelDownloader {
   }
 
   /// Model downloader with default app.
+  @available(
+    *,
+    deprecated,
+    message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+  )
   public static func modelDownloader() -> ModelDownloader {
     guard let defaultApp = FirebaseApp.app() else {
       fatalError(ModelDownloader.ErrorDescription.defaultAppNotConfigured)
@@ -107,6 +122,11 @@ public class ModelDownloader {
   }
 
   /// Model Downloader with custom app.
+  @available(
+    *,
+    deprecated,
+    message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+  )
   public static func modelDownloader(app: FirebaseApp) -> ModelDownloader {
     if let downloader = modelDownloaderDictionary[app.name] {
       DeviceLogger.logEvent(level: .debug,
@@ -133,6 +153,11 @@ public class ModelDownloader {
   /// download progress.
   ///   - completion: Returns either a `CustomModel` on success, or a `DownloadError` on failure, at
   /// the end of a model download.
+  @available(
+    *,
+    deprecated,
+    message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+  )
   public func getModel(name modelName: String,
                        downloadType: ModelDownloadType,
                        conditions: ModelDownloadConditions,
@@ -209,6 +234,11 @@ public class ModelDownloader {
   /// Gets the set of all downloaded models saved on device.
   /// - Parameter completion: Returns either a set of `CustomModel` models on success, or a
   /// `DownloadedModelError` on failure.
+  @available(
+    *,
+    deprecated,
+    message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+  )
   public func listDownloadedModels(completion: @escaping (Result<Set<CustomModel>,
     DownloadedModelError>) -> Void) {
     do {
@@ -274,6 +304,11 @@ public class ModelDownloader {
   ///   - modelName: The name of the model, matching Firebase console and already downloaded to
   /// device.
   ///   - completion: Returns a `DownloadedModelError` on failure.
+  @available(
+    *,
+    deprecated,
+    message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+  )
   public func deleteDownloadedModel(name modelName: String,
                                     completion: @escaping (Result<Void, DownloadedModelError>)
                                       -> Void) {
@@ -504,6 +539,11 @@ extension ModelDownloader {
 }
 
 /// Possible errors with model downloading.
+@available(
+  *,
+  deprecated,
+  message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+)
 public enum DownloadError: Error, Equatable {
   /// No model with this name exists on server.
   case notFound
@@ -524,6 +564,11 @@ public enum DownloadError: Error, Equatable {
 }
 
 /// Possible errors with locating a model file on device.
+@available(
+  *,
+  deprecated,
+  message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+)
 public enum DownloadedModelError: Error {
   /// No model with this name exists on device.
   case notFound

--- a/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
+++ b/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
@@ -109,11 +109,6 @@ public class ModelDownloader {
   }
 
   /// Model downloader with default app.
-  @available(
-    *,
-    deprecated,
-    message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
-  )
   public static func modelDownloader() -> ModelDownloader {
     guard let defaultApp = FirebaseApp.app() else {
       fatalError(ModelDownloader.ErrorDescription.defaultAppNotConfigured)
@@ -122,11 +117,6 @@ public class ModelDownloader {
   }
 
   /// Model Downloader with custom app.
-  @available(
-    *,
-    deprecated,
-    message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
-  )
   public static func modelDownloader(app: FirebaseApp) -> ModelDownloader {
     if let downloader = modelDownloaderDictionary[app.name] {
       DeviceLogger.logEvent(level: .debug,
@@ -153,11 +143,6 @@ public class ModelDownloader {
   /// download progress.
   ///   - completion: Returns either a `CustomModel` on success, or a `DownloadError` on failure, at
   /// the end of a model download.
-  @available(
-    *,
-    deprecated,
-    message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
-  )
   public func getModel(name modelName: String,
                        downloadType: ModelDownloadType,
                        conditions: ModelDownloadConditions,
@@ -234,11 +219,6 @@ public class ModelDownloader {
   /// Gets the set of all downloaded models saved on device.
   /// - Parameter completion: Returns either a set of `CustomModel` models on success, or a
   /// `DownloadedModelError` on failure.
-  @available(
-    *,
-    deprecated,
-    message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
-  )
   public func listDownloadedModels(completion: @escaping (Result<Set<CustomModel>,
     DownloadedModelError>) -> Void) {
     do {
@@ -304,11 +284,6 @@ public class ModelDownloader {
   ///   - modelName: The name of the model, matching Firebase console and already downloaded to
   /// device.
   ///   - completion: Returns a `DownloadedModelError` on failure.
-  @available(
-    *,
-    deprecated,
-    message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
-  )
   public func deleteDownloadedModel(name modelName: String,
                                     completion: @escaping (Result<Void, DownloadedModelError>)
                                       -> Void) {

--- a/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
+++ b/FirebaseMLModelDownloader/Sources/ModelDownloader.swift
@@ -25,7 +25,7 @@ import Foundation
 @available(
   *,
   deprecated,
-  message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+  message: "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
 )
 public enum ModelDownloadType {
   /// Get local model stored on device if available. If no local model on device, this is the same
@@ -43,7 +43,7 @@ public enum ModelDownloadType {
 @available(
   *,
   deprecated,
-  message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+  message: "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
 )
 public class ModelDownloader {
   /// Name of the app associated with this instance of ModelDownloader.
@@ -517,7 +517,7 @@ extension ModelDownloader {
 @available(
   *,
   deprecated,
-  message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+  message: "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
 )
 public enum DownloadError: Error, Equatable {
   /// No model with this name exists on server.
@@ -542,7 +542,7 @@ public enum DownloadError: Error, Equatable {
 @available(
   *,
   deprecated,
-  message: "FirebaseMLModelDownloader is deprecated and the service will shut down on June 15, 2027. Use other custom model downloading alternatives. For more info, see https://firebase.google.com/docs/ml"
+  message: "Firebase ML is deprecated and will be shut down on June 15, 2027. To host custom models, you must migrate to another solution. You can use Cloud Storage for Firebase as an alternative for hosting custom models. For more info, see https://firebase.google.com/docs/ml/migrate-to-cloud-storage"
 )
 public enum DownloadedModelError: Error {
   /// No model with this name exists on device.

--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -51,7 +51,7 @@ public let shared = Manifest(
     Pod("FirebaseMessaging", zip: true),
     Pod("FirebasePerformance", platforms: ["ios", "tvos"], zip: true),
     Pod("FirebaseStorage", zip: true),
-    Pod("FirebaseMLModelDownloader", isBeta: true, zip: true),
+    Pod("FirebaseMLModelDownloader", isBeta: true, allowWarnings: true, zip: true),
     Pod("Firebase", allowWarnings: true, platforms: ["ios", "tvos", "macos"], zip: true),
     Pod("FirebaseCombineSwift", releasing: false, zip: false),
   ]


### PR DESCRIPTION
Deprecate the FirebaseMLModelDownloader library within the Firebase Apple SDK, reflecting its scheduled shutdown on June 15, 2027. 

- Mark the CocoaPod as deprecated in its podspec
- Add a deprecation notice to the changelog
- Annotate public Swift APIs with `@available(*, deprecated, ...)`
- Update the release tooling manifest to allow warnings for this pod