### PR TITLE
Fix StorageUploadTask cancel

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixed a race condition in Storage task cancellation and improved Swift 6 strict concurrency compliance for `StorageTask`. (#16353)
+
 # 12.12.1
 - [fixed] Fixed `InstanceCache` keying by bucket only, which caused named apps sharing a
   storage bucket with the default app to use the wrong auth context. (#16039)

--- a/FirebaseStorage/Sources/Internal/StorageInternalTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageInternalTask.swift
@@ -22,7 +22,7 @@ import Foundation
 
 /// Implement StorageTasks that are not directly exposed via the public API.
 @preconcurrency
-class StorageInternalTask: StorageTask {
+class StorageInternalTask: StorageTask, @unchecked Sendable {
   private var fetcher: GTMSessionFetcher?
 
   @discardableResult
@@ -66,5 +66,3 @@ class StorageInternalTask: StorageTask {
     self.fetcher?.stopFetching()
   }
 }
-
-extension StorageInternalTask: @unchecked Sendable {}

--- a/FirebaseStorage/Sources/Internal/StorageInternalTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageInternalTask.swift
@@ -66,3 +66,5 @@ class StorageInternalTask: StorageTask {
     self.fetcher?.stopFetching()
   }
 }
+
+extension StorageInternalTask: @unchecked Sendable {}

--- a/FirebaseStorage/Sources/Internal/StorageInternalTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageInternalTask.swift
@@ -47,10 +47,12 @@ class StorageInternalTask: StorageTask, @unchecked Sendable {
 
         let fetcher = fetcherService.fetcher(with: request)
         fetcher.comment = fetcherComment
-        self.fetcher = fetcher
+        self.stateLock.withLock {
+          self.fetcher = fetcher
+        }
         let callbackQueue = reference.storage.callbackQueue
         do {
-          let data = try await self.fetcher?.beginFetch()
+          let data = try await fetcher.beginFetch()
           callbackQueue.async {
             completion?(data, nil)
           }

--- a/FirebaseStorage/Sources/Internal/StorageInternalTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageInternalTask.swift
@@ -36,7 +36,9 @@ class StorageInternalTask: StorageTask, @unchecked Sendable {
 
     // Prepare a task and begins execution.
     dispatchQueue.async { [self] in
-      self.state = .queueing
+      stateLock.withLock {
+        self.state = .queueing
+      }
       Task {
         let fetcherService = await StorageFetcherService.shared.service(reference.storage)
         var request = request ?? self.baseRequest

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -47,22 +47,25 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
    * Pauses a task currently in progress. Calling this on a paused task has no effect.
    */
   @objc open func pause() {
-    dispatchQueue.async { [weak self] in
-      guard let self = self else { return }
-      if self.state == .paused || self.state == .pausing {
-        return
-      }
-      self.state = .pausing
-      // Use the resume callback to confirm pause status since it always runs after the last
-      // NSURLSession update.
-      self.fetcher?.resumeDataBlock = { [weak self] (data: Data) in
-        guard let self = self else { return }
-        self.downloadData = data
-        self.state = .paused
-        self.fire(for: .pause, snapshot: self.snapshot)
-      }
-      self.fetcher?.stopFetching()
+    stateLock.lock()
+    if state == .paused || state == .pausing || state == .success || state == .cancelled || state ==
+      .failed {
+      stateLock.unlock()
+      return
     }
+    state = .pausing
+    // Use the resume callback to confirm pause status since it always runs after the last
+    // NSURLSession update.
+    fetcher?.resumeDataBlock = { [weak self] (data: Data) in
+      guard let self = self else { return }
+      self.stateLock.lock()
+      self.downloadData = data
+      self.state = .paused
+      self.stateLock.unlock()
+      self.fire(for: .pause, snapshot: self.snapshot)
+    }
+    fetcher?.stopFetching()
+    stateLock.unlock()
   }
 
   /**
@@ -76,14 +79,28 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
    * Resumes a paused task. Calling this on a running task has no effect.
    */
   @objc open func resume() {
-    dispatchQueue.async { [weak self] in
-      guard let self = self else { return }
-      self.state = .resuming
-      self.fire(for: .resume, snapshot: self.snapshot)
-      self.state = .running
-      Task {
-        await self.enqueueImplementation(resumeWith: self.downloadData)
-      }
+    stateLock.lock()
+    if state == .running || state == .resuming || state == .success || state == .cancelled ||
+      state ==
+      .failed {
+      stateLock.unlock()
+      return
+    }
+    state = .resuming
+    stateLock.unlock()
+
+    fire(for: .resume, snapshot: snapshot)
+
+    stateLock.lock()
+    if state == .cancelled || state == .paused || state == .pausing {
+      stateLock.unlock()
+      return
+    }
+    state = .running
+    stateLock.unlock()
+
+    Task {
+      await self.enqueueImplementation(resumeWith: self.downloadData)
     }
   }
 
@@ -106,7 +123,9 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
   }
 
   private func enqueueImplementation(resumeWith resumeData: Data? = nil) async {
+    stateLock.lock()
     state = .queueing
+    stateLock.unlock()
 
     var request = baseRequest
     request.httpMethod = "GET"
@@ -134,78 +153,123 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
                                                      totalBytesWritten: Int64,
                                                      totalBytesExpectedToWrite: Int64) in
           guard let self = self else { return }
-          self.dispatchQueue.async { [weak self] in
-            guard let self = self else { return }
-            if self.state == .cancelled || self.state == .pausing || self
-              .state == .paused { return }
-            self.state = .progress
-            self.progress.completedUnitCount = totalBytesWritten
-            self.progress.totalUnitCount = totalBytesExpectedToWrite
-            self.fire(for: .progress, snapshot: self.snapshot)
-            self.state = .running
+          self.stateLock.lock()
+          if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+            self.stateLock.unlock()
+            return
           }
+          self.state = .progress
+          self.progress.completedUnitCount = totalBytesWritten
+          self.progress.totalUnitCount = totalBytesExpectedToWrite
+          self.stateLock.unlock()
+
+          self.fire(for: .progress, snapshot: self.snapshot)
+
+          self.stateLock.lock()
+          if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+            self.stateLock.unlock()
+            return
+          }
+          self.state = .running
+          self.stateLock.unlock()
       }
     } else {
       // Handle data downloads
       fetcher.receivedProgressBlock = { [weak self] (bytesWritten: Int64,
                                                      totalBytesWritten: Int64) in
           guard let self = self else { return }
-          self.dispatchQueue.async { [weak self] in
-            guard let self = self else { return }
-            if self.state == .cancelled || self.state == .pausing || self
-              .state == .paused { return }
-            self.state = .progress
-            self.progress.completedUnitCount = totalBytesWritten
-            if let totalLength = self.fetcher?.response?.expectedContentLength {
-              self.progress.totalUnitCount = totalLength
-            }
-            self.fire(for: .progress, snapshot: self.snapshot)
-            self.state = .running
+          self.stateLock.lock()
+          if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+            self.stateLock.unlock()
+            return
           }
+          self.state = .progress
+          self.progress.completedUnitCount = totalBytesWritten
+          if let totalLength = self.fetcher?.response?.expectedContentLength {
+            self.progress.totalUnitCount = totalLength
+          }
+          self.stateLock.unlock()
+
+          self.fire(for: .progress, snapshot: self.snapshot)
+
+          self.stateLock.lock()
+          if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+            self.stateLock.unlock()
+            return
+          }
+          self.state = .running
+          self.stateLock.unlock()
       }
     }
     self.fetcher = fetcher
+    stateLock.lock()
     state = .running
+    stateLock.unlock()
     do {
       let data = try await self.fetcher?.beginFetch()
-      dispatchQueue.async { [weak self] in
-        guard let self = self else { return }
-        if self.state == .cancelled { return }
-        // Fire last progress updates
-        self.fire(for: .progress, snapshot: self.snapshot)
+      stateLock.lock()
+      if state == .cancelled {
+        stateLock.unlock()
+        return
+      }
+      stateLock.unlock()
 
-        // Download completed successfully, fire completion callbacks
-        self.state = .success
-        if let data {
-          self.downloadData = data
-        }
-        self.fire(for: .success, snapshot: self.snapshot)
-        self.removeAllObservers()
+      // Fire last progress updates
+      fire(for: .progress, snapshot: snapshot)
+
+      // Download completed successfully, fire completion callbacks
+      stateLock.lock()
+      if state == .cancelled {
+        stateLock.unlock()
+        return
       }
+      state = .success
+      if let data {
+        downloadData = data
+      }
+      stateLock.unlock()
+
+      fire(for: .success, snapshot: snapshot)
+      removeAllObservers()
     } catch {
-      dispatchQueue.async { [weak self] in
-        guard let self = self else { return }
-        if self.state == .cancelled { return }
-        self.fire(for: .progress, snapshot: self.snapshot)
-        self.state = .failed
-        self.error = StorageErrorCode.error(
-          withServerError: error as NSError,
-          ref: self.reference
-        )
-        self.fire(for: .failure, snapshot: self.snapshot)
-        self.removeAllObservers()
+      stateLock.lock()
+      if state == .cancelled {
+        stateLock.unlock()
+        return
       }
+      stateLock.unlock()
+
+      fire(for: .progress, snapshot: snapshot)
+
+      stateLock.lock()
+      if state == .cancelled {
+        stateLock.unlock()
+        return
+      }
+      state = .failed
+      self.error = StorageErrorCode.error(
+        withServerError: error as NSError,
+        ref: reference
+      )
+      stateLock.unlock()
+
+      fire(for: .failure, snapshot: snapshot)
+      removeAllObservers()
     }
   }
 
   func cancel(withError error: NSError) {
-    dispatchQueue.async { [weak self] in
-      guard let self = self else { return }
-      self.state = .cancelled
-      self.fetcher?.stopFetching()
-      self.error = error
-      self.fire(for: .failure, snapshot: self.snapshot)
-      self.removeAllObservers()
+    stateLock.lock()
+    if state == .cancelled || state == .success || state == .failed {
+      stateLock.unlock()
+      return
     }
+    state = .cancelled
+    fetcher?.stopFetching()
+    self.error = error
+    stateLock.unlock()
+
+    fire(for: .failure, snapshot: snapshot)
+    removeAllObservers()
   }
 }

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -48,7 +48,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
    */
   @objc open func pause() {
     stateLock.withLock {
-      if state == .paused || state == .pausing || state == .success || state == .cancelled || state == .failed {
+      if state == .paused || state == .pausing || state == .success || state == .cancelled ||
+        state == .failed {
         return
       }
       state = .pausing
@@ -78,7 +79,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
    */
   @objc open func resume() {
     let shouldReturn1 = stateLock.withLock { () -> Bool in
-      if state == .running || state == .resuming || state == .success || state == .cancelled || state == .failed {
+      if state == .running || state == .resuming || state == .success || state == .cancelled ||
+        state == .failed {
         return true
       }
       state = .resuming

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -59,7 +59,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
       fetcher?.resumeDataBlock = { [weak self] (data: Data) in
         guard let self = self else { return }
         let shouldFire = self.stateLock.withLock { () -> Bool in
-          if self.state == .cancelled || self.state == .failed || self.state == .success {
+          if self.state != .pausing {
             return false
           }
           self.downloadData = data
@@ -134,7 +134,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
   private func enqueueImplementation(resumeWith resumeData: Data? = nil) async {
     let shouldProceed = stateLock.withLock { () -> Bool in
       if state == .cancelled || state == .pausing || state == .paused || state == .success ||
-         state == .failed {
+        state == .failed {
         return false
       }
       state = .queueing
@@ -170,7 +170,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
           guard let self = self else { return }
           let shouldReturn = self.stateLock.withLock { () -> Bool in
             if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
-               self.state == .success || self.state == .failed {
+              self.state == .success || self.state == .failed {
               return true
             }
             self.state = .progress
@@ -183,7 +183,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
           self.fire(for: .progress, snapshot: self.snapshot)
 
           self.stateLock.withLock {
-            if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+            if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
+              self.state == .success || self.state == .failed {
               return
             }
             self.state = .running
@@ -195,7 +196,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
                                                      totalBytesWritten: Int64) in
           guard let self = self else { return }
           let shouldReturn = self.stateLock.withLock { () -> Bool in
-            if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+            if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
+              self.state == .success || self.state == .failed {
               return true
             }
             self.state = .progress
@@ -210,7 +212,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
           self.fire(for: .progress, snapshot: self.snapshot)
 
           self.stateLock.withLock {
-            if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+            if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
+              self.state == .success || self.state == .failed {
               return
             }
             self.state = .running
@@ -231,7 +234,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
         fetcher.resumeDataBlock = { [weak self] (data: Data) in
           guard let self = self else { return }
           let shouldFire = self.stateLock.withLock { () -> Bool in
-            if self.state == .cancelled || self.state == .failed || self.state == .success {
+            if self.state != .pausing {
               return false
             }
             self.downloadData = data

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -134,49 +134,68 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
                                                      totalBytesWritten: Int64,
                                                      totalBytesExpectedToWrite: Int64) in
           guard let self = self else { return }
-          self.state = .progress
-          self.progress.completedUnitCount = totalBytesWritten
-          self.progress.totalUnitCount = totalBytesExpectedToWrite
-          self.fire(for: .progress, snapshot: self.snapshot)
-          self.state = .running
+          self.dispatchQueue.async { [weak self] in
+            guard let self = self else { return }
+            if self.state == .cancelled || self.state == .pausing || self
+              .state == .paused { return }
+            self.state = .progress
+            self.progress.completedUnitCount = totalBytesWritten
+            self.progress.totalUnitCount = totalBytesExpectedToWrite
+            self.fire(for: .progress, snapshot: self.snapshot)
+            self.state = .running
+          }
       }
     } else {
       // Handle data downloads
       fetcher.receivedProgressBlock = { [weak self] (bytesWritten: Int64,
                                                      totalBytesWritten: Int64) in
           guard let self = self else { return }
-          self.state = .progress
-          self.progress.completedUnitCount = totalBytesWritten
-          if let totalLength = self.fetcher?.response?.expectedContentLength {
-            self.progress.totalUnitCount = totalLength
+          self.dispatchQueue.async { [weak self] in
+            guard let self = self else { return }
+            if self.state == .cancelled || self.state == .pausing || self
+              .state == .paused { return }
+            self.state = .progress
+            self.progress.completedUnitCount = totalBytesWritten
+            if let totalLength = self.fetcher?.response?.expectedContentLength {
+              self.progress.totalUnitCount = totalLength
+            }
+            self.fire(for: .progress, snapshot: self.snapshot)
+            self.state = .running
           }
-          self.fire(for: .progress, snapshot: self.snapshot)
-          self.state = .running
       }
     }
     self.fetcher = fetcher
     state = .running
     do {
       let data = try await self.fetcher?.beginFetch()
-      // Fire last progress updates
-      fire(for: .progress, snapshot: snapshot)
+      dispatchQueue.async { [weak self] in
+        guard let self = self else { return }
+        if self.state == .cancelled { return }
+        // Fire last progress updates
+        self.fire(for: .progress, snapshot: self.snapshot)
 
-      // Download completed successfully, fire completion callbacks
-      state = .success
-      if let data {
-        downloadData = data
+        // Download completed successfully, fire completion callbacks
+        self.state = .success
+        if let data {
+          self.downloadData = data
+        }
+        self.fire(for: .success, snapshot: self.snapshot)
+        self.removeAllObservers()
       }
-      fire(for: .success, snapshot: snapshot)
     } catch {
-      fire(for: .progress, snapshot: snapshot)
-      state = .failed
-      self.error = StorageErrorCode.error(
-        withServerError: error as NSError,
-        ref: reference
-      )
-      fire(for: .failure, snapshot: snapshot)
+      dispatchQueue.async { [weak self] in
+        guard let self = self else { return }
+        if self.state == .cancelled { return }
+        self.fire(for: .progress, snapshot: self.snapshot)
+        self.state = .failed
+        self.error = StorageErrorCode.error(
+          withServerError: error as NSError,
+          ref: self.reference
+        )
+        self.fire(for: .failure, snapshot: self.snapshot)
+        self.removeAllObservers()
+      }
     }
-    removeAllObservers()
   }
 
   func cancel(withError error: NSError) {

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -226,8 +226,10 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
           }
       }
     }
+    var isPausing = false
     let shouldContinue = stateLock.withLock { () -> Bool in
       if state == .cancelled || state == .pausing || state == .paused {
+        isPausing = state == .pausing
         return false
       }
       self.fetcher = fetcher
@@ -235,7 +237,6 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
       return true
     }
     if !shouldContinue {
-      let isPausing = stateLock.withLock { state == .pausing }
       if isPausing {
         fetcher.resumeDataBlock = { [weak self] (data: Data) in
           guard let self = self else { return }

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -206,9 +206,9 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
       }
     } else {
       // Handle data downloads
-      fetcher.receivedProgressBlock = { [weak self] (bytesWritten: Int64,
-                                                     totalBytesWritten: Int64) in
-          guard let self = self else { return }
+      fetcher.receivedProgressBlock = { [weak self, weak fetcher] (bytesWritten: Int64,
+                                                                   totalBytesWritten: Int64) in
+          guard let self = self, let fetcher = fetcher else { return }
           var snapshotToFire: StorageTaskSnapshot?
           self.stateLock.withLock {
             if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
@@ -217,7 +217,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
             }
             self.state = .progress
             self.progress.completedUnitCount = totalBytesWritten
-            if let totalLength = self.fetcher?.response?.expectedContentLength {
+            if let totalLength = fetcher.response?.expectedContentLength {
               self.progress.totalUnitCount = totalLength
             }
             snapshotToFire = self.snapshotUnderLock()

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -47,6 +47,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
    * Pauses a task currently in progress. Calling this on a paused task has no effect.
    */
   @objc open func pause() {
+    var shouldStop = false
     stateLock.withLock {
       if state == .paused || state == .pausing || state == .success || state == .cancelled ||
         state == .failed {
@@ -63,6 +64,9 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
         }
         self.fire(for: .pause, snapshot: self.snapshot)
       }
+      shouldStop = true
+    }
+    if shouldStop {
       fetcher?.stopFetching()
     }
   }
@@ -78,12 +82,14 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
    * Resumes a paused task. Calling this on a running task has no effect.
    */
   @objc open func resume() {
+    var downloadDataToResume: Data?
     let shouldReturn1 = stateLock.withLock { () -> Bool in
       if state == .running || state == .resuming || state == .success || state == .cancelled ||
         state == .failed {
         return true
       }
       state = .resuming
+      downloadDataToResume = downloadData
       return false
     }
     if shouldReturn1 { return }
@@ -96,7 +102,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
     }
 
     Task {
-      await self.enqueueImplementation(resumeWith: self.downloadData)
+      await self.enqueueImplementation(resumeWith: downloadDataToResume)
     }
   }
 
@@ -197,8 +203,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
           }
       }
     }
-    self.fetcher = fetcher
     stateLock.withLock {
+      self.fetcher = fetcher
       state = .running
     }
     do {
@@ -245,16 +251,17 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
   }
 
   func cancel(withError error: NSError) {
-    let shouldReturn = stateLock.withLock { () -> Bool in
+    let shouldCancel = stateLock.withLock { () -> Bool in
       if state == .cancelled || state == .success || state == .failed {
-        return true
+        return false
       }
       state = .cancelled
-      fetcher?.stopFetching()
       self.error = error
-      return false
+      return true
     }
-    if shouldReturn { return }
+    if !shouldCancel { return }
+
+    fetcher?.stopFetching()
 
     fire(for: .failure, snapshot: snapshot)
     removeAllObservers()

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -58,16 +58,16 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
       // NSURLSession update.
       fetcher?.resumeDataBlock = { [weak self] (data: Data) in
         guard let self = self else { return }
-        let shouldFire = self.stateLock.withLock { () -> Bool in
-          if self.state != .pausing {
-            return false
+        var snapshotToFire: StorageTaskSnapshot?
+        self.stateLock.withLock {
+          if self.state == .pausing {
+            self.downloadData = data
+            self.state = .paused
+            snapshotToFire = self.snapshotUnderLock()
           }
-          self.downloadData = data
-          self.state = .paused
-          return true
         }
-        if shouldFire {
-          self.fire(for: .pause, snapshot: self.snapshot)
+        if let snapshotToFire {
+          self.fire(for: .pause, snapshot: snapshotToFire)
         }
       }
       fetcherToStop = fetcher
@@ -87,6 +87,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
    */
   @objc open func resume() {
     var downloadDataToResume: Data?
+    var snapshotToFire: StorageTaskSnapshot?
     let shouldReturn1 = stateLock.withLock { () -> Bool in
       if state == .running || state == .resuming || state == .success || state == .cancelled ||
         state == .failed {
@@ -94,11 +95,14 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
       }
       state = .resuming
       downloadDataToResume = downloadData
+      snapshotToFire = snapshotUnderLock()
       return false
     }
     if shouldReturn1 { return }
 
-    fire(for: .resume, snapshot: snapshot)
+    if let snapshotToFire {
+      fire(for: .resume, snapshot: snapshotToFire)
+    }
 
     let shouldEnqueue = stateLock.withLock { () -> Bool in
       if state == .cancelled || state == .paused || state == .pausing { return false }
@@ -168,19 +172,20 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
                                                      totalBytesWritten: Int64,
                                                      totalBytesExpectedToWrite: Int64) in
           guard let self = self else { return }
-          let shouldReturn = self.stateLock.withLock { () -> Bool in
+          var snapshotToFire: StorageTaskSnapshot?
+          self.stateLock.withLock {
             if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
               self.state == .success || self.state == .failed {
-              return true
+              return
             }
             self.state = .progress
             self.progress.completedUnitCount = totalBytesWritten
             self.progress.totalUnitCount = totalBytesExpectedToWrite
-            return false
+            snapshotToFire = self.snapshotUnderLock()
           }
-          if shouldReturn { return }
-
-          self.fire(for: .progress, snapshot: self.snapshot)
+          if let snapshotToFire {
+            self.fire(for: .progress, snapshot: snapshotToFire)
+          }
 
           self.stateLock.withLock {
             if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
@@ -195,21 +200,22 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
       fetcher.receivedProgressBlock = { [weak self] (bytesWritten: Int64,
                                                      totalBytesWritten: Int64) in
           guard let self = self else { return }
-          let shouldReturn = self.stateLock.withLock { () -> Bool in
+          var snapshotToFire: StorageTaskSnapshot?
+          self.stateLock.withLock {
             if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
               self.state == .success || self.state == .failed {
-              return true
+              return
             }
             self.state = .progress
             self.progress.completedUnitCount = totalBytesWritten
             if let totalLength = self.fetcher?.response?.expectedContentLength {
               self.progress.totalUnitCount = totalLength
             }
-            return false
+            snapshotToFire = self.snapshotUnderLock()
           }
-          if shouldReturn { return }
-
-          self.fire(for: .progress, snapshot: self.snapshot)
+          if let snapshotToFire {
+            self.fire(for: .progress, snapshot: snapshotToFire)
+          }
 
           self.stateLock.withLock {
             if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
@@ -233,16 +239,16 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
       if isPausing {
         fetcher.resumeDataBlock = { [weak self] (data: Data) in
           guard let self = self else { return }
-          let shouldFire = self.stateLock.withLock { () -> Bool in
-            if self.state != .pausing {
-              return false
+          var snapshotToFire: StorageTaskSnapshot?
+          self.stateLock.withLock {
+            if self.state == .pausing {
+              self.downloadData = data
+              self.state = .paused
+              snapshotToFire = self.snapshotUnderLock()
             }
-            self.downloadData = data
-            self.state = .paused
-            return true
           }
-          if shouldFire {
-            self.fire(for: .pause, snapshot: self.snapshot)
+          if let snapshotToFire {
+            self.fire(for: .pause, snapshot: snapshotToFire)
           }
         }
       }
@@ -293,20 +299,20 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
 
   func cancel(withError error: NSError) {
     var fetcherToStop: GTMSessionFetcher?
-    let shouldCancel = stateLock.withLock { () -> Bool in
+    var failureSnapshot: StorageTaskSnapshot?
+    stateLock.withLock {
       if state == .cancelled || state == .success || state == .failed {
-        return false
+        return
       }
       state = .cancelled
       self.error = error
       fetcherToStop = fetcher
-      return true
+      failureSnapshot = snapshotUnderLock()
     }
-    if !shouldCancel { return }
-
-    fetcherToStop?.stopFetching()
-
-    fire(for: .failure, snapshot: snapshot)
-    removeAllObservers()
+    if let failureSnapshot {
+      fetcherToStop?.stopFetching()
+      fire(for: .failure, snapshot: failureSnapshot)
+      removeAllObservers()
+    }
   }
 }

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -50,8 +50,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
     var fetcherToStop: GTMSessionFetcher?
     var snapshotToFire: StorageTaskSnapshot?
     stateLock.withLock {
-      if state == .paused || state == .pausing || state == .success || state == .cancelled ||
-        state == .failed {
+      guard state == .unknown || state == .queueing || state == .resuming || state == .running ||
+        state == .progress else {
         return
       }
       if let fetcher {
@@ -98,8 +98,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
     var downloadDataToResume: Data?
     var snapshotToFire: StorageTaskSnapshot?
     let shouldReturn1 = stateLock.withLock { () -> Bool in
-      if state == .running || state == .resuming || state == .success || state == .cancelled ||
-        state == .failed {
+      guard state == .unknown || state == .queueing || state == .pausing || state == .paused ||
+        state == .progress else {
         return true
       }
       state = .resuming
@@ -146,8 +146,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
 
   private func enqueueImplementation(resumeWith resumeData: Data? = nil) async {
     let shouldProceed = stateLock.withLock { () -> Bool in
-      if state == .cancelled || state == .pausing || state == .paused || state == .success ||
-        state == .failed {
+      guard state == .unknown || state == .queueing || state == .resuming || state == .running ||
+        state == .progress else {
         return false
       }
       state = .queueing
@@ -183,8 +183,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
           guard let self = self else { return }
           var snapshotToFire: StorageTaskSnapshot?
           self.stateLock.withLock {
-            if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
-              self.state == .success || self.state == .failed {
+            guard self.state == .unknown || self.state == .queueing || self.state == .resuming ||
+              self.state == .running || self.state == .progress else {
               return
             }
             self.state = .progress
@@ -197,8 +197,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
           }
 
           self.stateLock.withLock {
-            if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
-              self.state == .success || self.state == .failed {
+            guard self.state == .unknown || self.state == .queueing || self.state == .resuming ||
+              self.state == .running || self.state == .progress else {
               return
             }
             self.state = .running
@@ -211,8 +211,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
           guard let self = self, let fetcher = fetcher else { return }
           var snapshotToFire: StorageTaskSnapshot?
           self.stateLock.withLock {
-            if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
-              self.state == .success || self.state == .failed {
+            guard self.state == .unknown || self.state == .queueing || self.state == .resuming ||
+              self.state == .running || self.state == .progress else {
               return
             }
             self.state = .progress
@@ -227,8 +227,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
           }
 
           self.stateLock.withLock {
-            if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
-              self.state == .success || self.state == .failed {
+            guard self.state == .unknown || self.state == .queueing || self.state == .resuming ||
+              self.state == .running || self.state == .progress else {
               return
             }
             self.state = .running

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -47,7 +47,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
    * Pauses a task currently in progress. Calling this on a paused task has no effect.
    */
   @objc open func pause() {
-    var shouldStop = false
+    var fetcherToStop: GTMSessionFetcher?
     stateLock.withLock {
       if state == .paused || state == .pausing || state == .success || state == .cancelled ||
         state == .failed {
@@ -64,11 +64,9 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
         }
         self.fire(for: .pause, snapshot: self.snapshot)
       }
-      shouldStop = true
+      fetcherToStop = fetcher
     }
-    if shouldStop {
-      fetcher?.stopFetching()
-    }
+    fetcherToStop?.stopFetching()
   }
 
   /**

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -96,13 +96,16 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
 
     fire(for: .resume, snapshot: snapshot)
 
-    stateLock.withLock {
-      if state == .cancelled || state == .paused || state == .pausing { return }
+    let shouldEnqueue = stateLock.withLock { () -> Bool in
+      if state == .cancelled || state == .paused || state == .pausing { return false }
       state = .running
+      return true
     }
 
-    Task {
-      await self.enqueueImplementation(resumeWith: downloadDataToResume)
+    if shouldEnqueue {
+      Task {
+        await self.enqueueImplementation(resumeWith: downloadDataToResume)
+      }
     }
   }
 
@@ -203,9 +206,28 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
           }
       }
     }
-    stateLock.withLock {
+    let shouldContinue = stateLock.withLock { () -> Bool in
+      if state == .cancelled || state == .pausing || state == .paused {
+        return false
+      }
       self.fetcher = fetcher
       state = .running
+      return true
+    }
+    if !shouldContinue {
+      let isPausing = stateLock.withLock { state == .pausing }
+      if isPausing {
+        fetcher.resumeDataBlock = { [weak self] (data: Data) in
+          guard let self = self else { return }
+          self.stateLock.withLock {
+            self.downloadData = data
+            self.state = .paused
+          }
+          self.fire(for: .pause, snapshot: self.snapshot)
+        }
+      }
+      fetcher.stopFetching()
+      return
     }
     do {
       let data = try await self.fetcher?.beginFetch()
@@ -229,8 +251,9 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
       fire(for: .success, snapshot: snapshot)
       removeAllObservers()
     } catch {
-      let isCancelled = stateLock.withLock { state == .cancelled }
-      if isCancelled { return }
+      let shouldReturnEarly = stateLock
+        .withLock { state == .cancelled || state == .paused || state == .pausing }
+      if shouldReturnEarly { return }
 
       fire(for: .progress, snapshot: snapshot)
 

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -258,3 +258,5 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
     removeAllObservers()
   }
 }
+
+extension StorageDownloadTask: @unchecked Sendable {}

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -47,25 +47,23 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
    * Pauses a task currently in progress. Calling this on a paused task has no effect.
    */
   @objc open func pause() {
-    stateLock.lock()
-    if state == .paused || state == .pausing || state == .success || state == .cancelled || state ==
-      .failed {
-      stateLock.unlock()
-      return
+    stateLock.withLock {
+      if state == .paused || state == .pausing || state == .success || state == .cancelled || state == .failed {
+        return
+      }
+      state = .pausing
+      // Use the resume callback to confirm pause status since it always runs after the last
+      // NSURLSession update.
+      fetcher?.resumeDataBlock = { [weak self] (data: Data) in
+        guard let self = self else { return }
+        self.stateLock.withLock {
+          self.downloadData = data
+          self.state = .paused
+        }
+        self.fire(for: .pause, snapshot: self.snapshot)
+      }
+      fetcher?.stopFetching()
     }
-    state = .pausing
-    // Use the resume callback to confirm pause status since it always runs after the last
-    // NSURLSession update.
-    fetcher?.resumeDataBlock = { [weak self] (data: Data) in
-      guard let self = self else { return }
-      self.stateLock.lock()
-      self.downloadData = data
-      self.state = .paused
-      self.stateLock.unlock()
-      self.fire(for: .pause, snapshot: self.snapshot)
-    }
-    fetcher?.stopFetching()
-    stateLock.unlock()
   }
 
   /**
@@ -79,25 +77,21 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
    * Resumes a paused task. Calling this on a running task has no effect.
    */
   @objc open func resume() {
-    stateLock.lock()
-    if state == .running || state == .resuming || state == .success || state == .cancelled ||
-      state ==
-      .failed {
-      stateLock.unlock()
-      return
+    let shouldReturn1 = stateLock.withLock { () -> Bool in
+      if state == .running || state == .resuming || state == .success || state == .cancelled || state == .failed {
+        return true
+      }
+      state = .resuming
+      return false
     }
-    state = .resuming
-    stateLock.unlock()
+    if shouldReturn1 { return }
 
     fire(for: .resume, snapshot: snapshot)
 
-    stateLock.lock()
-    if state == .cancelled || state == .paused || state == .pausing {
-      stateLock.unlock()
-      return
+    stateLock.withLock {
+      if state == .cancelled || state == .paused || state == .pausing { return }
+      state = .running
     }
-    state = .running
-    stateLock.unlock()
 
     Task {
       await self.enqueueImplementation(resumeWith: self.downloadData)
@@ -123,9 +117,9 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
   }
 
   private func enqueueImplementation(resumeWith resumeData: Data? = nil) async {
-    stateLock.lock()
-    state = .queueing
-    stateLock.unlock()
+    stateLock.withLock {
+      state = .queueing
+    }
 
     var request = baseRequest
     request.httpMethod = "GET"
@@ -153,105 +147,95 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
                                                      totalBytesWritten: Int64,
                                                      totalBytesExpectedToWrite: Int64) in
           guard let self = self else { return }
-          self.stateLock.lock()
-          if self.state == .cancelled || self.state == .pausing || self.state == .paused {
-            self.stateLock.unlock()
-            return
+          let shouldReturn = self.stateLock.withLock { () -> Bool in
+            if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+              return true
+            }
+            self.state = .progress
+            self.progress.completedUnitCount = totalBytesWritten
+            self.progress.totalUnitCount = totalBytesExpectedToWrite
+            return false
           }
-          self.state = .progress
-          self.progress.completedUnitCount = totalBytesWritten
-          self.progress.totalUnitCount = totalBytesExpectedToWrite
-          self.stateLock.unlock()
+          if shouldReturn { return }
 
           self.fire(for: .progress, snapshot: self.snapshot)
 
-          self.stateLock.lock()
-          if self.state == .cancelled || self.state == .pausing || self.state == .paused {
-            self.stateLock.unlock()
-            return
+          self.stateLock.withLock {
+            if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+              return
+            }
+            self.state = .running
           }
-          self.state = .running
-          self.stateLock.unlock()
       }
     } else {
       // Handle data downloads
       fetcher.receivedProgressBlock = { [weak self] (bytesWritten: Int64,
                                                      totalBytesWritten: Int64) in
           guard let self = self else { return }
-          self.stateLock.lock()
-          if self.state == .cancelled || self.state == .pausing || self.state == .paused {
-            self.stateLock.unlock()
-            return
+          let shouldReturn = self.stateLock.withLock { () -> Bool in
+            if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+              return true
+            }
+            self.state = .progress
+            self.progress.completedUnitCount = totalBytesWritten
+            if let totalLength = self.fetcher?.response?.expectedContentLength {
+              self.progress.totalUnitCount = totalLength
+            }
+            return false
           }
-          self.state = .progress
-          self.progress.completedUnitCount = totalBytesWritten
-          if let totalLength = self.fetcher?.response?.expectedContentLength {
-            self.progress.totalUnitCount = totalLength
-          }
-          self.stateLock.unlock()
+          if shouldReturn { return }
 
           self.fire(for: .progress, snapshot: self.snapshot)
 
-          self.stateLock.lock()
-          if self.state == .cancelled || self.state == .pausing || self.state == .paused {
-            self.stateLock.unlock()
-            return
+          self.stateLock.withLock {
+            if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+              return
+            }
+            self.state = .running
           }
-          self.state = .running
-          self.stateLock.unlock()
       }
     }
     self.fetcher = fetcher
-    stateLock.lock()
-    state = .running
-    stateLock.unlock()
+    stateLock.withLock {
+      state = .running
+    }
     do {
       let data = try await self.fetcher?.beginFetch()
-      stateLock.lock()
-      if state == .cancelled {
-        stateLock.unlock()
-        return
-      }
-      stateLock.unlock()
+      let isCancelled = stateLock.withLock { state == .cancelled }
+      if isCancelled { return }
 
       // Fire last progress updates
       fire(for: .progress, snapshot: snapshot)
 
       // Download completed successfully, fire completion callbacks
-      stateLock.lock()
-      if state == .cancelled {
-        stateLock.unlock()
-        return
+      let shouldReturn = stateLock.withLock { () -> Bool in
+        if state == .cancelled { return true }
+        state = .success
+        if let data {
+          downloadData = data
+        }
+        return false
       }
-      state = .success
-      if let data {
-        downloadData = data
-      }
-      stateLock.unlock()
+      if shouldReturn { return }
 
       fire(for: .success, snapshot: snapshot)
       removeAllObservers()
     } catch {
-      stateLock.lock()
-      if state == .cancelled {
-        stateLock.unlock()
-        return
-      }
-      stateLock.unlock()
+      let isCancelled = stateLock.withLock { state == .cancelled }
+      if isCancelled { return }
 
       fire(for: .progress, snapshot: snapshot)
 
-      stateLock.lock()
-      if state == .cancelled {
-        stateLock.unlock()
-        return
+      let shouldReturn = stateLock.withLock { () -> Bool in
+        if state == .cancelled { return true }
+        state = .failed
+        self.error = StorageErrorCode.error(
+          withServerError: error as NSError,
+          ref: reference
+        )
+        return false
       }
-      state = .failed
-      self.error = StorageErrorCode.error(
-        withServerError: error as NSError,
-        ref: reference
-      )
-      stateLock.unlock()
+      if shouldReturn { return }
 
       fire(for: .failure, snapshot: snapshot)
       removeAllObservers()
@@ -259,15 +243,16 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
   }
 
   func cancel(withError error: NSError) {
-    stateLock.lock()
-    if state == .cancelled || state == .success || state == .failed {
-      stateLock.unlock()
-      return
+    let shouldReturn = stateLock.withLock { () -> Bool in
+      if state == .cancelled || state == .success || state == .failed {
+        return true
+      }
+      state = .cancelled
+      fetcher?.stopFetching()
+      self.error = error
+      return false
     }
-    state = .cancelled
-    fetcher?.stopFetching()
-    self.error = error
-    stateLock.unlock()
+    if shouldReturn { return }
 
     fire(for: .failure, snapshot: snapshot)
     removeAllObservers()

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -58,11 +58,17 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
       // NSURLSession update.
       fetcher?.resumeDataBlock = { [weak self] (data: Data) in
         guard let self = self else { return }
-        self.stateLock.withLock {
+        let shouldFire = self.stateLock.withLock { () -> Bool in
+          if self.state == .cancelled || self.state == .failed || self.state == .success {
+            return false
+          }
           self.downloadData = data
           self.state = .paused
+          return true
         }
-        self.fire(for: .pause, snapshot: self.snapshot)
+        if shouldFire {
+          self.fire(for: .pause, snapshot: self.snapshot)
+        }
       }
       fetcherToStop = fetcher
     }
@@ -126,9 +132,15 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
   }
 
   private func enqueueImplementation(resumeWith resumeData: Data? = nil) async {
-    stateLock.withLock {
+    let shouldProceed = stateLock.withLock { () -> Bool in
+      if state == .cancelled || state == .pausing || state == .paused || state == .success ||
+         state == .failed {
+        return false
+      }
       state = .queueing
+      return true
     }
+    if !shouldProceed { return }
 
     var request = baseRequest
     request.httpMethod = "GET"
@@ -157,7 +169,8 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
                                                      totalBytesExpectedToWrite: Int64) in
           guard let self = self else { return }
           let shouldReturn = self.stateLock.withLock { () -> Bool in
-            if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+            if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
+               self.state == .success || self.state == .failed {
               return true
             }
             self.state = .progress
@@ -217,11 +230,17 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
       if isPausing {
         fetcher.resumeDataBlock = { [weak self] (data: Data) in
           guard let self = self else { return }
-          self.stateLock.withLock {
+          let shouldFire = self.stateLock.withLock { () -> Bool in
+            if self.state == .cancelled || self.state == .failed || self.state == .success {
+              return false
+            }
             self.downloadData = data
             self.state = .paused
+            return true
           }
-          self.fire(for: .pause, snapshot: self.snapshot)
+          if shouldFire {
+            self.fire(for: .pause, snapshot: self.snapshot)
+          }
         }
       }
       fetcher.stopFetching()

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -48,29 +48,38 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
    */
   @objc open func pause() {
     var fetcherToStop: GTMSessionFetcher?
+    var snapshotToFire: StorageTaskSnapshot?
     stateLock.withLock {
       if state == .paused || state == .pausing || state == .success || state == .cancelled ||
         state == .failed {
         return
       }
-      state = .pausing
-      // Use the resume callback to confirm pause status since it always runs after the last
-      // NSURLSession update.
-      fetcher?.resumeDataBlock = { [weak self] (data: Data) in
-        guard let self = self else { return }
-        var snapshotToFire: StorageTaskSnapshot?
-        self.stateLock.withLock {
-          if self.state == .pausing {
-            self.downloadData = data
-            self.state = .paused
-            snapshotToFire = self.snapshotUnderLock()
+      if let fetcher {
+        state = .pausing
+        // Use the resume callback to confirm pause status since it always runs after the last
+        // NSURLSession update.
+        fetcher.resumeDataBlock = { [weak self] (data: Data) in
+          guard let self = self else { return }
+          var snapshotToFire: StorageTaskSnapshot?
+          self.stateLock.withLock {
+            if self.state == .pausing {
+              self.downloadData = data
+              self.state = .paused
+              snapshotToFire = self.snapshotUnderLock()
+            }
+          }
+          if let snapshotToFire {
+            self.fire(for: .pause, snapshot: snapshotToFire)
           }
         }
-        if let snapshotToFire {
-          self.fire(for: .pause, snapshot: snapshotToFire)
-        }
+        fetcherToStop = fetcher
+      } else {
+        state = .paused
+        snapshotToFire = snapshotUnderLock()
       }
-      fetcherToStop = fetcher
+    }
+    if let snapshotToFire {
+      fire(for: .pause, snapshot: snapshotToFire)
     }
     fetcherToStop?.stopFetching()
   }

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -260,40 +260,52 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
       let isCancelled = stateLock.withLock { state == .cancelled }
       if isCancelled { return }
 
-      // Fire last progress updates
-      fire(for: .progress, snapshot: snapshot)
+      var progressSnapshot: StorageTaskSnapshot?
+      var successSnapshot: StorageTaskSnapshot?
 
-      // Download completed successfully, fire completion callbacks
-      let shouldReturn = stateLock.withLock { () -> Bool in
-        if state == .cancelled { return true }
+      stateLock.withLock {
+        if state == .cancelled { return }
+
+        state = .progress
+        progressSnapshot = snapshotUnderLock()
+
         state = .success
         downloadData = data
-        return false
+        successSnapshot = snapshotUnderLock()
       }
-      if shouldReturn { return }
 
-      fire(for: .success, snapshot: snapshot)
-      removeAllObservers()
+      if let progressSnapshot {
+        fire(for: .progress, snapshot: progressSnapshot)
+      }
+      if let successSnapshot {
+        fire(for: .success, snapshot: successSnapshot)
+        removeAllObservers()
+      }
     } catch {
-      let shouldReturnEarly = stateLock
-        .withLock { state == .cancelled || state == .paused || state == .pausing }
-      if shouldReturnEarly { return }
+      var progressSnapshot: StorageTaskSnapshot?
+      var failureSnapshot: StorageTaskSnapshot?
 
-      fire(for: .progress, snapshot: snapshot)
+      stateLock.withLock {
+        if state == .cancelled || state == .paused || state == .pausing { return }
 
-      let shouldReturn = stateLock.withLock { () -> Bool in
-        if state == .cancelled { return true }
+        state = .progress
+        progressSnapshot = snapshotUnderLock()
+
         state = .failed
         self.error = StorageErrorCode.error(
           withServerError: error as NSError,
           ref: reference
         )
-        return false
+        failureSnapshot = snapshotUnderLock()
       }
-      if shouldReturn { return }
 
-      fire(for: .failure, snapshot: snapshot)
-      removeAllObservers()
+      if let progressSnapshot {
+        fire(for: .progress, snapshot: progressSnapshot)
+      }
+      if let failureSnapshot {
+        fire(for: .failure, snapshot: failureSnapshot)
+        removeAllObservers()
+      }
     }
   }
 

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -33,7 +33,7 @@ import Foundation
  * specified `callbackQueue` in Storage, or the main queue if left unspecified.
  */
 @objc(FIRStorageDownloadTask)
-open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
+open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @unchecked Sendable {
   /**
    * Prepares a task and begins execution.
    */
@@ -258,5 +258,3 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement {
     removeAllObservers()
   }
 }
-
-extension StorageDownloadTask: @unchecked Sendable {}

--- a/FirebaseStorage/Sources/StorageDownloadTask.swift
+++ b/FirebaseStorage/Sources/StorageDownloadTask.swift
@@ -230,7 +230,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
       return
     }
     do {
-      let data = try await self.fetcher?.beginFetch()
+      let data = try await fetcher.beginFetch()
       let isCancelled = stateLock.withLock { state == .cancelled }
       if isCancelled { return }
 
@@ -241,9 +241,7 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
       let shouldReturn = stateLock.withLock { () -> Bool in
         if state == .cancelled { return true }
         state = .success
-        if let data {
-          downloadData = data
-        }
+        downloadData = data
         return false
       }
       if shouldReturn { return }
@@ -274,17 +272,19 @@ open class StorageDownloadTask: StorageObservableTask, StorageTaskManagement, @u
   }
 
   func cancel(withError error: NSError) {
+    var fetcherToStop: GTMSessionFetcher?
     let shouldCancel = stateLock.withLock { () -> Bool in
       if state == .cancelled || state == .success || state == .failed {
         return false
       }
       state = .cancelled
       self.error = error
+      fetcherToStop = fetcher
       return true
     }
     if !shouldCancel { return }
 
-    fetcher?.stopFetching()
+    fetcherToStop?.stopFetching()
 
     fire(for: .failure, snapshot: snapshot)
     removeAllObservers()

--- a/FirebaseStorage/Sources/StorageObservableTask.swift
+++ b/FirebaseStorage/Sources/StorageObservableTask.swift
@@ -66,9 +66,9 @@ import Foundation
           "of: Pause, Resume, Progress, Complete, or Failure")
       }
     }
-    stateLock.lock()
-    handleToStatusMap[uuidString] = status
-    stateLock.unlock()
+    stateLock.withLock {
+      handleToStatusMap[uuidString] = status
+    }
 
     return uuidString
   }
@@ -79,10 +79,10 @@ import Foundation
    */
   @objc(removeObserverWithHandle:) open func removeObserver(withHandle handle: String) {
     if let status = handleToStatusMap[handle] {
-      stateLock.lock()
-      handlerDictionaries[status]?.removeValue(forKey: handle)
-      handleToStatusMap.removeValue(forKey: handle)
-      stateLock.unlock()
+      stateLock.withLock {
+        handlerDictionaries[status]?.removeValue(forKey: handle)
+        handleToStatusMap.removeValue(forKey: handle)
+      }
     }
   }
 
@@ -93,12 +93,12 @@ import Foundation
   @objc(removeAllObserversForStatus:)
   open func removeAllObservers(for status: StorageTaskStatus) {
     if let handlerDictionary = handlerDictionaries[status] {
-      stateLock.lock()
-      for (key, _) in handlerDictionary {
-        handleToStatusMap.removeValue(forKey: key)
+      stateLock.withLock {
+        for (key, _) in handlerDictionary {
+          handleToStatusMap.removeValue(forKey: key)
+        }
+        handlerDictionaries[status]?.removeAll()
       }
-      handlerDictionaries[status]?.removeAll()
-      stateLock.unlock()
     }
   }
 
@@ -106,12 +106,12 @@ import Foundation
    * Removes all observers.
    */
   @objc open func removeAllObservers() {
-    stateLock.lock()
-    for (status, _) in handlerDictionaries {
-      handlerDictionaries[status]?.removeAll()
+    stateLock.withLock {
+      for (status, _) in handlerDictionaries {
+        handlerDictionaries[status]?.removeAll()
+      }
+      handleToStatusMap.removeAll()
     }
-    handleToStatusMap.removeAll()
-    stateLock.unlock()
   }
 
   // MARK: - Private Handler Dictionaries
@@ -146,9 +146,9 @@ import Foundation
     -> String {
     // TODO: use an increasing counter instead of a random UUID
     let uuidString = NSUUID().uuidString
-    stateLock.lock()
-    handlerDictionaries[status]?[uuidString] = handler
-    stateLock.unlock()
+    stateLock.withLock {
+      handlerDictionaries[status]?[uuidString] = handler
+    }
     return uuidString
   }
 
@@ -160,9 +160,7 @@ import Foundation
 
   func fire(handlers: [String: (StorageTaskSnapshot) -> Void],
             snapshot: StorageTaskSnapshot) {
-    stateLock.lock()
-    let enumeration = handlers.enumerated()
-    stateLock.unlock()
+    let enumeration = stateLock.withLock { handlers.enumerated() }
     for (_, handler) in enumeration {
       reference.storage.callbackQueue.async {
         handler.value(snapshot)

--- a/FirebaseStorage/Sources/StorageObservableTask.swift
+++ b/FirebaseStorage/Sources/StorageObservableTask.swift
@@ -34,7 +34,7 @@ import Foundation
   open func observe(_ status: StorageTaskStatus,
                     handler: @escaping (StorageTaskSnapshot) -> Void) -> String {
     let callback = handler
-    let uuidString = NSUUID().uuidString
+    let uuidString = UUID().uuidString
 
     let snapshot = stateLock.withLock { () -> StorageTaskSnapshot in
       handlerDictionaries[status]?[uuidString] = callback

--- a/FirebaseStorage/Sources/StorageObservableTask.swift
+++ b/FirebaseStorage/Sources/StorageObservableTask.swift
@@ -168,3 +168,5 @@ import Foundation
     }
   }
 }
+
+extension StorageObservableTask: @unchecked Sendable {}

--- a/FirebaseStorage/Sources/StorageObservableTask.swift
+++ b/FirebaseStorage/Sources/StorageObservableTask.swift
@@ -40,30 +40,25 @@ import Foundation
 
     // TODO: use an increasing counter instead of a random UUID
     let uuidString = updateHandlerDictionary(for: status, with: callback)
-    if let handlerDictionary = stateLock.withLock({ handlerDictionaries[status] }) {
-      switch status {
-      case .pause:
-        if snapshot.state == .pausing || snapshot.state == .paused {
-          fire(handlers: handlerDictionary, snapshot: snapshot)
-        }
-      case .resume:
-        if snapshot.state == .resuming || snapshot.state == .running {
-          fire(handlers: handlerDictionary, snapshot: snapshot)
-        }
-      case .progress:
-        if snapshot.state == .running || snapshot.state == .progress {
-          fire(handlers: handlerDictionary, snapshot: snapshot)
-        }
-      case .success:
-        if snapshot.state == .success {
-          fire(handlers: handlerDictionary, snapshot: snapshot)
-        }
-      case .failure:
-        if snapshot.state == .failed || snapshot.state == .failing {
-          fire(handlers: handlerDictionary, snapshot: snapshot)
-        }
-      case .unknown: fatalError("Invalid observer status requested, use one " +
-          "of: Pause, Resume, Progress, Complete, or Failure")
+    var shouldFire = false
+    switch status {
+    case .pause:
+      shouldFire = snapshot.state == .pausing || snapshot.state == .paused
+    case .resume:
+      shouldFire = snapshot.state == .resuming || snapshot.state == .running
+    case .progress:
+      shouldFire = snapshot.state == .running || snapshot.state == .progress
+    case .success:
+      shouldFire = snapshot.state == .success
+    case .failure:
+      shouldFire = snapshot.state == .failed || snapshot.state == .failing
+    case .unknown:
+      fatalError("Invalid observer status requested, use one of: Pause, Resume, Progress, Complete, or Failure")
+    }
+
+    if shouldFire {
+      reference.storage.callbackQueue.async {
+        callback(snapshot)
       }
     }
     stateLock.withLock {

--- a/FirebaseStorage/Sources/StorageObservableTask.swift
+++ b/FirebaseStorage/Sources/StorageObservableTask.swift
@@ -43,23 +43,23 @@ import Foundation
     if let handlerDictionary = stateLock.withLock({ handlerDictionaries[status] }) {
       switch status {
       case .pause:
-        if state == .pausing || state == .paused {
+        if snapshot.state == .pausing || snapshot.state == .paused {
           fire(handlers: handlerDictionary, snapshot: snapshot)
         }
       case .resume:
-        if state == .resuming || state == .running {
+        if snapshot.state == .resuming || snapshot.state == .running {
           fire(handlers: handlerDictionary, snapshot: snapshot)
         }
       case .progress:
-        if state == .running || state == .progress {
+        if snapshot.state == .running || snapshot.state == .progress {
           fire(handlers: handlerDictionary, snapshot: snapshot)
         }
       case .success:
-        if state == .success {
+        if snapshot.state == .success {
           fire(handlers: handlerDictionary, snapshot: snapshot)
         }
       case .failure:
-        if state == .failed || state == .failing {
+        if snapshot.state == .failed || snapshot.state == .failing {
           fire(handlers: handlerDictionary, snapshot: snapshot)
         }
       case .unknown: fatalError("Invalid observer status requested, use one " +

--- a/FirebaseStorage/Sources/StorageObservableTask.swift
+++ b/FirebaseStorage/Sources/StorageObservableTask.swift
@@ -66,9 +66,9 @@ import Foundation
           "of: Pause, Resume, Progress, Complete, or Failure")
       }
     }
-    objc_sync_enter(StorageObservableTask.self)
+    stateLock.lock()
     handleToStatusMap[uuidString] = status
-    objc_sync_exit(StorageObservableTask.self)
+    stateLock.unlock()
 
     return uuidString
   }
@@ -79,10 +79,10 @@ import Foundation
    */
   @objc(removeObserverWithHandle:) open func removeObserver(withHandle handle: String) {
     if let status = handleToStatusMap[handle] {
-      objc_sync_enter(StorageObservableTask.self)
+      stateLock.lock()
       handlerDictionaries[status]?.removeValue(forKey: handle)
       handleToStatusMap.removeValue(forKey: handle)
-      objc_sync_exit(StorageObservableTask.self)
+      stateLock.unlock()
     }
   }
 
@@ -93,12 +93,12 @@ import Foundation
   @objc(removeAllObserversForStatus:)
   open func removeAllObservers(for status: StorageTaskStatus) {
     if let handlerDictionary = handlerDictionaries[status] {
-      objc_sync_enter(StorageObservableTask.self)
+      stateLock.lock()
       for (key, _) in handlerDictionary {
         handleToStatusMap.removeValue(forKey: key)
       }
       handlerDictionaries[status]?.removeAll()
-      objc_sync_exit(StorageObservableTask.self)
+      stateLock.unlock()
     }
   }
 
@@ -106,12 +106,12 @@ import Foundation
    * Removes all observers.
    */
   @objc open func removeAllObservers() {
-    objc_sync_enter(StorageObservableTask.self)
+    stateLock.lock()
     for (status, _) in handlerDictionaries {
       handlerDictionaries[status]?.removeAll()
     }
     handleToStatusMap.removeAll()
-    objc_sync_exit(StorageObservableTask.self)
+    stateLock.unlock()
   }
 
   // MARK: - Private Handler Dictionaries
@@ -146,9 +146,9 @@ import Foundation
     -> String {
     // TODO: use an increasing counter instead of a random UUID
     let uuidString = NSUUID().uuidString
-    objc_sync_enter(StorageObservableTask.self)
+    stateLock.lock()
     handlerDictionaries[status]?[uuidString] = handler
-    objc_sync_exit(StorageObservableTask.self)
+    stateLock.unlock()
     return uuidString
   }
 
@@ -160,9 +160,9 @@ import Foundation
 
   func fire(handlers: [String: (StorageTaskSnapshot) -> Void],
             snapshot: StorageTaskSnapshot) {
-    objc_sync_enter(StorageObservableTask.self)
+    stateLock.lock()
     let enumeration = handlers.enumerated()
-    objc_sync_exit(StorageObservableTask.self)
+    stateLock.unlock()
     for (_, handler) in enumeration {
       reference.storage.callbackQueue.async {
         handler.value(snapshot)

--- a/FirebaseStorage/Sources/StorageObservableTask.swift
+++ b/FirebaseStorage/Sources/StorageObservableTask.swift
@@ -39,16 +39,7 @@ import Foundation
     let snapshot = stateLock.withLock { () -> StorageTaskSnapshot in
       handlerDictionaries[status]?[uuidString] = callback
       handleToStatusMap[uuidString] = status
-      let progressCopy = Progress(totalUnitCount: self.progress.totalUnitCount)
-      progressCopy.completedUnitCount = self.progress.completedUnitCount
-      return StorageTaskSnapshot(
-        task: self,
-        state: state,
-        reference: reference,
-        progress: progressCopy,
-        metadata: metadata,
-        error: error
-      )
+      return snapshotUnderLock()
     }
 
     var shouldFire = false

--- a/FirebaseStorage/Sources/StorageObservableTask.swift
+++ b/FirebaseStorage/Sources/StorageObservableTask.swift
@@ -21,7 +21,7 @@ import Foundation
  * Observers produce a `StorageHandle`, which is used to keep track of and remove specific
  * observers at a later date.
  */
-@objc(FIRStorageObservableTask) open class StorageObservableTask: StorageTask {
+@objc(FIRStorageObservableTask) open class StorageObservableTask: StorageTask, @unchecked Sendable {
   /**
    * Observes changes in the upload status: Resume, Pause, Progress, Success, and Failure.
    * - Parameters:
@@ -168,5 +168,3 @@ import Foundation
     }
   }
 }
-
-extension StorageObservableTask: @unchecked Sendable {}

--- a/FirebaseStorage/Sources/StorageObservableTask.swift
+++ b/FirebaseStorage/Sources/StorageObservableTask.swift
@@ -78,8 +78,8 @@ import Foundation
    * - Parameter handle: The handle of the task to remove.
    */
   @objc(removeObserverWithHandle:) open func removeObserver(withHandle handle: String) {
-    if let status = handleToStatusMap[handle] {
-      stateLock.withLock {
+    stateLock.withLock {
+      if let status = handleToStatusMap[handle] {
         handlerDictionaries[status]?.removeValue(forKey: handle)
         handleToStatusMap.removeValue(forKey: handle)
       }
@@ -92,8 +92,8 @@ import Foundation
    */
   @objc(removeAllObserversForStatus:)
   open func removeAllObservers(for status: StorageTaskStatus) {
-    if let handlerDictionary = handlerDictionaries[status] {
-      stateLock.withLock {
+    stateLock.withLock {
+      if let handlerDictionary = handlerDictionaries[status] {
         for (key, _) in handlerDictionary {
           handleToStatusMap.removeValue(forKey: key)
         }
@@ -160,10 +160,9 @@ import Foundation
 
   func fire(handlers: [String: (StorageTaskSnapshot) -> Void],
             snapshot: StorageTaskSnapshot) {
-    let enumeration = stateLock.withLock { handlers.enumerated() }
-    for (_, handler) in enumeration {
+    for handler in handlers.values {
       reference.storage.callbackQueue.async {
-        handler.value(snapshot)
+        handler(snapshot)
       }
     }
   }

--- a/FirebaseStorage/Sources/StorageObservableTask.swift
+++ b/FirebaseStorage/Sources/StorageObservableTask.swift
@@ -40,7 +40,7 @@ import Foundation
 
     // TODO: use an increasing counter instead of a random UUID
     let uuidString = updateHandlerDictionary(for: status, with: callback)
-    if let handlerDictionary = handlerDictionaries[status] {
+    if let handlerDictionary = stateLock.withLock({ handlerDictionaries[status] }) {
       switch status {
       case .pause:
         if state == .pausing || state == .paused {
@@ -153,7 +153,7 @@ import Foundation
   }
 
   func fire(for status: StorageTaskStatus, snapshot: StorageTaskSnapshot) {
-    if let observerDictionary = handlerDictionaries[status] {
+    if let observerDictionary = stateLock.withLock({ handlerDictionaries[status] }) {
       fire(handlers: observerDictionary, snapshot: snapshot)
     }
   }

--- a/FirebaseStorage/Sources/StorageObservableTask.swift
+++ b/FirebaseStorage/Sources/StorageObservableTask.swift
@@ -34,12 +34,23 @@ import Foundation
   open func observe(_ status: StorageTaskStatus,
                     handler: @escaping (StorageTaskSnapshot) -> Void) -> String {
     let callback = handler
+    let uuidString = NSUUID().uuidString
 
-    // Note: self.snapshot is synchronized
-    let snapshot = self.snapshot
+    let snapshot = stateLock.withLock { () -> StorageTaskSnapshot in
+      handlerDictionaries[status]?[uuidString] = callback
+      handleToStatusMap[uuidString] = status
+      let progressCopy = Progress(totalUnitCount: self.progress.totalUnitCount)
+      progressCopy.completedUnitCount = self.progress.completedUnitCount
+      return StorageTaskSnapshot(
+        task: self,
+        state: state,
+        reference: reference,
+        progress: progressCopy,
+        metadata: metadata,
+        error: error
+      )
+    }
 
-    // TODO: use an increasing counter instead of a random UUID
-    let uuidString = updateHandlerDictionary(for: status, with: callback)
     var shouldFire = false
     switch status {
     case .pause:
@@ -53,16 +64,15 @@ import Foundation
     case .failure:
       shouldFire = snapshot.state == .failed || snapshot.state == .failing
     case .unknown:
-      fatalError("Invalid observer status requested, use one of: Pause, Resume, Progress, Complete, or Failure")
+      fatalError(
+        "Invalid observer status requested, use one of: Pause, Resume, Progress, Complete, or Failure"
+      )
     }
 
     if shouldFire {
       reference.storage.callbackQueue.async {
         callback(snapshot)
       }
-    }
-    stateLock.withLock {
-      handleToStatusMap[uuidString] = status
     }
 
     return uuidString
@@ -134,17 +144,6 @@ import Foundation
     handleToStatusMap = [:]
     fileURL = file
     super.init(reference: reference, queue: queue)
-  }
-
-  func updateHandlerDictionary(for status: StorageTaskStatus,
-                               with handler: @escaping ((StorageTaskSnapshot) -> Void))
-    -> String {
-    // TODO: use an increasing counter instead of a random UUID
-    let uuidString = NSUUID().uuidString
-    stateLock.withLock {
-      handlerDictionaries[status]?[uuidString] = handler
-    }
-    return uuidString
   }
 
   func fire(for status: StorageTaskStatus, snapshot: StorageTaskSnapshot) {

--- a/FirebaseStorage/Sources/StorageTask.swift
+++ b/FirebaseStorage/Sources/StorageTask.swift
@@ -35,17 +35,21 @@ import Foundation
    */
   @objc public var snapshot: StorageTaskSnapshot {
     stateLock.withLock {
-      let progress = Progress(totalUnitCount: self.progress.totalUnitCount)
-      progress.completedUnitCount = self.progress.completedUnitCount
-      return StorageTaskSnapshot(
-        task: self,
-        state: state,
-        reference: reference,
-        progress: progress,
-        metadata: metadata,
-        error: error
-      )
+      return snapshotUnderLock()
     }
+  }
+
+  func snapshotUnderLock() -> StorageTaskSnapshot {
+    let progress = Progress(totalUnitCount: self.progress.totalUnitCount)
+    progress.completedUnitCount = self.progress.completedUnitCount
+    return StorageTaskSnapshot(
+      task: self,
+      state: state,
+      reference: reference,
+      progress: progress,
+      metadata: metadata,
+      error: error
+    )
   }
 
   // MARK: - Internal Implementations

--- a/FirebaseStorage/Sources/StorageTask.swift
+++ b/FirebaseStorage/Sources/StorageTask.swift
@@ -35,7 +35,7 @@ import Foundation
    */
   @objc public var snapshot: StorageTaskSnapshot {
     stateLock.withLock {
-      return snapshotUnderLock()
+      snapshotUnderLock()
     }
   }
 

--- a/FirebaseStorage/Sources/StorageTask.swift
+++ b/FirebaseStorage/Sources/StorageTask.swift
@@ -34,8 +34,8 @@ import Foundation
    * An immutable view of the task and associated metadata, progress, error, etc.
    */
   @objc public var snapshot: StorageTaskSnapshot {
-    objc_sync_enter(StorageTask.self)
-    defer { objc_sync_exit(StorageTask.self) }
+    stateLock.lock()
+    defer { stateLock.unlock() }
     let progress = Progress(totalUnitCount: self.progress.totalUnitCount)
     progress.completedUnitCount = self.progress.completedUnitCount
     return StorageTaskSnapshot(
@@ -49,6 +49,11 @@ import Foundation
   }
 
   // MARK: - Internal Implementations
+
+  /**
+   * Lock to protect mutable state (state, progress, metadata, error).
+   */
+  let stateLock = NSLock()
 
   /**
    * State for the current task in progress.

--- a/FirebaseStorage/Sources/StorageTask.swift
+++ b/FirebaseStorage/Sources/StorageTask.swift
@@ -34,18 +34,18 @@ import Foundation
    * An immutable view of the task and associated metadata, progress, error, etc.
    */
   @objc public var snapshot: StorageTaskSnapshot {
-    stateLock.lock()
-    defer { stateLock.unlock() }
-    let progress = Progress(totalUnitCount: self.progress.totalUnitCount)
-    progress.completedUnitCount = self.progress.completedUnitCount
-    return StorageTaskSnapshot(
-      task: self,
-      state: state,
-      reference: reference,
-      progress: progress,
-      metadata: metadata,
-      error: error
-    )
+    stateLock.withLock {
+      let progress = Progress(totalUnitCount: self.progress.totalUnitCount)
+      progress.completedUnitCount = self.progress.completedUnitCount
+      return StorageTaskSnapshot(
+        task: self,
+        state: state,
+        reference: reference,
+        progress: progress,
+        metadata: metadata,
+        error: error
+      )
+    }
   }
 
   // MARK: - Internal Implementations
@@ -125,3 +125,5 @@ import Foundation
    */
   @objc optional func resume()
 }
+
+extension StorageTask: @unchecked Sendable {}

--- a/FirebaseStorage/Sources/StorageTaskSnapshot.swift
+++ b/FirebaseStorage/Sources/StorageTaskSnapshot.swift
@@ -50,6 +50,9 @@ import Foundation
    */
   @objc public let status: StorageTaskStatus
 
+  /// The internal state of the task when this snapshot was created.
+  let state: StorageTaskState
+
   // MARK: NSObject overrides
 
   @objc override public var description: String {
@@ -74,6 +77,7 @@ import Foundation
     self.progress = progress
     self.error = error
     self.metadata = metadata
+    self.state = state
 
     switch state {
     case .queueing, .running, .resuming: status = StorageTaskStatus.resume

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -112,7 +112,8 @@ import Foundation
                                                          totalBytesExpectedToSend: Int64) in
             guard let self = self else { return }
             let shouldReturn = self.stateLock.withLock { () -> Bool in
-              if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+              if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
+                self.state == .success || self.state == .failed {
                 return true
               }
               self.state = .progress
@@ -126,7 +127,8 @@ import Foundation
             self.fire(for: .progress, snapshot: self.snapshot)
 
             self.stateLock.withLock {
-              if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+              if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
+                self.state == .success || self.state == .failed {
                 return
               }
               self.state = .running

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -151,7 +151,7 @@ import Foundation
           return
         }
         do {
-          let data = try await self.uploadFetcher?.beginFetch()
+          let data = try await uploadFetcher.beginFetch()
           let isCancelled = self.stateLock.withLock { self.state == .cancelled }
           if isCancelled { return }
 
@@ -162,10 +162,6 @@ import Foundation
           let shouldReturn = self.stateLock.withLock { () -> Bool in
             if self.state == .cancelled { return true }
             self.state = .success
-
-            guard let data = data else {
-              fatalError("Internal Error: uploadFetcher returned with nil data and no error")
-            }
 
             if let responseDictionary = try? JSONSerialization
               .jsonObject(with: data) as? [String: AnyHashable] {
@@ -207,6 +203,7 @@ import Foundation
    * Pauses a task currently in progress.
    */
   @objc open func pause() {
+    var fetcherToPause: GTMSessionUploadFetcher?
     let shouldPause = stateLock.withLock { () -> Bool in
       if state == .paused || state == .pausing || state == .success || state == .cancelled ||
         state == .failed {
@@ -214,11 +211,12 @@ import Foundation
       }
       state = .paused
       metadata = uploadMetadata
+      fetcherToPause = uploadFetcher
       return true
     }
     if !shouldPause { return }
 
-    uploadFetcher?.pauseFetching()
+    fetcherToPause?.pauseFetching()
 
     fire(for: .pause, snapshot: snapshot)
   }
@@ -227,6 +225,7 @@ import Foundation
    * Cancels a task.
    */
   @objc open func cancel() {
+    var fetcherToStop: GTMSessionUploadFetcher?
     let shouldCancel = stateLock.withLock { () -> Bool in
       if state == .cancelled || state == .success || state == .failed {
         return false
@@ -234,11 +233,12 @@ import Foundation
       state = .cancelled
       metadata = uploadMetadata
       error = StorageError.cancelled as NSError
+      fetcherToStop = uploadFetcher
       return true
     }
     if !shouldCancel { return }
 
-    uploadFetcher?.stopFetching()
+    fetcherToStop?.stopFetching()
 
     fire(for: .failure, snapshot: snapshot)
     removeAllObservers()
@@ -248,6 +248,7 @@ import Foundation
    * Resumes a paused task.
    */
   @objc open func resume() {
+    var fetcherToResume: GTMSessionUploadFetcher?
     let shouldResume = stateLock.withLock { () -> Bool in
       if state == .running || state == .resuming || state == .success || state == .cancelled ||
         state == .failed {
@@ -255,11 +256,12 @@ import Foundation
       }
       state = .resuming
       metadata = uploadMetadata
+      fetcherToResume = uploadFetcher
       return true
     }
     if !shouldResume { return }
 
-    uploadFetcher?.resumeFetching()
+    fetcherToResume?.resumeFetching()
 
     fire(for: .resume, snapshot: snapshot)
 

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -46,15 +46,18 @@ import Foundation
   @objc open func enqueue() {
     // Capturing self so that the upload is done whether or not there is a callback.
     dispatchQueue.async { [self] in
-      stateLock.lock()
-      if let contentValidationError = self.contentUploadError() {
-        self.error = contentValidationError
-        stateLock.unlock()
+      let shouldReturn = stateLock.withLock { () -> Bool in
+        if let contentValidationError = self.contentUploadError() {
+          self.error = contentValidationError
+          return true
+        }
+        self.state = .queueing
+        return false
+      }
+      if shouldReturn {
         self.finishTaskWithStatus(status: .failure, snapshot: self.snapshot)
         return
       }
-      self.state = .queueing
-      stateLock.unlock()
 
       let dataRepresentation = self.uploadMetadata.dictionaryRepresentation()
       let bodyData = try? JSONSerialization.data(withJSONObject: dataRepresentation)
@@ -108,88 +111,77 @@ import Foundation
         uploadFetcher.sendProgressBlock = { [weak self] (bytesSent: Int64, totalBytesSent: Int64,
                                                          totalBytesExpectedToSend: Int64) in
             guard let self = self else { return }
-            self.stateLock.lock()
-            if self.state == .cancelled || self.state == .pausing || self.state == .paused {
-              self.stateLock.unlock()
-              return
+            let shouldReturn = self.stateLock.withLock { () -> Bool in
+              if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+                return true
+              }
+              self.state = .progress
+              self.progress.completedUnitCount = totalBytesSent
+              self.progress.totalUnitCount = totalBytesExpectedToSend
+              self.metadata = self.uploadMetadata
+              return false
             }
-            self.state = .progress
-            self.progress.completedUnitCount = totalBytesSent
-            self.progress.totalUnitCount = totalBytesExpectedToSend
-            self.metadata = self.uploadMetadata
-            self.stateLock.unlock()
+            if shouldReturn { return }
 
             self.fire(for: .progress, snapshot: self.snapshot)
 
-            self.stateLock.lock()
-            if self.state == .cancelled || self.state == .pausing || self.state == .paused {
-              self.stateLock.unlock()
-              return
+            self.stateLock.withLock {
+              if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+                return
+              }
+              self.state = .running
             }
-            self.state = .running
-            self.stateLock.unlock()
         }
         self.uploadFetcher = uploadFetcher
 
         // Process fetches
-        self.stateLock.lock()
-        self.state = .running
-        self.stateLock.unlock()
+        self.stateLock.withLock {
+          self.state = .running
+        }
         do {
           let data = try await self.uploadFetcher?.beginFetch()
-          self.stateLock.lock()
-          if self.state == .cancelled {
-            self.stateLock.unlock()
-            return
-          }
-          self.stateLock.unlock()
+          let isCancelled = self.stateLock.withLock { self.state == .cancelled }
+          if isCancelled { return }
 
           // Fire last progress updates
           self.fire(for: .progress, snapshot: self.snapshot)
 
           // Upload completed successfully, fire completion callbacks
-          self.stateLock.lock()
-          if self.state == .cancelled {
-            self.stateLock.unlock()
-            return
-          }
-          self.state = .success
+          let shouldReturn = self.stateLock.withLock { () -> Bool in
+            if self.state == .cancelled { return true }
+            self.state = .success
 
-          guard let data = data else {
-            self.stateLock.unlock()
-            fatalError("Internal Error: uploadFetcher returned with nil data and no error")
-          }
+            guard let data = data else {
+              fatalError("Internal Error: uploadFetcher returned with nil data and no error")
+            }
 
-          if let responseDictionary = try? JSONSerialization
-            .jsonObject(with: data) as? [String: AnyHashable] {
-            let metadata = StorageMetadata(dictionary: responseDictionary)
-            metadata.fileType = .file
-            self.metadata = metadata
-          } else {
-            self.error = StorageErrorCode.error(withInvalidRequest: data)
+            if let responseDictionary = try? JSONSerialization
+              .jsonObject(with: data) as? [String: AnyHashable] {
+              let metadata = StorageMetadata(dictionary: responseDictionary)
+              metadata.fileType = .file
+              self.metadata = metadata
+            } else {
+              self.error = StorageErrorCode.error(withInvalidRequest: data)
+            }
+            return false
           }
-          self.stateLock.unlock()
+          if shouldReturn { return }
           self.finishTaskWithStatus(status: .success, snapshot: self.snapshot)
         } catch {
-          self.stateLock.lock()
-          if self.state == .cancelled {
-            self.stateLock.unlock()
-            return
-          }
-          self.stateLock.unlock()
+          let isCancelled = self.stateLock.withLock { self.state == .cancelled }
+          if isCancelled { return }
 
           self.fire(for: .progress, snapshot: self.snapshot)
 
-          self.stateLock.lock()
-          if self.state == .cancelled {
-            self.stateLock.unlock()
-            return
+          let shouldReturn = self.stateLock.withLock { () -> Bool in
+            if self.state == .cancelled { return true }
+            self.state = .failed
+            self.error = StorageErrorCode.error(withServerError: error as NSError,
+                                                ref: self.reference)
+            self.metadata = self.uploadMetadata
+            return false
           }
-          self.state = .failed
-          self.error = StorageErrorCode.error(withServerError: error as NSError,
-                                              ref: self.reference)
-          self.metadata = self.uploadMetadata
-          self.stateLock.unlock()
+          if shouldReturn { return }
 
           self.finishTaskWithStatus(status: .failure, snapshot: self.snapshot)
         }
@@ -201,16 +193,16 @@ import Foundation
    * Pauses a task currently in progress.
    */
   @objc open func pause() {
-    stateLock.lock()
-    if state == .paused || state == .pausing || state == .success || state == .cancelled || state ==
-      .failed {
-      stateLock.unlock()
-      return
+    let shouldReturn = stateLock.withLock { () -> Bool in
+      if state == .paused || state == .pausing || state == .success || state == .cancelled || state == .failed {
+        return true
+      }
+      state = .paused
+      uploadFetcher?.pauseFetching()
+      metadata = uploadMetadata
+      return false
     }
-    state = .paused
-    uploadFetcher?.pauseFetching()
-    metadata = uploadMetadata
-    stateLock.unlock()
+    if shouldReturn { return }
 
     fire(for: .pause, snapshot: snapshot)
   }
@@ -219,19 +211,20 @@ import Foundation
    * Cancels a task.
    */
   @objc open func cancel() {
-    stateLock.lock()
-    if state == .cancelled || state == .success || state == .failed {
-      stateLock.unlock()
-      return
+    let shouldReturn = stateLock.withLock { () -> Bool in
+      if state == .cancelled || state == .success || state == .failed {
+        return true
+      }
+      state = .cancelled
+      uploadFetcher?.stopFetching()
+      metadata = uploadMetadata
+      error = StorageErrorCode.error(
+        withServerError: StorageErrorCode.cancelled as NSError,
+        ref: reference
+      )
+      return false
     }
-    state = .cancelled
-    uploadFetcher?.stopFetching()
-    metadata = uploadMetadata
-    error = StorageErrorCode.error(
-      withServerError: StorageErrorCode.cancelled as NSError,
-      ref: reference
-    )
-    stateLock.unlock()
+    if shouldReturn { return }
 
     fire(for: .failure, snapshot: snapshot)
     removeAllObservers()
@@ -241,27 +234,23 @@ import Foundation
    * Resumes a paused task.
    */
   @objc open func resume() {
-    stateLock.lock()
-    if state == .running || state == .resuming || state == .success || state == .cancelled ||
-      state ==
-      .failed {
-      stateLock.unlock()
-      return
+    let shouldReturn1 = stateLock.withLock { () -> Bool in
+      if state == .running || state == .resuming || state == .success || state == .cancelled || state == .failed {
+        return true
+      }
+      state = .resuming
+      uploadFetcher?.resumeFetching()
+      metadata = uploadMetadata
+      return false
     }
-    state = .resuming
-    uploadFetcher?.resumeFetching()
-    metadata = uploadMetadata
-    stateLock.unlock()
+    if shouldReturn1 { return }
 
     fire(for: .resume, snapshot: snapshot)
 
-    stateLock.lock()
-    if state == .cancelled || state == .paused || state == .pausing {
-      stateLock.unlock()
-      return
+    stateLock.withLock {
+      if state == .cancelled || state == .paused || state == .pausing { return }
+      state = .running
     }
-    state = .running
-    stateLock.unlock()
   }
 
   private var uploadFetcher: GTMSessionUploadFetcher?

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -132,11 +132,23 @@ import Foundation
               self.state = .running
             }
         }
-        self.uploadFetcher = uploadFetcher
-
         // Process fetches
-        self.stateLock.withLock {
+        let shouldContinue = self.stateLock.withLock { () -> Bool in
+          if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+            return false
+          }
+          self.uploadFetcher = uploadFetcher
           self.state = .running
+          return true
+        }
+        if !shouldContinue {
+          let isPaused = self.stateLock.withLock { self.state == .paused || self.state == .pausing }
+          if isPaused {
+            uploadFetcher.pauseFetching()
+          } else {
+            uploadFetcher.stopFetching()
+          }
+          return
         }
         do {
           let data = try await self.uploadFetcher?.beginFetch()
@@ -168,8 +180,10 @@ import Foundation
           if shouldReturn { return }
           self.finishTaskWithStatus(status: .success, snapshot: self.snapshot)
         } catch {
-          let isCancelled = self.stateLock.withLock { self.state == .cancelled }
-          if isCancelled { return }
+          let shouldReturnEarly = self.stateLock.withLock { self.state == .cancelled ||
+            self.state == .paused || self.state == .pausing
+          }
+          if shouldReturnEarly { return }
 
           self.fire(for: .progress, snapshot: self.snapshot)
 

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -46,16 +46,24 @@ import Foundation
   @objc open func enqueue() {
     // Capturing self so that the upload is done whether or not there is a callback.
     dispatchQueue.async { [self] in
-      let shouldReturn = stateLock.withLock { () -> Bool in
+      var isValidationError = false
+      let shouldProceed = stateLock.withLock { () -> Bool in
+        if state == .cancelled || state == .pausing || state == .paused || state == .success ||
+          state == .failed {
+          return false
+        }
         if let contentValidationError = self.contentUploadError() {
           self.error = contentValidationError
-          return true
+          isValidationError = true
+          return false
         }
         self.state = .queueing
-        return false
+        return true
       }
-      if shouldReturn {
-        self.finishTaskWithStatus(status: .failure, snapshot: self.snapshot)
+      if !shouldProceed {
+        if isValidationError {
+          self.finishTaskWithStatus(status: .failure, snapshot: self.snapshot)
+        }
         return
       }
 
@@ -251,6 +259,7 @@ import Foundation
    */
   @objc open func resume() {
     var fetcherToResume: GTMSessionUploadFetcher?
+    var shouldReenqueue = false
     let shouldResume = stateLock.withLock { () -> Bool in
       if state == .running || state == .resuming || state == .success || state == .cancelled ||
         state == .failed {
@@ -258,18 +267,29 @@ import Foundation
       }
       state = .resuming
       metadata = uploadMetadata
-      fetcherToResume = uploadFetcher
+      if uploadFetcher == nil {
+        shouldReenqueue = true
+      } else {
+        fetcherToResume = uploadFetcher
+      }
       return true
     }
     if !shouldResume { return }
 
-    fetcherToResume?.resumeFetching()
-
     fire(for: .resume, snapshot: snapshot)
 
-    stateLock.withLock {
-      if state == .cancelled || state == .paused || state == .pausing { return }
+    let shouldProceed = stateLock.withLock { () -> Bool in
+      if state == .cancelled || state == .paused || state == .pausing { return false }
       state = .running
+      return true
+    }
+
+    if shouldProceed {
+      if shouldReenqueue {
+        enqueue()
+      } else {
+        fetcherToResume?.resumeFetching()
+      }
     }
   }
 

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -39,7 +39,7 @@ import Foundation
  * specified `callbackQueue` in Storage, or the main queue if unspecified.
  */
 @objc(FIRStorageUploadTask) open class StorageUploadTask: StorageObservableTask,
-  StorageTaskManagement {
+  StorageTaskManagement, @unchecked Sendable {
   /**
    * Prepares a task and begins execution.
    */
@@ -309,5 +309,3 @@ import Foundation
     return input.addingPercentEncoding(withAllowedCharacters: allowedCharacters)
   }
 }
-
-extension StorageUploadTask: @unchecked Sendable {}

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -194,7 +194,8 @@ import Foundation
    */
   @objc open func pause() {
     let shouldReturn = stateLock.withLock { () -> Bool in
-      if state == .paused || state == .pausing || state == .success || state == .cancelled || state == .failed {
+      if state == .paused || state == .pausing || state == .success || state == .cancelled ||
+        state == .failed {
         return true
       }
       state = .paused
@@ -235,7 +236,8 @@ import Foundation
    */
   @objc open func resume() {
     let shouldReturn1 = stateLock.withLock { () -> Bool in
-      if state == .running || state == .resuming || state == .success || state == .cancelled || state == .failed {
+      if state == .running || state == .resuming || state == .success || state == .cancelled ||
+        state == .failed {
         return true
       }
       state = .resuming

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -193,17 +193,18 @@ import Foundation
    * Pauses a task currently in progress.
    */
   @objc open func pause() {
-    let shouldReturn = stateLock.withLock { () -> Bool in
+    let shouldPause = stateLock.withLock { () -> Bool in
       if state == .paused || state == .pausing || state == .success || state == .cancelled ||
         state == .failed {
-        return true
+        return false
       }
       state = .paused
-      uploadFetcher?.pauseFetching()
       metadata = uploadMetadata
-      return false
+      return true
     }
-    if shouldReturn { return }
+    if !shouldPause { return }
+
+    uploadFetcher?.pauseFetching()
 
     fire(for: .pause, snapshot: snapshot)
   }
@@ -212,17 +213,18 @@ import Foundation
    * Cancels a task.
    */
   @objc open func cancel() {
-    let shouldReturn = stateLock.withLock { () -> Bool in
+    let shouldCancel = stateLock.withLock { () -> Bool in
       if state == .cancelled || state == .success || state == .failed {
-        return true
+        return false
       }
       state = .cancelled
-      uploadFetcher?.stopFetching()
       metadata = uploadMetadata
       error = StorageError.cancelled as NSError
-      return false
+      return true
     }
-    if shouldReturn { return }
+    if !shouldCancel { return }
+
+    uploadFetcher?.stopFetching()
 
     fire(for: .failure, snapshot: snapshot)
     removeAllObservers()
@@ -232,17 +234,18 @@ import Foundation
    * Resumes a paused task.
    */
   @objc open func resume() {
-    let shouldReturn1 = stateLock.withLock { () -> Bool in
+    let shouldResume = stateLock.withLock { () -> Bool in
       if state == .running || state == .resuming || state == .success || state == .cancelled ||
         state == .failed {
-        return true
+        return false
       }
       state = .resuming
-      uploadFetcher?.resumeFetching()
       metadata = uploadMetadata
-      return false
+      return true
     }
-    if shouldReturn1 { return }
+    if !shouldResume { return }
+
+    uploadFetcher?.resumeFetching()
 
     fire(for: .resume, snapshot: snapshot)
 

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -46,7 +46,7 @@ import Foundation
   @objc open func enqueue() {
     // Capturing self so that the upload is done whether or not there is a callback.
     dispatchQueue.async { [self] in
-      var isValidationError = false
+      var failureSnapshot: StorageTaskSnapshot?
       let shouldProceed = stateLock.withLock { () -> Bool in
         if state == .cancelled || state == .pausing || state == .paused || state == .success ||
           state == .failed {
@@ -54,15 +54,16 @@ import Foundation
         }
         if let contentValidationError = self.contentUploadError() {
           self.error = contentValidationError
-          isValidationError = true
+          self.state = .failed
+          failureSnapshot = self.snapshotUnderLock()
           return false
         }
         self.state = .queueing
         return true
       }
       if !shouldProceed {
-        if isValidationError {
-          self.finishTaskWithStatus(status: .failure, snapshot: self.snapshot)
+        if let failureSnapshot {
+          self.finishTaskWithStatus(status: .failure, snapshot: failureSnapshot)
         }
         return
       }
@@ -119,20 +120,21 @@ import Foundation
         uploadFetcher.sendProgressBlock = { [weak self] (bytesSent: Int64, totalBytesSent: Int64,
                                                          totalBytesExpectedToSend: Int64) in
             guard let self = self else { return }
-            let shouldReturn = self.stateLock.withLock { () -> Bool in
+            var snapshotToFire: StorageTaskSnapshot?
+            self.stateLock.withLock {
               if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
                 self.state == .success || self.state == .failed {
-                return true
+                return
               }
               self.state = .progress
               self.progress.completedUnitCount = totalBytesSent
               self.progress.totalUnitCount = totalBytesExpectedToSend
               self.metadata = self.uploadMetadata
-              return false
+              snapshotToFire = self.snapshotUnderLock()
             }
-            if shouldReturn { return }
-
-            self.fire(for: .progress, snapshot: self.snapshot)
+            if let snapshotToFire {
+              self.fire(for: .progress, snapshot: snapshotToFire)
+            }
 
             self.stateLock.withLock {
               if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
@@ -162,17 +164,16 @@ import Foundation
         }
         do {
           let data = try await uploadFetcher.beginFetch()
-          let isCancelled = self.stateLock.withLock { self.state == .cancelled }
-          if isCancelled { return }
+          var progressSnapshot: StorageTaskSnapshot?
+          var successSnapshot: StorageTaskSnapshot?
 
-          // Fire last progress updates
-          self.fire(for: .progress, snapshot: self.snapshot)
+          self.stateLock.withLock {
+            if self.state == .cancelled { return }
 
-          // Upload completed successfully, fire completion callbacks
-          let shouldReturn = self.stateLock.withLock { () -> Bool in
-            if self.state == .cancelled { return true }
+            self.state = .progress
+            progressSnapshot = self.snapshotUnderLock()
+
             self.state = .success
-
             if let responseDictionary = try? JSONSerialization
               .jsonObject(with: data) as? [String: AnyHashable] {
               let metadata = StorageMetadata(dictionary: responseDictionary)
@@ -181,29 +182,38 @@ import Foundation
             } else {
               self.error = StorageErrorCode.error(withInvalidRequest: data)
             }
-            return false
+            successSnapshot = self.snapshotUnderLock()
           }
-          if shouldReturn { return }
-          self.finishTaskWithStatus(status: .success, snapshot: self.snapshot)
+
+          if let progressSnapshot {
+            self.fire(for: .progress, snapshot: progressSnapshot)
+          }
+          if let successSnapshot {
+            self.finishTaskWithStatus(status: .success, snapshot: successSnapshot)
+          }
         } catch {
-          let shouldReturnEarly = self.stateLock.withLock { self.state == .cancelled ||
-            self.state == .paused || self.state == .pausing
-          }
-          if shouldReturnEarly { return }
+          var progressSnapshot: StorageTaskSnapshot?
+          var failureSnapshot: StorageTaskSnapshot?
 
-          self.fire(for: .progress, snapshot: self.snapshot)
+          self.stateLock.withLock {
+            if self.state == .cancelled || self.state == .paused || self.state == .pausing { return }
 
-          let shouldReturn = self.stateLock.withLock { () -> Bool in
-            if self.state == .cancelled { return true }
+            self.state = .progress
+            progressSnapshot = self.snapshotUnderLock()
+
             self.state = .failed
             self.error = StorageErrorCode.error(withServerError: error as NSError,
                                                 ref: self.reference)
             self.metadata = self.uploadMetadata
-            return false
+            failureSnapshot = self.snapshotUnderLock()
           }
-          if shouldReturn { return }
 
-          self.finishTaskWithStatus(status: .failure, snapshot: self.snapshot)
+          if let progressSnapshot {
+            self.fire(for: .progress, snapshot: progressSnapshot)
+          }
+          if let failureSnapshot {
+            self.finishTaskWithStatus(status: .failure, snapshot: failureSnapshot)
+          }
         }
       }
     }
@@ -214,21 +224,21 @@ import Foundation
    */
   @objc open func pause() {
     var fetcherToPause: GTMSessionUploadFetcher?
-    let shouldPause = stateLock.withLock { () -> Bool in
+    var pauseSnapshot: StorageTaskSnapshot?
+    stateLock.withLock {
       if state == .paused || state == .pausing || state == .success || state == .cancelled ||
         state == .failed {
-        return false
+        return
       }
       state = .paused
       metadata = uploadMetadata
       fetcherToPause = uploadFetcher
-      return true
+      pauseSnapshot = snapshotUnderLock()
     }
-    if !shouldPause { return }
-
-    fetcherToPause?.pauseFetching()
-
-    fire(for: .pause, snapshot: snapshot)
+    if let pauseSnapshot {
+      fetcherToPause?.pauseFetching()
+      fire(for: .pause, snapshot: pauseSnapshot)
+    }
   }
 
   /**
@@ -236,22 +246,22 @@ import Foundation
    */
   @objc open func cancel() {
     var fetcherToStop: GTMSessionUploadFetcher?
-    let shouldCancel = stateLock.withLock { () -> Bool in
+    var failureSnapshot: StorageTaskSnapshot?
+    stateLock.withLock {
       if state == .cancelled || state == .success || state == .failed {
-        return false
+        return
       }
       state = .cancelled
       metadata = uploadMetadata
       error = StorageError.cancelled as NSError
       fetcherToStop = uploadFetcher
-      return true
+      failureSnapshot = snapshotUnderLock()
     }
-    if !shouldCancel { return }
-
-    fetcherToStop?.stopFetching()
-
-    fire(for: .failure, snapshot: snapshot)
-    removeAllObservers()
+    if let failureSnapshot {
+      fetcherToStop?.stopFetching()
+      fire(for: .failure, snapshot: failureSnapshot)
+      removeAllObservers()
+    }
   }
 
   /**
@@ -260,6 +270,7 @@ import Foundation
   @objc open func resume() {
     var fetcherToResume: GTMSessionUploadFetcher?
     var shouldReenqueue = false
+    var resumeSnapshot: StorageTaskSnapshot?
     let shouldResume = stateLock.withLock { () -> Bool in
       if state == .running || state == .resuming || state == .success || state == .cancelled ||
         state == .failed {
@@ -272,11 +283,14 @@ import Foundation
       } else {
         fetcherToResume = uploadFetcher
       }
+      resumeSnapshot = snapshotUnderLock()
       return true
     }
     if !shouldResume { return }
 
-    fire(for: .resume, snapshot: snapshot)
+    if let resumeSnapshot {
+      fire(for: .resume, snapshot: resumeSnapshot)
+    }
 
     let shouldProceed = stateLock.withLock { () -> Bool in
       if state == .cancelled || state == .paused || state == .pausing { return false }

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -168,6 +168,7 @@ import Foundation
           let data = try await uploadFetcher.beginFetch()
           var progressSnapshot: StorageTaskSnapshot?
           var successSnapshot: StorageTaskSnapshot?
+          var failureSnapshot: StorageTaskSnapshot?
 
           self.stateLock.withLock {
             if self.state == .cancelled { return }
@@ -175,16 +176,18 @@ import Foundation
             self.state = .progress
             progressSnapshot = self.snapshotUnderLock()
 
-            self.state = .success
             if let responseDictionary = try? JSONSerialization
               .jsonObject(with: data) as? [String: AnyHashable] {
+              self.state = .success
               let metadata = StorageMetadata(dictionary: responseDictionary)
               metadata.fileType = .file
               self.metadata = metadata
+              successSnapshot = self.snapshotUnderLock()
             } else {
+              self.state = .failed
               self.error = StorageErrorCode.error(withInvalidRequest: data)
+              failureSnapshot = self.snapshotUnderLock()
             }
-            successSnapshot = self.snapshotUnderLock()
           }
 
           if let progressSnapshot {
@@ -192,6 +195,8 @@ import Foundation
           }
           if let successSnapshot {
             self.finishTaskWithStatus(status: .success, snapshot: successSnapshot)
+          } else if let failureSnapshot {
+            self.finishTaskWithStatus(status: .failure, snapshot: failureSnapshot)
           }
         } catch {
           var progressSnapshot: StorageTaskSnapshot?

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -219,10 +219,7 @@ import Foundation
       state = .cancelled
       uploadFetcher?.stopFetching()
       metadata = uploadMetadata
-      error = StorageErrorCode.error(
-        withServerError: StorageErrorCode.cancelled as NSError,
-        ref: reference
-      )
+      error = StorageError.cancelled as NSError
       return false
     }
     if shouldReturn { return }

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -46,13 +46,14 @@ import Foundation
   @objc open func enqueue() {
     // Capturing self so that the upload is done whether or not there is a callback.
     dispatchQueue.async { [self] in
+      let contentValidationError = self.contentUploadError()
       var failureSnapshot: StorageTaskSnapshot?
       let shouldProceed = stateLock.withLock { () -> Bool in
         if state == .cancelled || state == .pausing || state == .paused || state == .success ||
           state == .failed {
           return false
         }
-        if let contentValidationError = self.contentUploadError() {
+        if let contentValidationError {
           self.error = contentValidationError
           self.state = .failed
           failureSnapshot = self.snapshotUnderLock()

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -146,8 +146,10 @@ import Foundation
             }
         }
         // Process fetches
+        var isPaused = false
         let shouldContinue = self.stateLock.withLock { () -> Bool in
           if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+            isPaused = self.state == .paused || self.state == .pausing
             return false
           }
           self.uploadFetcher = uploadFetcher
@@ -155,7 +157,6 @@ import Foundation
           return true
         }
         if !shouldContinue {
-          let isPaused = self.stateLock.withLock { self.state == .paused || self.state == .pausing }
           if isPaused {
             uploadFetcher.pauseFetching()
           } else {

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -309,3 +309,5 @@ import Foundation
     return input.addingPercentEncoding(withAllowedCharacters: allowedCharacters)
   }
 }
+
+extension StorageUploadTask: @unchecked Sendable {}

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -49,8 +49,8 @@ import Foundation
       let contentValidationError = self.contentUploadError()
       var failureSnapshot: StorageTaskSnapshot?
       let shouldProceed = stateLock.withLock { () -> Bool in
-        if state == .cancelled || state == .pausing || state == .paused || state == .success ||
-          state == .failed {
+        guard state == .unknown || state == .queueing || state == .resuming || state == .running ||
+          state == .progress else {
           return false
         }
         if let contentValidationError {
@@ -123,8 +123,8 @@ import Foundation
             guard let self = self else { return }
             var snapshotToFire: StorageTaskSnapshot?
             self.stateLock.withLock {
-              if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
-                self.state == .success || self.state == .failed {
+              guard self.state == .unknown || self.state == .queueing || self.state == .resuming ||
+                self.state == .running || self.state == .progress else {
                 return
               }
               self.state = .progress
@@ -138,8 +138,8 @@ import Foundation
             }
 
             self.stateLock.withLock {
-              if self.state == .cancelled || self.state == .pausing || self.state == .paused ||
-                self.state == .success || self.state == .failed {
+              guard self.state == .unknown || self.state == .queueing || self.state == .resuming ||
+                self.state == .running || self.state == .progress else {
                 return
               }
               self.state = .running
@@ -234,8 +234,8 @@ import Foundation
     var fetcherToPause: GTMSessionUploadFetcher?
     var pauseSnapshot: StorageTaskSnapshot?
     stateLock.withLock {
-      if state == .paused || state == .pausing || state == .success || state == .cancelled ||
-        state == .failed {
+      guard state == .unknown || state == .queueing || state == .resuming || state == .running ||
+        state == .progress else {
         return
       }
       state = .paused
@@ -280,8 +280,8 @@ import Foundation
     var shouldReenqueue = false
     var resumeSnapshot: StorageTaskSnapshot?
     let shouldResume = stateLock.withLock { () -> Bool in
-      if state == .running || state == .resuming || state == .success || state == .cancelled ||
-        state == .failed {
+      guard state == .unknown || state == .queueing || state == .pausing || state == .paused ||
+        state == .progress else {
         return false
       }
       state = .resuming

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -106,12 +106,17 @@ import Foundation
         uploadFetcher.sendProgressBlock = { [weak self] (bytesSent: Int64, totalBytesSent: Int64,
                                                          totalBytesExpectedToSend: Int64) in
             guard let self = self else { return }
-            self.state = .progress
-            self.progress.completedUnitCount = totalBytesSent
-            self.progress.totalUnitCount = totalBytesExpectedToSend
-            self.metadata = self.uploadMetadata
-            self.fire(for: .progress, snapshot: self.snapshot)
-            self.state = .running
+            self.dispatchQueue.async { [weak self] in
+              guard let self = self else { return }
+              if self.state == .cancelled || self.state == .pausing || self
+                .state == .paused { return }
+              self.state = .progress
+              self.progress.completedUnitCount = totalBytesSent
+              self.progress.totalUnitCount = totalBytesExpectedToSend
+              self.metadata = self.uploadMetadata
+              self.fire(for: .progress, snapshot: self.snapshot)
+              self.state = .running
+            }
         }
         self.uploadFetcher = uploadFetcher
 
@@ -119,32 +124,40 @@ import Foundation
         self.state = .running
         do {
           let data = try await self.uploadFetcher?.beginFetch()
-          // Fire last progress updates
-          self.fire(for: .progress, snapshot: self.snapshot)
+          self.dispatchQueue.async { [weak self] in
+            guard let self = self else { return }
+            if self.state == .cancelled { return }
+            // Fire last progress updates
+            self.fire(for: .progress, snapshot: self.snapshot)
 
-          // Upload completed successfully, fire completion callbacks
-          self.state = .success
+            // Upload completed successfully, fire completion callbacks
+            self.state = .success
 
-          guard let data = data else {
-            fatalError("Internal Error: uploadFetcher returned with nil data and no error")
+            guard let data = data else {
+              fatalError("Internal Error: uploadFetcher returned with nil data and no error")
+            }
+
+            if let responseDictionary = try? JSONSerialization
+              .jsonObject(with: data) as? [String: AnyHashable] {
+              let metadata = StorageMetadata(dictionary: responseDictionary)
+              metadata.fileType = .file
+              self.metadata = metadata
+            } else {
+              self.error = StorageErrorCode.error(withInvalidRequest: data)
+            }
+            self.finishTaskWithStatus(status: .success, snapshot: self.snapshot)
           }
-
-          if let responseDictionary = try? JSONSerialization
-            .jsonObject(with: data) as? [String: AnyHashable] {
-            let metadata = StorageMetadata(dictionary: responseDictionary)
-            metadata.fileType = .file
-            self.metadata = metadata
-          } else {
-            self.error = StorageErrorCode.error(withInvalidRequest: data)
-          }
-          self.finishTaskWithStatus(status: .success, snapshot: self.snapshot)
         } catch {
-          self.fire(for: .progress, snapshot: self.snapshot)
-          self.state = .failed
-          self.error = StorageErrorCode.error(withServerError: error as NSError,
-                                              ref: self.reference)
-          self.metadata = self.uploadMetadata
-          self.finishTaskWithStatus(status: .failure, snapshot: self.snapshot)
+          self.dispatchQueue.async { [weak self] in
+            guard let self = self else { return }
+            if self.state == .cancelled { return }
+            self.fire(for: .progress, snapshot: self.snapshot)
+            self.state = .failed
+            self.error = StorageErrorCode.error(withServerError: error as NSError,
+                                                ref: self.reference)
+            self.metadata = self.uploadMetadata
+            self.finishTaskWithStatus(status: .failure, snapshot: self.snapshot)
+          }
         }
       }
     }
@@ -181,6 +194,7 @@ import Foundation
         ref: self.reference
       )
       self.fire(for: .failure, snapshot: self.snapshot)
+      self.removeAllObservers()
     }
   }
 

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -46,13 +46,15 @@ import Foundation
   @objc open func enqueue() {
     // Capturing self so that the upload is done whether or not there is a callback.
     dispatchQueue.async { [self] in
+      stateLock.lock()
       if let contentValidationError = self.contentUploadError() {
         self.error = contentValidationError
+        stateLock.unlock()
         self.finishTaskWithStatus(status: .failure, snapshot: self.snapshot)
         return
       }
-
       self.state = .queueing
+      stateLock.unlock()
 
       let dataRepresentation = self.uploadMetadata.dictionaryRepresentation()
       let bodyData = try? JSONSerialization.data(withJSONObject: dataRepresentation)
@@ -106,58 +108,90 @@ import Foundation
         uploadFetcher.sendProgressBlock = { [weak self] (bytesSent: Int64, totalBytesSent: Int64,
                                                          totalBytesExpectedToSend: Int64) in
             guard let self = self else { return }
-            self.dispatchQueue.async { [weak self] in
-              guard let self = self else { return }
-              if self.state == .cancelled || self.state == .pausing || self
-                .state == .paused { return }
-              self.state = .progress
-              self.progress.completedUnitCount = totalBytesSent
-              self.progress.totalUnitCount = totalBytesExpectedToSend
-              self.metadata = self.uploadMetadata
-              self.fire(for: .progress, snapshot: self.snapshot)
-              self.state = .running
+            self.stateLock.lock()
+            if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+              self.stateLock.unlock()
+              return
             }
+            self.state = .progress
+            self.progress.completedUnitCount = totalBytesSent
+            self.progress.totalUnitCount = totalBytesExpectedToSend
+            self.metadata = self.uploadMetadata
+            self.stateLock.unlock()
+
+            self.fire(for: .progress, snapshot: self.snapshot)
+
+            self.stateLock.lock()
+            if self.state == .cancelled || self.state == .pausing || self.state == .paused {
+              self.stateLock.unlock()
+              return
+            }
+            self.state = .running
+            self.stateLock.unlock()
         }
         self.uploadFetcher = uploadFetcher
 
         // Process fetches
+        self.stateLock.lock()
         self.state = .running
+        self.stateLock.unlock()
         do {
           let data = try await self.uploadFetcher?.beginFetch()
-          self.dispatchQueue.async { [weak self] in
-            guard let self = self else { return }
-            if self.state == .cancelled { return }
-            // Fire last progress updates
-            self.fire(for: .progress, snapshot: self.snapshot)
-
-            // Upload completed successfully, fire completion callbacks
-            self.state = .success
-
-            guard let data = data else {
-              fatalError("Internal Error: uploadFetcher returned with nil data and no error")
-            }
-
-            if let responseDictionary = try? JSONSerialization
-              .jsonObject(with: data) as? [String: AnyHashable] {
-              let metadata = StorageMetadata(dictionary: responseDictionary)
-              metadata.fileType = .file
-              self.metadata = metadata
-            } else {
-              self.error = StorageErrorCode.error(withInvalidRequest: data)
-            }
-            self.finishTaskWithStatus(status: .success, snapshot: self.snapshot)
+          self.stateLock.lock()
+          if self.state == .cancelled {
+            self.stateLock.unlock()
+            return
           }
+          self.stateLock.unlock()
+
+          // Fire last progress updates
+          self.fire(for: .progress, snapshot: self.snapshot)
+
+          // Upload completed successfully, fire completion callbacks
+          self.stateLock.lock()
+          if self.state == .cancelled {
+            self.stateLock.unlock()
+            return
+          }
+          self.state = .success
+
+          guard let data = data else {
+            self.stateLock.unlock()
+            fatalError("Internal Error: uploadFetcher returned with nil data and no error")
+          }
+
+          if let responseDictionary = try? JSONSerialization
+            .jsonObject(with: data) as? [String: AnyHashable] {
+            let metadata = StorageMetadata(dictionary: responseDictionary)
+            metadata.fileType = .file
+            self.metadata = metadata
+          } else {
+            self.error = StorageErrorCode.error(withInvalidRequest: data)
+          }
+          self.stateLock.unlock()
+          self.finishTaskWithStatus(status: .success, snapshot: self.snapshot)
         } catch {
-          self.dispatchQueue.async { [weak self] in
-            guard let self = self else { return }
-            if self.state == .cancelled { return }
-            self.fire(for: .progress, snapshot: self.snapshot)
-            self.state = .failed
-            self.error = StorageErrorCode.error(withServerError: error as NSError,
-                                                ref: self.reference)
-            self.metadata = self.uploadMetadata
-            self.finishTaskWithStatus(status: .failure, snapshot: self.snapshot)
+          self.stateLock.lock()
+          if self.state == .cancelled {
+            self.stateLock.unlock()
+            return
           }
+          self.stateLock.unlock()
+
+          self.fire(for: .progress, snapshot: self.snapshot)
+
+          self.stateLock.lock()
+          if self.state == .cancelled {
+            self.stateLock.unlock()
+            return
+          }
+          self.state = .failed
+          self.error = StorageErrorCode.error(withServerError: error as NSError,
+                                              ref: self.reference)
+          self.metadata = self.uploadMetadata
+          self.stateLock.unlock()
+
+          self.finishTaskWithStatus(status: .failure, snapshot: self.snapshot)
         }
       }
     }
@@ -167,51 +201,67 @@ import Foundation
    * Pauses a task currently in progress.
    */
   @objc open func pause() {
-    dispatchQueue.async { [weak self] in
-      guard let self = self else { return }
-      self.state = .paused
-      self.uploadFetcher?.pauseFetching()
-      if self.state != .success {
-        self.metadata = self.uploadMetadata
-      }
-      self.fire(for: .pause, snapshot: self.snapshot)
+    stateLock.lock()
+    if state == .paused || state == .pausing || state == .success || state == .cancelled || state ==
+      .failed {
+      stateLock.unlock()
+      return
     }
+    state = .paused
+    uploadFetcher?.pauseFetching()
+    metadata = uploadMetadata
+    stateLock.unlock()
+
+    fire(for: .pause, snapshot: snapshot)
   }
 
   /**
    * Cancels a task.
    */
   @objc open func cancel() {
-    dispatchQueue.async { [weak self] in
-      guard let self = self else { return }
-      self.state = .cancelled
-      self.uploadFetcher?.stopFetching()
-      if self.state != .success {
-        self.metadata = self.uploadMetadata
-      }
-      self.error = StorageErrorCode.error(
-        withServerError: StorageErrorCode.cancelled as NSError,
-        ref: self.reference
-      )
-      self.fire(for: .failure, snapshot: self.snapshot)
-      self.removeAllObservers()
+    stateLock.lock()
+    if state == .cancelled || state == .success || state == .failed {
+      stateLock.unlock()
+      return
     }
+    state = .cancelled
+    uploadFetcher?.stopFetching()
+    metadata = uploadMetadata
+    error = StorageErrorCode.error(
+      withServerError: StorageErrorCode.cancelled as NSError,
+      ref: reference
+    )
+    stateLock.unlock()
+
+    fire(for: .failure, snapshot: snapshot)
+    removeAllObservers()
   }
 
   /**
    * Resumes a paused task.
    */
   @objc open func resume() {
-    dispatchQueue.async { [weak self] in
-      guard let self = self else { return }
-      self.state = .resuming
-      self.uploadFetcher?.resumeFetching()
-      if self.state != .success {
-        self.metadata = self.uploadMetadata
-      }
-      self.fire(for: .resume, snapshot: self.snapshot)
-      self.state = .running
+    stateLock.lock()
+    if state == .running || state == .resuming || state == .success || state == .cancelled ||
+      state ==
+      .failed {
+      stateLock.unlock()
+      return
     }
+    state = .resuming
+    uploadFetcher?.resumeFetching()
+    metadata = uploadMetadata
+    stateLock.unlock()
+
+    fire(for: .resume, snapshot: snapshot)
+
+    stateLock.lock()
+    if state == .cancelled || state == .paused || state == .pausing {
+      stateLock.unlock()
+      return
+    }
+    state = .running
+    stateLock.unlock()
   }
 
   private var uploadFetcher: GTMSessionUploadFetcher?

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -196,7 +196,8 @@ import Foundation
           var failureSnapshot: StorageTaskSnapshot?
 
           self.stateLock.withLock {
-            if self.state == .cancelled || self.state == .paused || self.state == .pausing { return }
+            if self.state == .cancelled || self.state == .paused || self
+              .state == .pausing { return }
 
             self.state = .progress
             progressSnapshot = self.snapshotUnderLock()

--- a/FirebaseStorage/Tests/Integration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/Integration/StorageIntegration.swift
@@ -613,6 +613,35 @@ class StorageResultTests: StorageIntegrationCommon {
     waitForExpectations()
   }
 
+  func testCancelUpload() throws {
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/helloworld" + #function)
+    let data = Data(count: 1024 * 1024)
+
+    let task = ref.putData(data)
+    var fulfilled = false
+
+    task.observe(StorageTaskStatus.failure) { snapshot in
+      if !fulfilled {
+        fulfilled = true
+        let expected = "User cancelled the upload/download."
+        if let error = snapshot.error {
+          let errorDescription = error.localizedDescription
+          XCTAssertEqual(errorDescription, expected)
+          let code = (error as NSError).code
+          XCTAssertEqual(code, StorageErrorCode.cancelled.rawValue)
+        }
+        expectation.fulfill()
+      }
+    }
+
+    task.observe(StorageTaskStatus.progress) { snapshot in
+      task.cancel()
+    }
+
+    waitForExpectations()
+  }
+
   private func assertMetadata(actualMetadata: StorageMetadata,
                               expectedContentType: String,
                               expectedCustomMetadata: [String: String]) {

--- a/FirebaseStorage/Tests/ObjCIntegration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorage/Tests/ObjCIntegration/FIRStorageIntegrationTests.m
@@ -636,6 +636,35 @@ NSString *const kTestPassword = KPASSWORD;
   [self waitForExpectations];
 }
 
+- (void)testCancelUpload {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"testCancelUpload"];
+
+  FIRStorageReference *ref =
+      [self.storage referenceWithPath:@"ios/public/helloworldtestCancelUpload"];
+  NSData *data = [NSMutableData dataWithLength:1024 * 1024];
+
+  FIRStorageUploadTask *task = [ref putData:data];
+  // Don't fulfill twice if a second observe failure happens before the cancel completes.
+  BOOL __block fulfilled = NO;
+
+  [task observeStatus:FIRStorageTaskStatusFailure
+              handler:^(FIRStorageTaskSnapshot *snapshot) {
+                XCTAssertTrue([[snapshot description] containsString:@"State: Failed"]);
+                if (!fulfilled) {
+                  fulfilled = YES;
+                  XCTAssertEqual(snapshot.error.code, FIRStorageErrorCodeCancelled);
+                  [expectation fulfill];
+                }
+              }];
+
+  [task observeStatus:FIRStorageTaskStatusProgress
+              handler:^(FIRStorageTaskSnapshot *_Nonnull snapshot) {
+                [task cancel];
+              }];
+
+  [self waitForExpectations];
+}
+
 - (void)assertMetadata:(FIRStorageMetadata *)actualMetadata
            contentType:(NSString *)expectedContentType
         customMetadata:(NSDictionary *)expectedCustomMetadata {

--- a/FirebaseStorage/Tests/Unit/StorageDeleteTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageDeleteTests.swift
@@ -55,9 +55,6 @@ class StorageDeleteTests: StorageTestHelpers {
   func testSuccessfulFetchWithEmulator() async {
     let storage = self.storage()
     storage.useEmulator(withHost: "localhost", port: 8080)
-    _ = successBlock(
-      withURL: URL(string: "http://localhost:8080/v0/b/bucket/o/object")!
-    )
     await StorageFetcherService.shared.updateTestBlock(successBlock())
     let path = objectPath()
     let ref = StorageReference(storage: storage, path: path)

--- a/FirebaseStorage/Tests/Unit/StorageDeleteTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageDeleteTests.swift
@@ -55,7 +55,7 @@ class StorageDeleteTests: StorageTestHelpers {
   func testSuccessfulFetchWithEmulator() async {
     let storage = self.storage()
     storage.useEmulator(withHost: "localhost", port: 8080)
-    let testBlock = successBlock(
+    _ = successBlock(
       withURL: URL(string: "http://localhost:8080/v0/b/bucket/o/object")!
     )
     await StorageFetcherService.shared.updateTestBlock(successBlock())


### PR DESCRIPTION
Fix #16353

## Overview

This pull request addresses several critical race conditions in Firebase Storage task cancellation and significantly improves Swift 6 strict concurrency compliance. By introducing robust locking mechanisms and fixing logic flaws in task state management, we ensure reliable execution, proper cancellation, and safe concurrency across the Firebase Storage module.

## Key Changes

### 1\. Swift 6 Concurrency Compliance & Synchronization

* **`stateLock` (`NSLock`) Migration:** Replaced the legacy Objective-C synchronization (`objc_sync_enter` / `objc_sync_exit`) with a dedicated `NSLock` (`stateLock`) across `StorageTask` subclasses to protect mutable state and ensure thread safety.  
* **`@unchecked Sendable` Adherence:** Explicitly marked tasks (`StorageDownloadTask`, `StorageUploadTask`, `StorageObservableTask`, `StorageInternalTask`) as `@unchecked Sendable` to resolve Swift 6 strict concurrency warnings while manually managing cross-actor state synchronization.  
* **Synchronized Dictionary Access:** Fixed data races when reading observer handler dictionaries (e.g., `handlerDictionaries` in `StorageObservableTask`) by ensuring all accesses are protected by `stateLock.withLock`.

### 2\. Task State and Data Race Fixes

* **Terminal State Preservation:** Fixed critical bugs in `StorageDownloadTask` and `StorageUploadTask` where late-firing `progress`, `pause`, or `resume` callbacks could erroneously revert a task out of a terminal state (`.success`, `.failed`, or `.cancelled`), leading to corrupted states and deadlocks.  
* **Synchronized State Snapshots:** Added an internal `state` property directly to `StorageTaskSnapshot` to perfectly capture the raw `StorageTaskState` at the moment of creation. This completely eliminates unsynchronized reads of the task's internal state when firing observer callbacks.  
* **`StorageInternalTask` Fetcher Concurrency:** Fixed a data race where the private `fetcher` property was being written to and read concurrently. It is now properly synchronized with `stateLock.withLock`, and execution uses a thread-safe local reference.

### 3\. Observer Event Duplication

* **Atomic Registration:** Refactored `observe(_:handler:)` in `StorageObservableTask` to perform both the state snapshot creation and the dictionary registration atomically under a single lock. This prevents race conditions where a task changes state mid-registration, dropping events.  
* **Duplicate Callbacks Eliminated:** Addressed logic that previously fired all registered handlers simultaneously upon attaching a new observer. Now, the method cleanly guarantees that *only* the newly attached callback triggers for a previously-achieved state.

### 4\. Task Enqueueing and Resume Logic

* **No-Op Resume Fix:** Fixed a deadlock in `StorageUploadTask.resume()` where a task paused before its fetcher was allocated would fail to resume. The method now detects the missing fetcher and correctly re-queues the upload.  
* **Enqueue Override Protection:** Prevented `StorageUploadTask.enqueue()` from blindly forcing tasks into the `.queueing` state if they had already been successfully paused or cancelled while resting on the dispatch queue.  
* **Task Hop Bypasses Fixed:** Updated `enqueueImplementation` logic in `StorageDownloadTask` to accurately check a boolean flag and abort if the task was cancelled prior to the asynchronous task execution hopping threads.

## Testing

* All integration tests pass successfully.  
* Addressed failures related to cancellation assertions in `testCancelErrorCode` and `testCancelUpload`.  
* Added and verified integration testing patterns from `pb-fix-storage-upload-cancel` (in both `FirebaseStorage/Tests/Integration` and `FirebaseStorage/Tests/ObjCIntegration`).  
* Verified successful compilation without warnings under strict concurrency checks.
