### PR TITLE
[AI] Rename vertexAI to agentPlatform

### DIFF
--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -97,6 +97,7 @@ jobs:
     with:
       product: ${{  matrix.product }}
       supports_swift6: true
+      allow_warnings: ${{ matrix.product == 'FirebaseAI' }}
       setup_command: scripts/update_vertexai_responses.sh
 
   quickstart:

--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -97,7 +97,6 @@ jobs:
     with:
       product: ${{  matrix.product }}
       supports_swift6: true
-      allow_warnings: ${{ matrix.product == 'FirebaseAI' }}
       setup_command: scripts/update_vertexai_responses.sh
 
   quickstart:

--- a/FirebaseAI/AGENTS.md
+++ b/FirebaseAI/AGENTS.md
@@ -64,7 +64,7 @@ Data types used in the FirebaseAI library.
 
 ### Public Types
 
-- **`Backend.swift`**: Used to configure the backend API (Vertex AI or Google AI).
+- **`Backend.swift`**: Used to configure the backend API (Gemini Enterprise Agent Platform or Google AI).
 - **`ImageConfig.swift`**: Defines the `ImageConfig` struct, used for configuring generated image properties like aspect ratio and size.
 - **`Part.swift`**: Defines the `Part` protocol and conforming structs (Text, InlineData, FunctionCall, etc.).
 - **`ResponseModality.swift`**: Represents types of data a model can produce (text, image, audio).

--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 12.16.0
+- [changed] Deprecated `Backend.vertexAI` in favor of `Backend.agentPlatform` (supporting `"global"` as the default location instead of `"us-central1"`).
 - [fixed] Fixed a decoding failure in `GenerateContentResponse` when the Vertex AI
   backend returns citation metadata with a missing `endIndex`. (#16328)
 - [fixed] Fixed an issue where `generateContentStream` could stall indefinitely

--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 12.16.0
-- [changed] Deprecated `Backend.vertexAI` in favor of `Backend.agentPlatform` (supporting `"global"` as the default location instead of `"us-central1"`).
+- [changed] Deprecated `Backend.vertexAI` in favor of `Backend.agentPlatform` to
+  reflect the renaming of Vertex AI to Gemini Enterprise Agent Platform.
+  (#16372)
+
+  Note: The default location is now `global` instead of `us-central1` (no other
+  functionality has changed). To continue using `us-central1`, specify
+  `FirebaseAI.firebaseAI(backend: .agentPlatform(location: "us-central1"))` when
+  initializing the SDK.
 - [fixed] Fixed a decoding failure in `GenerateContentResponse` when the Vertex AI
   backend returns citation metadata with a missing `endIndex`. (#16328)
 - [fixed] Fixed an issue where `generateContentStream` could stall indefinitely

--- a/FirebaseAI/Sources/AILog.swift
+++ b/FirebaseAI/Sources/AILog.swift
@@ -29,7 +29,7 @@ enum AILog {
     case verboseLoggingEnabled = 101
 
     // API Enablement Errors
-    case vertexAIInFirebaseAPIDisabled = 200
+    case agentPlatformInFirebaseAPIDisabled = 200
 
     // Generative Model Configuration
     case generativeModelInitialized = 1000

--- a/FirebaseAI/Sources/Constants.swift
+++ b/FirebaseAI/Sources/Constants.swift
@@ -25,8 +25,8 @@ enum Constants {
   #if DEBUG
     /// The key for an environment variable containing a Google Cloud Access Token.
     ///
-    /// This should only be used for SDK development and testing with the Vertex AI direct backend
-    /// that bypasses the Firebase proxy..
+    /// This should only be used for SDK development and testing with the Gemini
+    /// Enterprise Agent Platform direct backend that bypasses the Firebase proxy.
     ///
     /// The value should is typically obtained from the gcloud CLI by calling
     /// `gcloud auth print-access-token`.

--- a/FirebaseAI/Sources/FirebaseAI.swift
+++ b/FirebaseAI/Sources/FirebaseAI.swift
@@ -379,7 +379,7 @@ public final class FirebaseAI: Sendable {
     }
 
     switch apiConfig.service {
-    case let .vertexAI(endpoint: _, location: location):
+    case let .agentPlatform(endpoint: _, location: location):
       return vertexAIModelResourceName(modelName: modelName, location: location)
     case .googleAI:
       return developerModelResourceName(modelName: modelName)

--- a/FirebaseAI/Sources/FirebaseAI.swift
+++ b/FirebaseAI/Sources/FirebaseAI.swift
@@ -380,13 +380,13 @@ public final class FirebaseAI: Sendable {
 
     switch apiConfig.service {
     case let .agentPlatform(endpoint: _, location: location):
-      return vertexAIModelResourceName(modelName: modelName, location: location)
+      return agentPlatformModelResourceName(modelName: modelName, location: location)
     case .googleAI:
       return developerModelResourceName(modelName: modelName)
     }
   }
 
-  private func vertexAIModelResourceName(modelName: String, location: String) -> String {
+  private func agentPlatformModelResourceName(modelName: String, location: String) -> String {
     guard !location.isEmpty && location
       .allSatisfy({ !$0.isWhitespace && !$0.isNewline && $0 != "/" }) else {
       fatalError("""
@@ -409,9 +409,9 @@ public final class FirebaseAI: Sendable {
         return "models/\(modelName)"
       case .firebaseProxyStaging:
         return "projects/\(firebaseInfo.projectID)/models/\(modelName)"
-      case .vertexAIStagingBypassProxy:
+      case .agentPlatformStagingBypassProxy:
         fatalError(
-          "The Vertex AI staging endpoint does not support the Gemini Developer API (Google AI)."
+          "The Gemini Enterprise Agent Platform staging endpoint does not support the Gemini Developer API (Google AI)."
         )
     #endif // DEBUG
     }

--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -431,7 +431,8 @@ public struct PromptFeedback: Sendable {
 /// > Important: If using Grounding with Google Search, you are required to comply with the
 /// "Grounding with Google Search" usage requirements for your chosen API provider:
 /// [Gemini Developer API](https://ai.google.dev/gemini-api/terms#grounding-with-google-search)
-/// or Vertex AI Gemini API (see [Service Terms](https://cloud.google.com/terms/service-terms)
+/// or Gemini Enterprise Agent Platform Gemini API (see
+/// [Service Terms](https://cloud.google.com/terms/service-terms)
 /// section within the Service Specific Terms).
 public struct GroundingMetadata: Sendable, Equatable, Hashable {
   /// A list of web search queries that the model performed to gather the grounding information.
@@ -473,7 +474,7 @@ public struct GroundingMetadata: Sendable, Equatable, Hashable {
     public let title: String?
     /// The domain of the original URI from which the content was retrieved.
     ///
-    /// This field is only populated when using the Vertex AI Gemini API.
+    /// This field is only populated when using the Gemini Enterprise Agent Platform Gemini API.
     public let domain: String?
   }
 
@@ -677,7 +678,7 @@ extension Candidate: Decodable {
 
 extension CitationMetadata: Decodable {
   enum CodingKeys: CodingKey {
-    case citations // Vertex AI
+    case citations // Gemini Enterprise Agent Platform
     case citationSources // Google AI
   }
 

--- a/FirebaseAI/Sources/GenerativeAIService.swift
+++ b/FirebaseAI/Sources/GenerativeAIService.swift
@@ -254,7 +254,7 @@ struct GenerativeAIService {
   private func logRPCError(_ error: BackendError) {
     let projectID = firebaseInfo.projectID
     if error.isVertexAIInFirebaseServiceDisabledError() {
-      AILog.error(code: .vertexAIInFirebaseAPIDisabled, """
+      AILog.error(code: .agentPlatformInFirebaseAPIDisabled, """
       The Firebase AI SDK requires the Firebase AI API \
       (`firebasevertexai.googleapis.com`) to be enabled in your Firebase project. Enable this API \
       by visiting the Firebase Console at

--- a/FirebaseAI/Sources/GenerativeModel.swift
+++ b/FirebaseAI/Sources/GenerativeModel.swift
@@ -61,7 +61,7 @@ public final class GenerativeModel: Sendable {
   ///   - modelName: The name of the model.
   ///   - modelResourceName: The model resource name corresponding with `modelName` in the backend.
   ///     The form depends on the backend and will be one of:
-  ///       - Vertex AI via Firebase AI SDK:
+  ///       - Gemini Enterprise Agent Platform via Firebase AI SDK:
   ///       `"projects/{projectID}/locations/{locationID}/publishers/google/models/{modelName}"`
   ///       - Developer API via Firebase AI SDK: `"projects/{projectID}/models/{modelName}"`
   ///       - Developer API via Generative Language: `"models/{modelName}"`

--- a/FirebaseAI/Sources/GenerativeModel.swift
+++ b/FirebaseAI/Sources/GenerativeModel.swift
@@ -231,9 +231,9 @@ public final class GenerativeModel: Sendable {
         "models/\(modelName)"
       case .googleAI(endpoint: .googleAIBypassProxy):
         modelResourceName
-      case .googleAI(endpoint: .vertexAIStagingBypassProxy):
+      case .googleAI(endpoint: .agentPlatformStagingBypassProxy):
         fatalError(
-          "The Vertex AI staging endpoint does not support the Gemini Developer API (Google AI)."
+          "The Gemini Enterprise Agent Platform staging endpoint does not support the Gemini Developer API (Google AI)."
         )
     #endif // DEBUG
     }

--- a/FirebaseAI/Sources/GenerativeModel.swift
+++ b/FirebaseAI/Sources/GenerativeModel.swift
@@ -207,7 +207,7 @@ public final class GenerativeModel: Sendable {
   /// ``CountTokensResponse/totalTokens``.
   public func countTokens(_ content: [ModelContent]) async throws -> CountTokensResponse {
     let requestContent = switch apiConfig.service {
-    case .vertexAI:
+    case .agentPlatform:
       content
     case .googleAI:
       // The `role` defaults to "user" but is ignored in `countTokens`. However, it is erroneously
@@ -222,7 +222,7 @@ public final class GenerativeModel: Sendable {
     // "models/model-name". This field is unaltered by the Firebase backend before forwarding the
     // request to the Generative Language backend, which expects the form "models/model-name".
     let generateContentRequestModelResourceName = switch apiConfig.service {
-    case .vertexAI:
+    case .agentPlatform:
       modelResourceName
     case .googleAI(endpoint: .firebaseProxyProd):
       "models/\(modelName)"

--- a/FirebaseAI/Sources/Safety.swift
+++ b/FirebaseAI/Sources/Safety.swift
@@ -291,7 +291,8 @@ extension SafetyRating: Decodable {
       HarmProbability.self, forKey: .probability
     ) ?? .unspecified
 
-    // The following 3 fields are only provided when using the Vertex AI backend (not Google AI).
+    // The following 3 fields are only provided when using the Gemini Enterprise Agent Platform
+    // backend (not Google AI).
     probabilityScore = try container.decodeIfPresent(Float.self, forKey: .probabilityScore) ?? 0.0
     severity = try container.decodeIfPresent(HarmSeverity.self, forKey: .severity) ?? .unspecified
     severityScore = try container.decodeIfPresent(Float.self, forKey: .severityScore) ?? 0.0

--- a/FirebaseAI/Sources/TemplateGenerateContentRequest.swift
+++ b/FirebaseAI/Sources/TemplateGenerateContentRequest.swift
@@ -46,7 +46,7 @@ extension TemplateGenerateContentRequest: GenerativeAIRequest {
   func getURL() throws -> URL {
     var urlString =
       "\(apiConfig.service.endpoint.rawValue)/\(apiConfig.version.rawValue)/projects/\(projectID)"
-    if case let .vertexAI(_, location) = apiConfig.service {
+    if case let .agentPlatform(_, location) = apiConfig.service {
       urlString += "/locations/\(location)"
     }
 

--- a/FirebaseAI/Sources/TemplateImagenGenerationRequest.swift
+++ b/FirebaseAI/Sources/TemplateImagenGenerationRequest.swift
@@ -71,7 +71,7 @@ extension TemplateImagenGenerationRequest: GenerativeAIRequest where ImageType: 
   func getURL() throws -> URL {
     var urlString =
       "\(apiConfig.service.endpoint.rawValue)/\(apiConfig.version.rawValue)/projects/\(projectID)"
-    if case let .vertexAI(_, location) = apiConfig.service {
+    if case let .agentPlatform(_, location) = apiConfig.service {
       urlString += "/locations/\(location)"
     }
     urlString += "/templates/\(template):\(ImageAPIMethod.generateImages.rawValue)"

--- a/FirebaseAI/Sources/Tool.swift
+++ b/FirebaseAI/Sources/Tool.swift
@@ -98,7 +98,8 @@ public struct FunctionDeclaration: Sendable {
 /// > Important: When using this feature, you are required to comply with the
 /// "Grounding with Google Search" usage requirements for your chosen API provider:
 /// [Gemini Developer API](https://ai.google.dev/gemini-api/terms#grounding-with-google-search)
-/// or Vertex AI Gemini API (see [Service Terms](https://cloud.google.com/terms/service-terms)
+/// or Gemini Enterprise Agent Platform Gemini API (see
+/// [Service Terms](https://cloud.google.com/terms/service-terms)
 /// section within the Service Specific Terms).
 public struct GoogleSearch: Sendable {
   public init() {}
@@ -284,7 +285,8 @@ public extension ToolRepresentable where Self == FirebaseAILogic.Tool {
   /// > Important: When using this feature, you are required to comply with the
   /// "Grounding with Google Search" usage requirements for your chosen API provider:
   /// [Gemini Developer API](https://ai.google.dev/gemini-api/terms#grounding-with-google-search)
-  /// or Vertex AI Gemini API (see [Service Terms](https://cloud.google.com/terms/service-terms)
+  /// or Gemini Enterprise Agent Platform Gemini API (see
+  /// [Service Terms](https://cloud.google.com/terms/service-terms)
   /// section within the Service Specific Terms).
   ///
   /// - Parameters:

--- a/FirebaseAI/Sources/Types/Internal/APIConfig.swift
+++ b/FirebaseAI/Sources/Types/Internal/APIConfig.swift
@@ -45,7 +45,7 @@ extension APIConfig {
     /// See the [Cloud
     /// docs](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) for
     /// more details.
-    case vertexAI(endpoint: Endpoint, location: String)
+    case agentPlatform(endpoint: Endpoint, location: String)
 
     /// The Gemini Developer API provided by Google AI.
     ///
@@ -57,7 +57,7 @@ extension APIConfig {
     /// This must correspond with the API set in `service`.
     var endpoint: Endpoint {
       switch self {
-      case let .vertexAI(endpoint: endpoint, _):
+      case let .agentPlatform(endpoint: endpoint, _):
         return endpoint
       case let .googleAI(endpoint: endpoint):
         return endpoint

--- a/FirebaseAI/Sources/Types/Internal/APIConfig.swift
+++ b/FirebaseAI/Sources/Types/Internal/APIConfig.swift
@@ -36,11 +36,11 @@ struct APIConfig: Sendable, Hashable, Encodable {
 extension APIConfig {
   /// API services providing generative AI functionality.
   ///
-  /// See [Vertex AI and Google AI
+  /// See [Gemini Enterprise Agent Platform and Google AI
   /// differences](https://cloud.google.com/vertex-ai/generative-ai/docs/overview#how-gemini-vertex-different-gemini-aistudio)
   /// for a comparison of the two [API services](https://google.aip.dev/9#api-service).
   enum Service: Hashable, Encodable {
-    /// Vertex AI Gemini API.
+    /// Gemini Enterprise Agent Platform Gemini API.
     ///
     /// See the [Cloud
     /// docs](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) for
@@ -72,27 +72,32 @@ extension APIConfig.Service {
   enum Endpoint: String, Encodable {
     /// The Firebase proxy production endpoint.
     ///
-    /// This endpoint supports both Google AI and Vertex AI.
+    /// This endpoint supports both Google AI and Gemini Enterprise Agent Platform.
     case firebaseProxyProd = "https://firebasevertexai.googleapis.com"
 
     #if DEBUG
       /// The Firebase proxy staging endpoint; for SDK development and testing only.
       ///
       /// This endpoint supports both the Gemini Developer API (commonly referred to as Google AI)
-      /// and the Gemini API in Vertex AI (commonly referred to simply as Vertex AI).
+      /// and the Gemini API in Gemini Enterprise Agent Platform (commonly referred to simply as
+      /// Gemini Enterprise Agent Platform).
       case firebaseProxyStaging = "https://staging-firebasevertexai.sandbox.googleapis.com"
 
       /// The Gemini Developer API (Google AI) direct production endpoint; for SDK development and
       /// testing only.
       ///
       /// This bypasses the Firebase proxy and directly connects to the Gemini Developer API
-      /// (Google AI) backend. This endpoint only supports the Gemini Developer API, not Vertex AI.
+      /// (Google AI) backend. This endpoint only supports the Gemini Developer API, not Gemini
+      /// Enterprise Agent Platform.
       case googleAIBypassProxy = "https://generativelanguage.googleapis.com"
 
-      /// The Vertex AI direct staging endpoint; for SDK development and testing only.
+      /// The Gemini Enterprise Agent Platform direct staging endpoint; for SDK development and
+      /// testing only.
       ///
-      /// This bypasses the Firebase proxy and directly connects to the Vertex AI backend. This
-      /// endpoint only supports the Gemini API in Vertex AI, not the Gemini Developer API.
+      /// This bypasses the Firebase proxy and directly connects to the Gemini Enterprise Agent
+      /// Platform backend. This
+      /// endpoint only supports the Gemini API in Gemini Enterprise Agent Platform, not the Gemini
+      /// Developer API.
       case vertexAIStagingBypassProxy = "https://staging-aiplatform.sandbox.googleapis.com"
     #endif // DEBUG
   }
@@ -109,7 +114,8 @@ extension APIConfig {
       /// only.
       case v1
 
-      /// The beta channel for version 1 of the direct Vertex AI API, when bypassing the Firebase
+      /// The beta channel for version 1 of the direct Gemini Enterprise Agent Platform API, when
+      /// bypassing the Firebase
       /// proxy; for SDK development and testing only.
       case v1beta1
     #endif // DEBUG

--- a/FirebaseAI/Sources/Types/Internal/APIConfig.swift
+++ b/FirebaseAI/Sources/Types/Internal/APIConfig.swift
@@ -98,7 +98,7 @@ extension APIConfig.Service {
       /// Platform backend. This
       /// endpoint only supports the Gemini API in Gemini Enterprise Agent Platform, not the Gemini
       /// Developer API.
-      case vertexAIStagingBypassProxy = "https://staging-aiplatform.sandbox.googleapis.com"
+      case agentPlatformStagingBypassProxy = "https://staging-aiplatform.sandbox.googleapis.com"
     #endif // DEBUG
   }
 }

--- a/FirebaseAI/Sources/Types/Internal/Live/LiveSessionService.swift
+++ b/FirebaseAI/Sources/Types/Internal/Live/LiveSessionService.swift
@@ -377,7 +377,7 @@ actor LiveSessionService {
   private nonisolated func createWebsocket() async throws -> AsyncWebSocket {
     let host = apiConfig.service.endpoint.rawValue.withoutPrefix("https://")
     let urlString = switch apiConfig.service {
-    case let .vertexAI(_, location: location):
+    case let .agentPlatform(_, location: location):
       "wss://\(host)/ws/google.firebase.vertexai.\(apiConfig.version.rawValue).LlmBidiService/BidiGenerateContent/locations/\(location)"
     case .googleAI:
       "wss://\(host)/ws/google.firebase.vertexai.\(apiConfig.version.rawValue).GenerativeService/BidiGenerateContent"

--- a/FirebaseAI/Sources/Types/Internal/Requests/CountTokensRequest.swift
+++ b/FirebaseAI/Sources/Types/Internal/Requests/CountTokensRequest.swift
@@ -63,7 +63,7 @@ extension CountTokensRequest: Encodable {
 
   func encode(to encoder: any Encoder) throws {
     switch apiConfig.service {
-    case .vertexAI:
+    case .agentPlatform:
       try encodeForVertexAI(to: encoder)
     case .googleAI:
       try encodeForDeveloper(to: encoder)

--- a/FirebaseAI/Sources/Types/Public/Backend.swift
+++ b/FirebaseAI/Sources/Types/Public/Backend.swift
@@ -27,7 +27,7 @@ public struct Backend {
   public static func vertexAI() -> Backend {
     return Backend(
       apiConfig: APIConfig(
-        service: .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1"),
+        service: .agentPlatform(endpoint: .firebaseProxyProd, location: "us-central1"),
         version: .v1beta
       )
     )
@@ -45,7 +45,7 @@ public struct Backend {
   public static func vertexAI(location: String) -> Backend {
     return Backend(
       apiConfig: APIConfig(
-        service: .vertexAI(endpoint: .firebaseProxyProd, location: location),
+        service: .agentPlatform(endpoint: .firebaseProxyProd, location: location),
         version: .v1beta
       )
     )
@@ -62,7 +62,7 @@ public struct Backend {
   public static func agentPlatform(location: String = "global") -> Backend {
     return Backend(
       apiConfig: APIConfig(
-        service: .vertexAI(endpoint: .firebaseProxyProd, location: location),
+        service: .agentPlatform(endpoint: .firebaseProxyProd, location: location),
         version: .v1beta
       )
     )

--- a/FirebaseAI/Sources/Types/Public/Backend.swift
+++ b/FirebaseAI/Sources/Types/Public/Backend.swift
@@ -18,12 +18,48 @@ public struct Backend {
 
   /// Initializes a `Backend` configured for the Gemini API in Vertex AI.
   ///
+  /// Defaults to the location `us-central1`; see
+  /// [Vertex AI locations](https://firebase.google.com/docs/vertex-ai/locations?platform=ios#available-locations)
+  /// for a list of supported locations.
+  @available(*, deprecated, message: """
+  Use agentPlatform(location:) instead; note that the default location is now "global" instead of "us-central1"
+  """)
+  public static func vertexAI() -> Backend {
+    return Backend(
+      apiConfig: APIConfig(
+        service: .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1"),
+        version: .v1beta
+      )
+    )
+  }
+
+  /// Initializes a `Backend` configured for the Gemini API in Vertex AI.
+  ///
   /// - Parameters:
-  ///   - location: The region identifier, defaulting to `us-central1`; see
-  ///     [Vertex AI locations]
-  ///     (https://firebase.google.com/docs/vertex-ai/locations?platform=ios#available-locations)
+  ///   - location: The region identifier; see
+  ///     [Vertex AI locations](https://firebase.google.com/docs/vertex-ai/locations?platform=ios#available-locations)
   ///     for a list of supported locations.
-  public static func vertexAI(location: String = "us-central1") -> Backend {
+  @available(*, deprecated, renamed: "agentPlatform(location:)", message: """
+  Vertex AI has been renamed to the Gemini Enterprise Agent Platform.
+  """)
+  public static func vertexAI(location: String) -> Backend {
+    return Backend(
+      apiConfig: APIConfig(
+        service: .vertexAI(endpoint: .firebaseProxyProd, location: location),
+        version: .v1beta
+      )
+    )
+  }
+
+  /// Initializes a `Backend` configured for the Gemini Enterprise Agent Platform.
+  ///
+  /// > Note: The Gemini Enterprise Agent Platform was formerly known as the Vertex AI.
+  ///
+  /// - Parameters:
+  ///   - location: The region identifier, defaulting to `global`; see
+  ///     [Vertex AI locations](https://firebase.google.com/docs/vertex-ai/locations?platform=ios#available-locations)
+  ///     for a list of supported locations.
+  public static func agentPlatform(location: String = "global") -> Backend {
     return Backend(
       apiConfig: APIConfig(
         service: .vertexAI(endpoint: .firebaseProxyProd, location: location),

--- a/FirebaseAI/Sources/Types/Public/GeminiModel.swift
+++ b/FirebaseAI/Sources/Types/Public/GeminiModel.swift
@@ -15,7 +15,8 @@
 import Foundation
 
 #if compiler(>=6.2.3)
-  /// A Gemini model accessed via the Gemini Developer API or the Vertex AI API.
+  /// A Gemini model accessed via the Gemini Developer API or the Gemini Enterprise Agent Platform
+  /// API.
   ///
   /// **Public Preview**: This API is a public preview and may be subject to change.
   ///

--- a/FirebaseAI/Sources/Types/Public/Imagen/ImagenSafetyFilterLevel.swift
+++ b/FirebaseAI/Sources/Types/Public/Imagen/ImagenSafetyFilterLevel.swift
@@ -20,7 +20,8 @@
 ///  (the "Nano Banana" models).](https://firebase.google.com/docs/ai-logic/imagen-models-migration)
 /// }
 ///
-/// Text prompts provided as inputs and images (generated or uploaded) through Imagen on Vertex AI
+/// Text prompts provided as inputs and images (generated or uploaded) through Imagen on Gemini
+/// Enterprise Agent Platform
 /// are assessed against a list of safety filters, which include 'harmful categories' (for example,
 /// `violence`, `sexual`, `derogatory`, and `toxic`). This filter level controls how aggressively to
 /// filter out potentially harmful content from responses. See the

--- a/FirebaseAI/Sources/Types/Public/SpeakerVoiceConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/SpeakerVoiceConfig.swift
@@ -30,7 +30,8 @@ public struct SpeakerVoiceConfig: Sendable {
   ///
   /// Find the list of supported voices for:
   /// - [Gemini Developer API](https://ai.google.dev/gemini-api/docs/speech-generation)
-  /// - [Vertex AI Gemini API](https://docs.cloud.google.com/text-to-speech/docs/gemini-tts)
+  /// - [Gemini Enterprise Agent Platform Gemini
+  /// API](https://docs.cloud.google.com/text-to-speech/docs/gemini-tts)
   // TODO(b/522397979): Update links to point to Firebase when they're live
   public init(speaker: String, voiceName: String) {
     self.init(

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/CountTokensIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/CountTokensIntegrationTests.swift
@@ -101,7 +101,7 @@ struct CountTokensIntegrationTests {
     let response = try await model.countTokens(prompt)
 
     switch config.apiConfig.service {
-    case .vertexAI:
+    case .agentPlatform:
       #expect(response.totalTokens == 65)
     case .googleAI:
       // The Developer API erroneously ignores the `responseSchema` when counting tokens, resulting

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -48,9 +48,9 @@ struct GenerateContentIntegrationTests {
   }
 
   @Test(arguments: [
-    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashLite),
-    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2_5_FlashLite),
-    (InstanceConfig.vertexAI_v1beta_global_appCheckLimitedUse, ModelNames.gemini2_5_FlashLite),
+    (InstanceConfig.agentPlatform_v1beta, ModelNames.gemini2_5_FlashLite),
+    (InstanceConfig.agentPlatform_v1beta_global, ModelNames.gemini2_5_FlashLite),
+    (InstanceConfig.agentPlatform_v1beta_global_appCheckLimitedUse, ModelNames.gemini2_5_FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini3_1_FlashLite),
     (InstanceConfig.googleAI_v1beta_appCheckLimitedUse, ModelNames.gemini3_1_FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemma4_31B),
@@ -149,14 +149,18 @@ struct GenerateContentIntegrationTests {
 
   @Test(
     arguments: [
-      (.vertexAI_v1beta, ModelNames.gemini2_5_Flash, ThinkingConfig(thinkingBudget: 0)),
-      (.vertexAI_v1beta, ModelNames.gemini2_5_Flash, ThinkingConfig(thinkingBudget: 24576)),
-      (.vertexAI_v1beta, ModelNames.gemini2_5_Flash, ThinkingConfig(
+      (.agentPlatform_v1beta, ModelNames.gemini2_5_Flash, ThinkingConfig(thinkingBudget: 0)),
+      (.agentPlatform_v1beta, ModelNames.gemini2_5_Flash, ThinkingConfig(thinkingBudget: 24576)),
+      (.agentPlatform_v1beta, ModelNames.gemini2_5_Flash, ThinkingConfig(
         thinkingBudget: 24576, includeThoughts: true
       )),
-      (.vertexAI_v1beta_global, ModelNames.gemini2_5_Pro, ThinkingConfig(thinkingBudget: 128)),
-      (.vertexAI_v1beta_global, ModelNames.gemini2_5_Pro, ThinkingConfig(thinkingBudget: 32768)),
-      (.vertexAI_v1beta_global, ModelNames.gemini2_5_Pro, ThinkingConfig(
+      (.agentPlatform_v1beta_global, ModelNames.gemini2_5_Pro, ThinkingConfig(thinkingBudget: 128)),
+      (
+        .agentPlatform_v1beta_global,
+        ModelNames.gemini2_5_Pro,
+        ThinkingConfig(thinkingBudget: 32768)
+      ),
+      (.agentPlatform_v1beta_global, ModelNames.gemini2_5_Pro, ThinkingConfig(
         thinkingBudget: 32768, includeThoughts: true
       )),
       (.googleAI_v1beta, ModelNames.gemini2_5_FlashLite, ThinkingConfig(thinkingBudget: 0)),
@@ -267,12 +271,16 @@ struct GenerateContentIntegrationTests {
 
   @Test(
     arguments: [
-      (.vertexAI_v1beta_global, ModelNames.gemini2_5_Flash, ThinkingConfig(thinkingBudget: -1)),
-      (.vertexAI_v1beta_global, ModelNames.gemini2_5_Flash, ThinkingConfig(
+      (
+        .agentPlatform_v1beta_global,
+        ModelNames.gemini2_5_Flash,
+        ThinkingConfig(thinkingBudget: -1)
+      ),
+      (.agentPlatform_v1beta_global, ModelNames.gemini2_5_Flash, ThinkingConfig(
         thinkingBudget: -1, includeThoughts: true
       )),
-      (.vertexAI_v1beta_global, ModelNames.gemini2_5_Pro, ThinkingConfig(thinkingBudget: -1)),
-      (.vertexAI_v1beta_global, ModelNames.gemini2_5_Pro, ThinkingConfig(
+      (.agentPlatform_v1beta_global, ModelNames.gemini2_5_Pro, ThinkingConfig(thinkingBudget: -1)),
+      (.agentPlatform_v1beta_global, ModelNames.gemini2_5_Pro, ThinkingConfig(
         thinkingBudget: -1, includeThoughts: true
       )),
       (.googleAI_v1beta, ModelNames.gemini2_5_FlashLite, ThinkingConfig(thinkingBudget: -1)),
@@ -350,11 +358,11 @@ struct GenerateContentIntegrationTests {
   }
 
   @Test(arguments: [
-    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashImage),
-    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2_5_FlashImage),
+    (InstanceConfig.agentPlatform_v1beta, ModelNames.gemini2_5_FlashImage),
+    (InstanceConfig.agentPlatform_v1beta_global, ModelNames.gemini2_5_FlashImage),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashImage),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini3_1_FlashImagePreview),
-    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini3_1_FlashImagePreview),
+    (InstanceConfig.agentPlatform_v1beta_global, ModelNames.gemini3_1_FlashImagePreview),
   ])
   func generateImageWithAspectRatio(_ config: InstanceConfig, modelName: String) async throws {
     let imageConfig = ImageConfig(aspectRatio: .landscape16x9)
@@ -395,7 +403,7 @@ struct GenerateContentIntegrationTests {
 
   @Test(arguments: [
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini3_1_FlashImagePreview),
-    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini3_1_FlashImagePreview),
+    (InstanceConfig.agentPlatform_v1beta_global, ModelNames.gemini3_1_FlashImagePreview),
   ])
   func generateImageWithCustomSize(_ config: InstanceConfig, modelName: String) async throws {
     let imageConfig = ImageConfig(
@@ -438,11 +446,11 @@ struct GenerateContentIntegrationTests {
   }
 
   @Test(arguments: [
-    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashImage),
-    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2_5_FlashImage),
+    (InstanceConfig.agentPlatform_v1beta, ModelNames.gemini2_5_FlashImage),
+    (InstanceConfig.agentPlatform_v1beta_global, ModelNames.gemini2_5_FlashImage),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashImage),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini3_1_FlashImagePreview),
-    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini3_1_FlashImagePreview),
+    (InstanceConfig.agentPlatform_v1beta_global, ModelNames.gemini3_1_FlashImagePreview),
   ])
   func generateContent_finishReason_imageSafety(_ config: InstanceConfig,
                                                 modelName: String) async throws {
@@ -476,8 +484,8 @@ struct GenerateContentIntegrationTests {
   }
 
   @Test(arguments: [
-    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashImage),
-    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2_5_FlashImage),
+    (InstanceConfig.agentPlatform_v1beta, ModelNames.gemini2_5_FlashImage),
+    (InstanceConfig.agentPlatform_v1beta_global, ModelNames.gemini2_5_FlashImage),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashImage),
     // Note: The following configs are commented out for easy one-off manual testing.
     // (InstanceConfig.googleAI_v1beta_staging, ModelNames.gemini2_5_FlashImage)
@@ -554,7 +562,7 @@ struct GenerateContentIntegrationTests {
   }
 
   // TODO: b/524685673 - Re-enable googleAI_v1beta once backend bug is fixed.
-  @Test("generateContent with URL Context", arguments: [InstanceConfig.vertexAI_v1beta_global])
+  @Test("generateContent with URL Context", arguments: [InstanceConfig.agentPlatform_v1beta_global])
   func generateContent_withURLContext_succeeds(_ config: InstanceConfig) async throws {
     let model = FirebaseAI.componentInstance(config).generativeModel(
       modelName: ModelNames.gemini3_1_FlashLite,
@@ -604,14 +612,14 @@ struct GenerateContentIntegrationTests {
   // MARK: Streaming Tests
 
   @Test(arguments: [
-    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashLite),
-    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini3_1_FlashLite),
-    (InstanceConfig.vertexAI_v1beta_global_appCheckLimitedUse, ModelNames.gemini3_1_FlashLite),
+    (InstanceConfig.agentPlatform_v1beta, ModelNames.gemini2_5_FlashLite),
+    (InstanceConfig.agentPlatform_v1beta_global, ModelNames.gemini3_1_FlashLite),
+    (InstanceConfig.agentPlatform_v1beta_global_appCheckLimitedUse, ModelNames.gemini3_1_FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashLite),
     (InstanceConfig.googleAI_v1beta_appCheckLimitedUse, ModelNames.gemini2_5_FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemma4_31B),
     // Note: The following configs are commented out for easy one-off manual testing.
-    // (InstanceConfig.vertexAI_v1beta_staging, ModelNames.gemini2_5_FlashLite),
+    // (InstanceConfig.agentPlatform_v1beta_staging, ModelNames.gemini2_5_FlashLite),
     // (InstanceConfig.googleAI_v1beta_staging, ModelNames.gemini2_5_FlashLite),
     // (InstanceConfig.googleAI_v1beta_staging, ModelNames.gemma4_31B),
     // (InstanceConfig.googleAI_v1beta_freeTier_bypassProxy, ModelNames.gemini2_5_FlashLite),
@@ -685,8 +693,8 @@ struct GenerateContentIntegrationTests {
   }
 
   @Test(arguments: [
-    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_FlashImage),
-    (InstanceConfig.vertexAI_v1beta_global, ModelNames.gemini2_5_FlashImage),
+    (InstanceConfig.agentPlatform_v1beta, ModelNames.gemini2_5_FlashImage),
+    (InstanceConfig.agentPlatform_v1beta_global, ModelNames.gemini2_5_FlashImage),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashImage),
     // Note: The following configs are commented out for easy one-off manual testing.
     // (InstanceConfig.googleAI_v1beta_staging, ModelNames.gemini2_5_FlashImage)

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerateContentIntegrationTests.swift
@@ -466,7 +466,7 @@ struct GenerateContentIntegrationTests {
     do {
       let response = try await model.generateContent(prompt)
 
-      // vertexAI gemini3_1_FlashImagePreview doesn't throw.
+      // agentPlatform gemini3_1_FlashImagePreview doesn't throw.
       let candidate = try #require(response.candidates.first)
       #expect(candidate.finishReason == .stop)
     } catch {

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
@@ -24,7 +24,7 @@
 
   @Suite(.serialized)
   struct GenerativeModelSessionHybridTests {
-    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
+    @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global])
     func respondText_fallbackOnGeminiModelError(_ config: InstanceConfig) async throws {
       let firebaseAI = FirebaseAI.componentInstance(config)
       let invalidModel1 = firebaseAI.geminiModel(name: "invalid-model-name-1")
@@ -56,7 +56,7 @@
       #expect(response.rawResponse.modelVersion == validModel._modelName)
     }
 
-    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
+    @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global])
     @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
@@ -87,7 +87,7 @@
       }
     }
 
-    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
+    @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global])
     @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
@@ -115,7 +115,7 @@
       #expect(response.rawResponse.modelVersion == validModel._modelName)
     }
 
-    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
+    @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global])
     func streamResponseText_fallbackOnGeminiModelError(_ config: InstanceConfig) async throws {
       let firebaseAI = FirebaseAI.componentInstance(config)
       let invalidModel = firebaseAI.geminiModel(name: "invalid-model-name")
@@ -162,7 +162,7 @@
       #expect(response.rawResponse.modelVersion == validModel._modelName)
     }
 
-    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
+    @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global])
     @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
@@ -208,7 +208,7 @@
       #expect(response.rawResponse.modelVersion == validModel._modelName)
     }
 
-    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
+    @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global])
     @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionTests.swift
@@ -26,7 +26,7 @@
   struct GenerativeModelSessionTests {
     let generationConfig = GenerationConfig(temperature: 0.0, topP: 0.0, topK: 1)
 
-    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
+    @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global, InstanceConfig.googleAI_v1beta])
     func respondText(_ config: InstanceConfig) async throws {
       let firebaseAI = FirebaseAI.componentInstance(config)
       let session = firebaseAI.generativeModelSession(model: ModelNames.gemini2_5_FlashLite)
@@ -62,7 +62,7 @@
         var profile: String
       }
 
-      @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
+      @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global, InstanceConfig.googleAI_v1beta])
       @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
@@ -90,7 +90,7 @@
         #expect(response.rawContent.generationID != nil)
       }
 
-      @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
+      @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global, InstanceConfig.googleAI_v1beta])
       @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
@@ -177,7 +177,7 @@
         var recipes: [Recipe]
       }
 
-      @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
+      @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global, InstanceConfig.googleAI_v1beta])
       @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
@@ -205,7 +205,7 @@
         #expect(response.rawContent.generationID != nil)
       }
 
-      @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
+      @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global, InstanceConfig.googleAI_v1beta])
       @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
@@ -271,7 +271,7 @@
       }
     }
 
-    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
+    @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global, InstanceConfig.googleAI_v1beta])
     @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
@@ -305,7 +305,7 @@
       #expect(response.rawResponse.functionCalls.isEmpty)
     }
 
-    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
+    @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global, InstanceConfig.googleAI_v1beta])
     @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
@@ -339,7 +339,7 @@
     }
 
     // TODO: b/524685673 - Re-enable googleAI_v1beta once backend bug is fixed.
-    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global])
+    @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global])
     func respondTextWithURLContext(_ config: InstanceConfig) async throws {
       let session = FirebaseAI.componentInstance(config).generativeModelSession(
         model: ModelNames.gemini3_1_FlashLite,
@@ -360,7 +360,7 @@
       #expect(retrievedURL == URL(string: url))
     }
 
-    @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
+    @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global, InstanceConfig.googleAI_v1beta])
     func streamResponseText(_ config: InstanceConfig) async throws {
       let firebaseAI = FirebaseAI.componentInstance(config)
       let session = firebaseAI.generativeModelSession(model: ModelNames.gemini2_5_FlashLite)
@@ -403,7 +403,7 @@
     }
 
     #if canImport(FoundationModels)
-      @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
+      @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global, InstanceConfig.googleAI_v1beta])
       @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
@@ -458,7 +458,7 @@
         #expect(!catProfile.profile.isEmpty)
       }
 
-      @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
+      @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global, InstanceConfig.googleAI_v1beta])
       @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)
@@ -532,7 +532,7 @@
         #expect(!catProfile.profile.isEmpty)
       }
 
-      @Test(arguments: [InstanceConfig.vertexAI_v1beta_global, InstanceConfig.googleAI_v1beta])
+      @Test(arguments: [InstanceConfig.agentPlatform_v1beta_global, InstanceConfig.googleAI_v1beta])
       @available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
       @available(tvOS, unavailable)
       @available(watchOS, unavailable)

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/ImagenIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/ImagenIntegrationTests.swift
@@ -37,7 +37,7 @@ struct ImagenIntegrationTests {
 
   init() async throws {
     userID1 = try await TestHelpers.getUserID()
-    vertex = FirebaseAI.firebaseAI(backend: .vertexAI())
+    vertex = FirebaseAI.firebaseAI(backend: .agentPlatform(location: "us-central1"))
     storage = Storage.storage()
   }
 

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/ImplicitCacheTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/ImplicitCacheTests.swift
@@ -27,8 +27,8 @@ struct ImplicitCacheTests {
   )
 
   @Test(arguments: [
-    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_Flash),
-    (InstanceConfig.vertexAI_v1beta, ModelNames.gemini2_5_Pro),
+    (InstanceConfig.agentPlatform_v1beta, ModelNames.gemini2_5_Flash),
+    (InstanceConfig.agentPlatform_v1beta, ModelNames.gemini2_5_Pro),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini2_5_FlashLite),
     (InstanceConfig.googleAI_v1beta, ModelNames.gemini3_1_FlashLite),
   ])

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -51,7 +51,7 @@ final class IntegrationTests: XCTestCase {
 
   override func setUp() async throws {
     userID1 = try await TestHelpers.getUserID()
-    vertex = FirebaseAI.firebaseAI(backend: .vertexAI(location: "global"))
+    vertex = FirebaseAI.firebaseAI(backend: .agentPlatform())
     model = vertex.generativeModel(
       modelName: ModelNames.gemini3_1_FlashLite,
       generationConfig: generationConfig,
@@ -196,7 +196,7 @@ final class IntegrationTests: XCTestCase {
 
   func testCountTokens_appCheckNotConfigured_shouldFail() async throws {
     let app = try XCTUnwrap(FirebaseApp.app(name: FirebaseAppNames.appCheckNotConfigured))
-    let vertex = FirebaseAI.firebaseAI(app: app, backend: .vertexAI())
+    let vertex = FirebaseAI.firebaseAI(app: app, backend: .agentPlatform(location: "us-central1"))
     let model = vertex.generativeModel(modelName: ModelNames.gemini2_5_Flash)
     let prompt = "Why is the sky blue?"
 

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
@@ -23,7 +23,7 @@ import Testing
 struct LiveSessionTests {
   private static let arguments = InstanceConfig.liveConfigs.flatMap { config in
     switch config.apiConfig.service {
-    case .vertexAI:
+    case .agentPlatform:
       [
         (config, ModelNames.gemini2_5_FlashLive),
       ]
@@ -347,7 +347,7 @@ struct LiveSessionTests {
       switch $0.0.apiConfig.service {
       case .googleAI:
         true
-      case .vertexAI:
+      case .agentPlatform:
         false
       }
     }

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/ServerPromptTemplateIntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/ServerPromptTemplateIntegrationTests.swift
@@ -24,10 +24,10 @@ import Testing
 struct ServerPromptTemplateIntegrationTests {
   private static let testConfigs: [InstanceConfig] = [
     .googleAI_v1beta,
-    .vertexAI_v1beta,
-    .vertexAI_v1beta_global,
+    .agentPlatform_v1beta,
+    .agentPlatform_v1beta_global,
   ]
-  private static let imageGenerationTestConfigs: [InstanceConfig] = [.vertexAI_v1beta]
+  private static let imageGenerationTestConfigs: [InstanceConfig] = [.agentPlatform_v1beta]
 
   @Test(arguments: testConfigs)
   func generateContentWithText(_ config: InstanceConfig) async throws {
@@ -66,7 +66,7 @@ struct ServerPromptTemplateIntegrationTests {
 
   @Test(arguments: [
     InstanceConfig.googleAI_v1beta,
-    InstanceConfig.vertexAI_v1beta,
+    InstanceConfig.agentPlatform_v1beta,
   ])
   func generateContentWithTemplateMapsGrounding(_ config: InstanceConfig) async throws {
     let toolConfig = TemplateToolConfig(
@@ -90,7 +90,7 @@ struct ServerPromptTemplateIntegrationTests {
 
   @Test(arguments: [
     InstanceConfig.googleAI_v1beta,
-    InstanceConfig.vertexAI_v1beta,
+    InstanceConfig.agentPlatform_v1beta,
   ])
   @available(*, deprecated)
   func generateImages(_ config: InstanceConfig) async throws {

--- a/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
@@ -22,39 +22,39 @@ import Testing
 struct InstanceConfig: Equatable, Encodable {
   static let agentPlatform_v1beta = InstanceConfig(
     apiConfig: APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1"),
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: "us-central1"),
       version: .v1beta
     )
   )
   static let agentPlatform_v1beta_appCheckLimitedUse = InstanceConfig(
     useLimitedUseAppCheckTokens: true,
     apiConfig: APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1"),
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: "us-central1"),
       version: .v1beta
     )
   )
   static let agentPlatform_v1beta_global = InstanceConfig(
     apiConfig: APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: "global"),
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: "global"),
       version: .v1beta
     )
   )
   static let agentPlatform_v1beta_global_appCheckLimitedUse = InstanceConfig(
     useLimitedUseAppCheckTokens: true,
     apiConfig: APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: "global"),
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: "global"),
       version: .v1beta
     )
   )
   static let agentPlatform_v1beta_staging = InstanceConfig(
     apiConfig: APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyStaging, location: "us-central1"),
+      service: .agentPlatform(endpoint: .firebaseProxyStaging, location: "us-central1"),
       version: .v1beta
     )
   )
   static let agentPlatform_v1beta_staging_global_bypassProxy = InstanceConfig(
     apiConfig: APIConfig(
-      service: .vertexAI(endpoint: .vertexAIStagingBypassProxy, location: "global"),
+      service: .agentPlatform(endpoint: .vertexAIStagingBypassProxy, location: "global"),
       version: .v1beta1
     )
   )
@@ -103,7 +103,7 @@ struct InstanceConfig: Equatable, Encodable {
   static let agentPlatform_v1beta_appCheckNotConfigured = InstanceConfig(
     appName: FirebaseAppNames.appCheckNotConfigured,
     apiConfig: APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1"),
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: "us-central1"),
       version: .v1beta
     )
   )
@@ -111,7 +111,7 @@ struct InstanceConfig: Equatable, Encodable {
     appName: FirebaseAppNames.appCheckNotConfigured,
     useLimitedUseAppCheckTokens: true,
     apiConfig: APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1"),
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: "us-central1"),
       version: .v1beta
     )
   )
@@ -148,7 +148,7 @@ struct InstanceConfig: Equatable, Encodable {
 
   var serviceName: String {
     switch apiConfig.service {
-    case .vertexAI:
+    case .agentPlatform:
       return "Agent Platform"
     case .googleAI:
       return "Google AI"
@@ -174,7 +174,7 @@ extension InstanceConfig: CustomTestStringConvertible {
       " - Staging - Bypass Proxy"
     }
     let locationSuffix: String
-    if case let .vertexAI(_, location: location) = apiConfig.service {
+    if case let .agentPlatform(_, location: location) = apiConfig.service {
       locationSuffix = " - (\(location))"
     } else {
       locationSuffix = ""
@@ -191,7 +191,7 @@ extension InstanceConfig: CustomTestStringConvertible {
 extension FirebaseAI {
   static func componentInstance(_ instanceConfig: InstanceConfig) -> FirebaseAI {
     switch instanceConfig.apiConfig.service {
-    case .vertexAI:
+    case .agentPlatform:
       return FirebaseAI.createInstance(
         app: instanceConfig.app,
         apiConfig: instanceConfig.apiConfig,

--- a/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
@@ -20,39 +20,39 @@ import Testing
 @testable import struct FirebaseAILogic.APIConfig
 
 struct InstanceConfig: Equatable, Encodable {
-  static let vertexAI_v1beta = InstanceConfig(
+  static let agentPlatform_v1beta = InstanceConfig(
     apiConfig: APIConfig(
       service: .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1"),
       version: .v1beta
     )
   )
-  static let vertexAI_v1beta_appCheckLimitedUse = InstanceConfig(
+  static let agentPlatform_v1beta_appCheckLimitedUse = InstanceConfig(
     useLimitedUseAppCheckTokens: true,
     apiConfig: APIConfig(
       service: .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1"),
       version: .v1beta
     )
   )
-  static let vertexAI_v1beta_global = InstanceConfig(
+  static let agentPlatform_v1beta_global = InstanceConfig(
     apiConfig: APIConfig(
       service: .vertexAI(endpoint: .firebaseProxyProd, location: "global"),
       version: .v1beta
     )
   )
-  static let vertexAI_v1beta_global_appCheckLimitedUse = InstanceConfig(
+  static let agentPlatform_v1beta_global_appCheckLimitedUse = InstanceConfig(
     useLimitedUseAppCheckTokens: true,
     apiConfig: APIConfig(
       service: .vertexAI(endpoint: .firebaseProxyProd, location: "global"),
       version: .v1beta
     )
   )
-  static let vertexAI_v1beta_staging = InstanceConfig(
+  static let agentPlatform_v1beta_staging = InstanceConfig(
     apiConfig: APIConfig(
       service: .vertexAI(endpoint: .firebaseProxyStaging, location: "us-central1"),
       version: .v1beta
     )
   )
-  static let vertexAI_v1beta_staging_global_bypassProxy = InstanceConfig(
+  static let agentPlatform_v1beta_staging_global_bypassProxy = InstanceConfig(
     apiConfig: APIConfig(
       service: .vertexAI(endpoint: .vertexAIStagingBypassProxy, location: "global"),
       version: .v1beta1
@@ -78,13 +78,13 @@ struct InstanceConfig: Equatable, Encodable {
   )
 
   static let defaultConfigs = [
-    vertexAI_v1beta_global,
+    agentPlatform_v1beta_global,
     googleAI_v1beta,
     // Note: The following configs are commented out for easy one-off manual testing.
-    // vertexAI_v1beta,
-    // vertexAI_v1beta_global_appCheckLimitedUse,
-    // vertexAI_v1beta_staging,
-    // vertexAI_v1beta_staging_global_bypassProxy,
+    // agentPlatform_v1beta,
+    // agentPlatform_v1beta_global_appCheckLimitedUse,
+    // agentPlatform_v1beta_staging,
+    // agentPlatform_v1beta_staging_global_bypassProxy,
     // googleAI_v1beta_appCheckLimitedUse,
     // googleAI_v1beta_staging,
     // googleAI_v1beta_freeTier,
@@ -92,22 +92,22 @@ struct InstanceConfig: Equatable, Encodable {
   ]
 
   static let liveConfigs = [
-    vertexAI_v1beta,
+    agentPlatform_v1beta,
     googleAI_v1beta,
     // Note: The following configs are commented out for easy one-off manual testing.
-    // vertexAI_v1beta_appCheckLimitedUse,
+    // agentPlatform_v1beta_appCheckLimitedUse,
     // googleAI_v1beta_appCheckLimitedUse,
     // googleAI_v1beta_freeTier,
   ]
 
-  static let vertexAI_v1beta_appCheckNotConfigured = InstanceConfig(
+  static let agentPlatform_v1beta_appCheckNotConfigured = InstanceConfig(
     appName: FirebaseAppNames.appCheckNotConfigured,
     apiConfig: APIConfig(
       service: .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1"),
       version: .v1beta
     )
   )
-  static let vertexAI_v1beta_appCheckNotConfigured_limitedUseTokens = InstanceConfig(
+  static let agentPlatform_v1beta_appCheckNotConfigured_limitedUseTokens = InstanceConfig(
     appName: FirebaseAppNames.appCheckNotConfigured,
     useLimitedUseAppCheckTokens: true,
     apiConfig: APIConfig(
@@ -126,8 +126,8 @@ struct InstanceConfig: Equatable, Encodable {
   )
 
   static let appCheckNotConfiguredConfigs = [
-    vertexAI_v1beta_appCheckNotConfigured,
-    vertexAI_v1beta_appCheckNotConfigured_limitedUseTokens,
+    agentPlatform_v1beta_appCheckNotConfigured,
+    agentPlatform_v1beta_appCheckNotConfigured_limitedUseTokens,
     googleAI_v1beta_appCheckNotConfigured,
     googleAI_v1beta_appCheckNotConfigured_limitedUseTokens,
   ]
@@ -149,7 +149,7 @@ struct InstanceConfig: Equatable, Encodable {
   var serviceName: String {
     switch apiConfig.service {
     case .vertexAI:
-      return "Vertex AI"
+      return "Agent Platform"
     case .googleAI:
       return "Google AI"
     }

--- a/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Utilities/InstanceConfig.swift
@@ -54,7 +54,7 @@ struct InstanceConfig: Equatable, Encodable {
   )
   static let agentPlatform_v1beta_staging_global_bypassProxy = InstanceConfig(
     apiConfig: APIConfig(
-      service: .agentPlatform(endpoint: .vertexAIStagingBypassProxy, location: "global"),
+      service: .agentPlatform(endpoint: .agentPlatformStagingBypassProxy, location: "global"),
       version: .v1beta1
     )
   )
@@ -170,7 +170,7 @@ extension InstanceConfig: CustomTestStringConvertible {
       " - Staging"
     case .googleAIBypassProxy:
       " - Bypass Proxy"
-    case .vertexAIStagingBypassProxy:
+    case .agentPlatformStagingBypassProxy:
       " - Staging - Bypass Proxy"
     }
     let locationSuffix: String

--- a/FirebaseAI/Tests/Unit/APITests.swift
+++ b/FirebaseAI/Tests/Unit/APITests.swift
@@ -45,12 +45,16 @@ final class APITests: XCTestCase {
     let _ = FirebaseAI.firebaseAI(backend: .googleAI())
     let _ = FirebaseAI.firebaseAI(backend: .vertexAI())
     let _ = FirebaseAI.firebaseAI(backend: .vertexAI(location: "my-location"))
+    let _ = FirebaseAI.firebaseAI(backend: .agentPlatform())
+    let _ = FirebaseAI.firebaseAI(backend: .agentPlatform(location: "my-location"))
 
     // Instantiate Firebase AI SDK - Custom App
     let _ = FirebaseAI.firebaseAI(app: app!)
     let _ = FirebaseAI.firebaseAI(app: app!, backend: .googleAI())
     let _ = FirebaseAI.firebaseAI(app: app!, backend: .vertexAI())
     let _ = FirebaseAI.firebaseAI(app: app!, backend: .vertexAI(location: "my-location"))
+    let _ = FirebaseAI.firebaseAI(app: app!, backend: .agentPlatform())
+    let _ = FirebaseAI.firebaseAI(app: app!, backend: .agentPlatform(location: "my-location"))
 
     // Permutations without optional arguments.
 

--- a/FirebaseAI/Tests/Unit/APITests.swift
+++ b/FirebaseAI/Tests/Unit/APITests.swift
@@ -21,6 +21,7 @@ import XCTest
   import UIKit // For UIImage extensions.
 #endif
 
+@available(*, deprecated)
 final class APITests: XCTestCase {
   func codeSamples() async throws {
     let app = FirebaseApp.app()

--- a/FirebaseAI/Tests/Unit/GenerativeModelVertexAITests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelVertexAITests.swift
@@ -1241,7 +1241,7 @@ final class GenerativeModelVertexAITests: XCTestCase {
     XCTFail("Should have caught an error.")
   }
 
-  func testGenerateContentStream_failure_vertexAIInFirebaseAPINotEnabled() async throws {
+  func testGenerateContentStream_failure_agentPlatformInFirebaseAPINotEnabled() async throws {
     let expectedStatusCode = 403
     MockURLProtocol
       .requestHandler = try GenerativeModelTestUtil.httpRequestHandler(

--- a/FirebaseAI/Tests/Unit/Snippets/LiveSnippets.swift
+++ b/FirebaseAI/Tests/Unit/Snippets/LiveSnippets.swift
@@ -30,11 +30,11 @@ final class LiveSnippets: XCTestCase {
   }
 
   func sendAudioReceiveAudio() async throws {
-    // Initialize the Vertex AI Gemini API backend service
+    // Initialize the Gemini Enterprise Agent Platform backend service
     // Set the location to `us-central1` (the flash-live model is only supported in that location)
     // Create a `LiveGenerativeModel` instance with the flash-live model (only model that supports
     // the Live API)
-    let model = FirebaseAI.firebaseAI(backend: .vertexAI(location: "us-central1")).liveModel(
+    let model = FirebaseAI.firebaseAI(backend: .agentPlatform(location: "us-central1")).liveModel(
       modelName: "gemini-2.0-flash-exp",
       // Configure the model to respond with audio
       generationConfig: LiveGenerationConfig(

--- a/FirebaseAI/Tests/Unit/Snippets/MultimodalSnippets.swift
+++ b/FirebaseAI/Tests/Unit/Snippets/MultimodalSnippets.swift
@@ -26,7 +26,7 @@ import XCTest
 @available(macOS 12.0, watchOS 8.0, *)
 final class MultimodalSnippets: XCTestCase {
   let bundle = BundleTestUtil.bundle()
-  lazy var model = FirebaseAI.firebaseAI(backend: .vertexAI()).generativeModel(
+  lazy var model = FirebaseAI.firebaseAI(backend: .agentPlatform()).generativeModel(
     modelName: "gemini-2.0-flash"
   )
   lazy var videoURL = {

--- a/FirebaseAI/Tests/Unit/TemplateGenerativeModelTests.swift
+++ b/FirebaseAI/Tests/Unit/TemplateGenerativeModelTests.swift
@@ -127,7 +127,7 @@ final class TemplateGenerativeModelTests: XCTestCase {
       urlSession: urlSession
     )
     let apiConfig = APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1"),
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: "us-central1"),
       version: .v1beta
     )
     let model = TemplateGenerativeModel(

--- a/FirebaseAI/Tests/Unit/TemplateGenerativeModelTests.swift
+++ b/FirebaseAI/Tests/Unit/TemplateGenerativeModelTests.swift
@@ -113,7 +113,7 @@ final class TemplateGenerativeModelTests: XCTestCase {
     XCTAssertEqual(firstChunk.placeID, "places/ChIJqdNaaBVbwokRLTafYrQlZI8")
   }
 
-  func testGenerateContent_success_mapsGrounding_vertexAI() async throws {
+  func testGenerateContent_success_mapsGrounding_agentPlatform() async throws {
     MockURLProtocol.requestHandler = try GenerativeModelTestUtil.httpRequestHandler(
       forResource: "unary-success-google-maps-grounding",
       withExtension: "json",

--- a/FirebaseAI/Tests/Unit/TestUtilities/FirebaseAI+DefaultAPIConfig.swift
+++ b/FirebaseAI/Tests/Unit/TestUtilities/FirebaseAI+DefaultAPIConfig.swift
@@ -16,7 +16,7 @@
 
 extension FirebaseAI {
   static let defaultVertexAIAPIConfig = APIConfig(
-    service: .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1"),
+    service: .agentPlatform(endpoint: .firebaseProxyProd, location: "us-central1"),
     version: .v1beta
   )
 }

--- a/FirebaseAI/Tests/Unit/Types/BackendTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/BackendTests.swift
@@ -17,6 +17,7 @@ import XCTest
 @testable import FirebaseAILogic
 
 final class BackendTests: XCTestCase {
+  @available(*, deprecated)
   func testVertexAI_defaultLocation() {
     let expectedAPIConfig = APIConfig(
       service: .agentPlatform(endpoint: .firebaseProxyProd, location: "us-central1"),
@@ -28,6 +29,7 @@ final class BackendTests: XCTestCase {
     XCTAssertEqual(backend.apiConfig, expectedAPIConfig)
   }
 
+  @available(*, deprecated)
   func testVertexAI_customLocation() {
     let customLocation = "europe-west1"
     let expectedAPIConfig = APIConfig(

--- a/FirebaseAI/Tests/Unit/Types/BackendTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/BackendTests.swift
@@ -19,7 +19,7 @@ import XCTest
 final class BackendTests: XCTestCase {
   func testVertexAI_defaultLocation() {
     let expectedAPIConfig = APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1"),
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: "us-central1"),
       version: .v1beta
     )
 
@@ -31,7 +31,7 @@ final class BackendTests: XCTestCase {
   func testVertexAI_customLocation() {
     let customLocation = "europe-west1"
     let expectedAPIConfig = APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: customLocation),
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: customLocation),
       version: .v1beta
     )
 
@@ -53,7 +53,7 @@ final class BackendTests: XCTestCase {
 
   func testAgentPlatform_defaultLocation() {
     let expectedAPIConfig = APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: "global"),
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: "global"),
       version: .v1beta
     )
 
@@ -65,7 +65,7 @@ final class BackendTests: XCTestCase {
   func testAgentPlatform_customLocation() {
     let customLocation = "europe-west1"
     let expectedAPIConfig = APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: customLocation),
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: customLocation),
       version: .v1beta
     )
 

--- a/FirebaseAI/Tests/Unit/Types/BackendTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/BackendTests.swift
@@ -50,4 +50,27 @@ final class BackendTests: XCTestCase {
 
     XCTAssertEqual(backend.apiConfig, expectedAPIConfig)
   }
+
+  func testAgentPlatform_defaultLocation() {
+    let expectedAPIConfig = APIConfig(
+      service: .vertexAI(endpoint: .firebaseProxyProd, location: "global"),
+      version: .v1beta
+    )
+
+    let backend = Backend.agentPlatform()
+
+    XCTAssertEqual(backend.apiConfig, expectedAPIConfig)
+  }
+
+  func testAgentPlatform_customLocation() {
+    let customLocation = "europe-west1"
+    let expectedAPIConfig = APIConfig(
+      service: .vertexAI(endpoint: .firebaseProxyProd, location: customLocation),
+      version: .v1beta
+    )
+
+    let backend = Backend.agentPlatform(location: customLocation)
+
+    XCTAssertEqual(backend.apiConfig, expectedAPIConfig)
+  }
 }

--- a/FirebaseAI/Tests/Unit/Types/CitationMetadataTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/CitationMetadataTests.swift
@@ -55,9 +55,9 @@ final class CitationMetadataTests: XCTestCase {
     XCTAssertEqual(citation, expectedCitation)
   }
 
-  // MARK: - Vertex AI Format Decoding
+  // MARK: - Gemini Enterprise Agent Platform Format Decoding
 
-  func testDecodeCitationMetadata_vertexAIFormat() throws {
+  func testDecodeCitationMetadata_agentPlatformFormat() throws {
     let json = """
     {
       "citations": [\(citationJSON)]

--- a/FirebaseAI/Tests/Unit/Types/Internal/APIConfigTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/Internal/APIConfigTests.swift
@@ -20,66 +20,66 @@ final class APIConfigTests: XCTestCase {
   let defaultLocation = "us-central1"
   let globalLocation = "global"
 
-  func testInitialize_vertexAI_prod_v1() {
+  func testInitialize_agentPlatform_prod_v1() {
     let apiConfig = APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: defaultLocation),
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: defaultLocation),
       version: .v1
     )
 
     switch apiConfig.service {
-    case let .vertexAI(endpoint: endpoint, location: location):
+    case let .agentPlatform(endpoint: endpoint, location: location):
       XCTAssertEqual(endpoint.rawValue, "https://firebasevertexai.googleapis.com")
       XCTAssertEqual(location, defaultLocation)
     case .googleAI:
-      XCTFail("Expected .vertexAI, got .googleAI")
+      XCTFail("Expected .agentPlatform, got .googleAI")
     }
     XCTAssertEqual(apiConfig.version.rawValue, "v1")
   }
 
-  func testInitialize_vertexAI_prod_v1beta() {
+  func testInitialize_agentPlatform_prod_v1beta() {
     let apiConfig = APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: defaultLocation),
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: defaultLocation),
       version: .v1beta
     )
 
     switch apiConfig.service {
-    case let .vertexAI(endpoint: endpoint, location: location):
+    case let .agentPlatform(endpoint: endpoint, location: location):
       XCTAssertEqual(endpoint.rawValue, "https://firebasevertexai.googleapis.com")
       XCTAssertEqual(location, defaultLocation)
     case .googleAI:
-      XCTFail("Expected .vertexAI, got .googleAI")
+      XCTFail("Expected .agentPlatform, got .googleAI")
     }
     XCTAssertEqual(apiConfig.version.rawValue, "v1beta")
   }
 
-  func testInitialize_vertexAI_staging_v1() {
+  func testInitialize_agentPlatform_staging_v1() {
     let apiConfig = APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyStaging, location: defaultLocation),
+      service: .agentPlatform(endpoint: .firebaseProxyStaging, location: defaultLocation),
       version: .v1
     )
 
     switch apiConfig.service {
-    case let .vertexAI(endpoint: endpoint, location: location):
+    case let .agentPlatform(endpoint: endpoint, location: location):
       XCTAssertEqual(endpoint.rawValue, "https://staging-firebasevertexai.sandbox.googleapis.com")
       XCTAssertEqual(location, defaultLocation)
     case .googleAI:
-      XCTFail("Expected .vertexAI, got .googleAI")
+      XCTFail("Expected .agentPlatform, got .googleAI")
     }
     XCTAssertEqual(apiConfig.version.rawValue, "v1")
   }
 
-  func testInitialize_vertexAI_staging_v1beta() {
+  func testInitialize_agentPlatform_staging_v1beta() {
     let apiConfig = APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyStaging, location: defaultLocation),
+      service: .agentPlatform(endpoint: .firebaseProxyStaging, location: defaultLocation),
       version: .v1beta
     )
 
     switch apiConfig.service {
-    case let .vertexAI(endpoint: endpoint, location: location):
+    case let .agentPlatform(endpoint: endpoint, location: location):
       XCTAssertEqual(endpoint.rawValue, "https://staging-firebasevertexai.sandbox.googleapis.com")
       XCTAssertEqual(location, defaultLocation)
     case .googleAI:
-      XCTFail("Expected .vertexAI, got .googleAI")
+      XCTFail("Expected .agentPlatform, got .googleAI")
     }
     XCTAssertEqual(apiConfig.version.rawValue, "v1beta")
   }
@@ -90,8 +90,8 @@ final class APIConfigTests: XCTestCase {
     )
 
     switch apiConfig.service {
-    case .vertexAI:
-      XCTFail("Expected .googleAI, got .vertexAI")
+    case .agentPlatform:
+      XCTFail("Expected .googleAI, got .agentPlatform")
     case let .googleAI(endpoint: endpoint):
       XCTAssertEqual(endpoint.rawValue, "https://staging-firebasevertexai.sandbox.googleapis.com")
     }
@@ -102,8 +102,8 @@ final class APIConfigTests: XCTestCase {
     let apiConfig = APIConfig(service: .googleAI(endpoint: .googleAIBypassProxy), version: .v1beta)
 
     switch apiConfig.service {
-    case .vertexAI:
-      XCTFail("Expected .googleAI, got .vertexAI")
+    case .agentPlatform:
+      XCTFail("Expected .googleAI, got .agentPlatform")
     case let .googleAI(endpoint: endpoint):
       XCTAssertEqual(endpoint.rawValue, "https://generativelanguage.googleapis.com")
     }

--- a/FirebaseAI/Tests/Unit/Types/Internal/Requests/CountTokensRequestTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/Internal/Requests/CountTokensRequestTests.swift
@@ -37,7 +37,7 @@ final class CountTokensRequestTests: XCTestCase {
 
   // MARK: CountTokensRequest Encoding
 
-  func testEncodeCountTokensRequest_vertexAI_minimal() throws {
+  func testEncodeCountTokensRequest_agentPlatform_minimal() throws {
     let content = ModelContent(role: nil, parts: [textPart])
     let generateContentRequest = GenerateContentRequest(
       model: modelResourceName,

--- a/FirebaseAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseAI/Tests/Unit/VertexComponentTests.swift
@@ -298,9 +298,10 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(modelResourceName, "projects/\(projectID)/models/\(model)")
   }
 
+  @available(*, deprecated)
   func testGenerativeModel_deprecatedVertexAI_defaultLocation() async throws {
     let app = try XCTUnwrap(VertexComponentTests.app)
-    let vertex = FirebaseAI.firebaseAI(app: app, backend: .agentPlatform(location: "us-central1"))
+    let vertex = FirebaseAI.firebaseAI(app: app, backend: .vertexAI())
     let modelResourceName = vertex.modelResourceName(modelName: modelName)
     let expectedSystemInstruction = ModelContent(role: nil, parts: systemInstruction.parts)
 

--- a/FirebaseAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseAI/Tests/Unit/VertexComponentTests.swift
@@ -50,6 +50,7 @@ class VertexComponentTests: XCTestCase {
   }
 
   /// Tests that a vertex instance can be created properly using the default Firebase app.
+  @available(*, deprecated)
   func testVertexInstanceCreation_defaultApp() throws {
     let vertex = FirebaseAI.firebaseAI(backend: .vertexAI(location: "us-central1"))
 
@@ -68,6 +69,7 @@ class VertexComponentTests: XCTestCase {
 
   /// Tests that a vertex instance can be created properly using the default Firebase app and custom
   /// location.
+  @available(*, deprecated)
   func testVertexInstanceCreation_defaultApp_customLocation() throws {
     let vertex = FirebaseAI.firebaseAI(backend: .vertexAI(location: location))
 
@@ -82,6 +84,7 @@ class VertexComponentTests: XCTestCase {
   }
 
   /// Tests that a vertex instance can be created properly.
+  @available(*, deprecated)
   func testVertexInstanceCreation_customApp() throws {
     let vertex = FirebaseAI.firebaseAI(
       app: VertexComponentTests.app,
@@ -310,6 +313,7 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(generativeModel.apiConfig, FirebaseAI.defaultVertexAIAPIConfig)
   }
 
+  @available(*, deprecated)
   func testGenerativeModel_deprecatedVertexAI_customLocation() async throws {
     let app = try XCTUnwrap(VertexComponentTests.app)
     let vertex = FirebaseAI.firebaseAI(app: app, backend: .vertexAI(location: location))

--- a/FirebaseAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseAI/Tests/Unit/VertexComponentTests.swift
@@ -51,7 +51,7 @@ class VertexComponentTests: XCTestCase {
 
   /// Tests that a vertex instance can be created properly using the default Firebase app.
   func testVertexInstanceCreation_defaultApp() throws {
-    let vertex = FirebaseAI.firebaseAI(backend: .vertexAI())
+    let vertex = FirebaseAI.firebaseAI(backend: .agentPlatform(location: "us-central1"))
 
     XCTAssertNotNil(vertex)
     XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
@@ -69,7 +69,7 @@ class VertexComponentTests: XCTestCase {
   /// Tests that a vertex instance can be created properly using the default Firebase app and custom
   /// location.
   func testVertexInstanceCreation_defaultApp_customLocation() throws {
-    let vertex = FirebaseAI.firebaseAI(backend: .vertexAI(location: location))
+    let vertex = FirebaseAI.firebaseAI(backend: .agentPlatform(location: location))
 
     XCTAssertNotNil(vertex)
     XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
@@ -85,7 +85,7 @@ class VertexComponentTests: XCTestCase {
   func testVertexInstanceCreation_customApp() throws {
     let vertex = FirebaseAI.firebaseAI(
       app: VertexComponentTests.app,
-      backend: .vertexAI(location: location)
+      backend: .agentPlatform(location: location)
     )
 
     XCTAssertNotNil(vertex)
@@ -149,8 +149,8 @@ class VertexComponentTests: XCTestCase {
   func testSameAppAndLocation_instanceReused() throws {
     let app = try XCTUnwrap(VertexComponentTests.app)
 
-    let vertex1 = FirebaseAI.firebaseAI(app: app, backend: .vertexAI(location: location))
-    let vertex2 = FirebaseAI.firebaseAI(app: app, backend: .vertexAI(location: location))
+    let vertex1 = FirebaseAI.firebaseAI(app: app, backend: .agentPlatform(location: location))
+    let vertex2 = FirebaseAI.firebaseAI(app: app, backend: .agentPlatform(location: location))
 
     // Ensure they're the same instance.
     XCTAssert(vertex1 === vertex2)
@@ -159,11 +159,11 @@ class VertexComponentTests: XCTestCase {
   func testSameAppAndDifferentLocation_newInstanceCreated() throws {
     let vertex1 = FirebaseAI.firebaseAI(
       app: VertexComponentTests.app,
-      backend: .vertexAI(location: location)
+      backend: .agentPlatform(location: location)
     )
     let vertex2 = FirebaseAI.firebaseAI(
       app: VertexComponentTests.app,
-      backend: .vertexAI(location: "differentLocation")
+      backend: .agentPlatform(location: "differentLocation")
     )
 
     // Ensure they are different instances.
@@ -177,9 +177,9 @@ class VertexComponentTests: XCTestCase {
 
     let vertex1 = FirebaseAI.firebaseAI(
       app: VertexComponentTests.app,
-      backend: .vertexAI(location: location)
+      backend: .agentPlatform(location: location)
     )
-    let vertex2 = FirebaseAI.firebaseAI(app: app2, backend: .vertexAI(location: location))
+    let vertex2 = FirebaseAI.firebaseAI(app: app2, backend: .agentPlatform(location: location))
 
     XCTAssert(VertexComponentTests.app != app2)
     XCTAssert(vertex1 !== vertex2) // Ensure they are different instances.
@@ -192,11 +192,11 @@ class VertexComponentTests: XCTestCase {
 
     let vertex1 = FirebaseAI.firebaseAI(
       app: VertexComponentTests.app,
-      backend: .vertexAI(location: location)
+      backend: .agentPlatform(location: location)
     )
     let vertex2 = FirebaseAI.firebaseAI(
       app: app2,
-      backend: .vertexAI(location: "differentLocation")
+      backend: .agentPlatform(location: "differentLocation")
     )
 
     XCTAssert(VertexComponentTests.app != app2)
@@ -250,10 +250,10 @@ class VertexComponentTests: XCTestCase {
     XCTAssertNil(weakVertex)
   }
 
-  func testModelResourceName_vertexAI() throws {
+  func testModelResourceName_agentPlatform() throws {
     let app = try XCTUnwrap(VertexComponentTests.app)
     let location = "test-location"
-    let vertex = FirebaseAI.firebaseAI(app: app, backend: .vertexAI(location: location))
+    let vertex = FirebaseAI.firebaseAI(app: app, backend: .agentPlatform(location: location))
     let model = "test-model-name"
     let projectID = vertex.firebaseInfo.projectID
 
@@ -295,9 +295,9 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(modelResourceName, "projects/\(projectID)/models/\(model)")
   }
 
-  func testGenerativeModel_vertexAI_defaultLocation() async throws {
+  func testGenerativeModel_deprecatedVertexAI_defaultLocation() async throws {
     let app = try XCTUnwrap(VertexComponentTests.app)
-    let vertex = FirebaseAI.firebaseAI(app: app, backend: .vertexAI())
+    let vertex = FirebaseAI.firebaseAI(app: app, backend: .agentPlatform(location: "us-central1"))
     let modelResourceName = vertex.modelResourceName(modelName: modelName)
     let expectedSystemInstruction = ModelContent(role: nil, parts: systemInstruction.parts)
 
@@ -310,9 +310,9 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(generativeModel.apiConfig, FirebaseAI.defaultVertexAIAPIConfig)
   }
 
-  func testGenerativeModel_vertexAI_customLocation() async throws {
+  func testGenerativeModel_deprecatedVertexAI_customLocation() async throws {
     let app = try XCTUnwrap(VertexComponentTests.app)
-    let vertex = FirebaseAI.firebaseAI(app: app, backend: .vertexAI(location: location))
+    let vertex = FirebaseAI.firebaseAI(app: app, backend: .agentPlatform(location: location))
     let modelResourceName = vertex.modelResourceName(modelName: modelName)
     let expectedAPIConfig = APIConfig(
       service: .agentPlatform(endpoint: .firebaseProxyProd, location: location), version: .v1beta

--- a/FirebaseAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseAI/Tests/Unit/VertexComponentTests.swift
@@ -57,7 +57,10 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
     XCTAssertEqual(vertex.firebaseInfo.apiKey, VertexComponentTests.apiKey)
     XCTAssertEqual(
-      vertex.apiConfig.service, .vertexAI(endpoint: .firebaseProxyProd, location: "us-central1")
+      vertex.apiConfig.service, .agentPlatform(
+        endpoint: .firebaseProxyProd,
+        location: "us-central1"
+      )
     )
     XCTAssertEqual(vertex.apiConfig.service.endpoint, .firebaseProxyProd)
     XCTAssertEqual(vertex.apiConfig.version, .v1beta)
@@ -72,7 +75,7 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
     XCTAssertEqual(vertex.firebaseInfo.apiKey, VertexComponentTests.apiKey)
     XCTAssertEqual(
-      vertex.apiConfig.service, .vertexAI(endpoint: .firebaseProxyProd, location: location)
+      vertex.apiConfig.service, .agentPlatform(endpoint: .firebaseProxyProd, location: location)
     )
     XCTAssertEqual(vertex.apiConfig.service.endpoint, .firebaseProxyProd)
     XCTAssertEqual(vertex.apiConfig.version, .v1beta)
@@ -89,7 +92,7 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
     XCTAssertEqual(vertex.firebaseInfo.apiKey, VertexComponentTests.apiKey)
     XCTAssertEqual(
-      vertex.apiConfig.service, .vertexAI(endpoint: .firebaseProxyProd, location: location)
+      vertex.apiConfig.service, .agentPlatform(endpoint: .firebaseProxyProd, location: location)
     )
     XCTAssertEqual(vertex.apiConfig.service.endpoint, .firebaseProxyProd)
     XCTAssertEqual(vertex.apiConfig.version, .v1beta)
@@ -103,7 +106,7 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
     XCTAssertEqual(vertex.firebaseInfo.apiKey, VertexComponentTests.apiKey)
     XCTAssertEqual(
-      vertex.apiConfig.service, .vertexAI(endpoint: .firebaseProxyProd, location: "global")
+      vertex.apiConfig.service, .agentPlatform(endpoint: .firebaseProxyProd, location: "global")
     )
     XCTAssertEqual(vertex.apiConfig.service.endpoint, .firebaseProxyProd)
     XCTAssertEqual(vertex.apiConfig.version, .v1beta)
@@ -119,7 +122,7 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
     XCTAssertEqual(vertex.firebaseInfo.apiKey, VertexComponentTests.apiKey)
     XCTAssertEqual(
-      vertex.apiConfig.service, .vertexAI(endpoint: .firebaseProxyProd, location: location)
+      vertex.apiConfig.service, .agentPlatform(endpoint: .firebaseProxyProd, location: location)
     )
     XCTAssertEqual(vertex.apiConfig.service.endpoint, .firebaseProxyProd)
     XCTAssertEqual(vertex.apiConfig.version, .v1beta)
@@ -136,7 +139,7 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
     XCTAssertEqual(vertex.firebaseInfo.apiKey, VertexComponentTests.apiKey)
     XCTAssertEqual(
-      vertex.apiConfig.service, .vertexAI(endpoint: .firebaseProxyProd, location: location)
+      vertex.apiConfig.service, .agentPlatform(endpoint: .firebaseProxyProd, location: location)
     )
     XCTAssertEqual(vertex.apiConfig.service.endpoint, .firebaseProxyProd)
     XCTAssertEqual(vertex.apiConfig.version, .v1beta)
@@ -204,7 +207,7 @@ class VertexComponentTests: XCTestCase {
     let vertex1 = FirebaseAI.createInstance(
       app: VertexComponentTests.app,
       apiConfig: APIConfig(
-        service: .vertexAI(endpoint: .firebaseProxyProd, location: location),
+        service: .agentPlatform(endpoint: .firebaseProxyProd, location: location),
         version: .v1beta
       ),
       useLimitedUseAppCheckTokens: false
@@ -212,7 +215,7 @@ class VertexComponentTests: XCTestCase {
     let vertex2 = FirebaseAI.createInstance(
       app: VertexComponentTests.app,
       apiConfig: APIConfig(
-        service: .vertexAI(endpoint: .firebaseProxyProd, location: location), version: .v1
+        service: .agentPlatform(endpoint: .firebaseProxyProd, location: location), version: .v1
       ),
       useLimitedUseAppCheckTokens: false
     )
@@ -235,7 +238,7 @@ class VertexComponentTests: XCTestCase {
       let vertex = FirebaseAI(
         app: app1,
         apiConfig: APIConfig(
-          service: .vertexAI(endpoint: .firebaseProxyProd, location: "transitory location"),
+          service: .agentPlatform(endpoint: .firebaseProxyProd, location: "transitory location"),
           version: .v1beta
         ),
         useLimitedUseAppCheckTokens: false
@@ -312,7 +315,7 @@ class VertexComponentTests: XCTestCase {
     let vertex = FirebaseAI.firebaseAI(app: app, backend: .vertexAI(location: location))
     let modelResourceName = vertex.modelResourceName(modelName: modelName)
     let expectedAPIConfig = APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: location), version: .v1beta
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: location), version: .v1beta
     )
     let expectedSystemInstruction = ModelContent(role: nil, parts: systemInstruction.parts)
 
@@ -330,7 +333,7 @@ class VertexComponentTests: XCTestCase {
     let vertex = FirebaseAI.firebaseAI(app: app, backend: .agentPlatform())
     let modelResourceName = vertex.modelResourceName(modelName: modelName)
     let expectedAPIConfig = APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: "global"), version: .v1beta
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: "global"), version: .v1beta
     )
     let expectedSystemInstruction = ModelContent(role: nil, parts: systemInstruction.parts)
 
@@ -348,7 +351,7 @@ class VertexComponentTests: XCTestCase {
     let vertex = FirebaseAI.firebaseAI(app: app, backend: .agentPlatform(location: location))
     let modelResourceName = vertex.modelResourceName(modelName: modelName)
     let expectedAPIConfig = APIConfig(
-      service: .vertexAI(endpoint: .firebaseProxyProd, location: location), version: .v1beta
+      service: .agentPlatform(endpoint: .firebaseProxyProd, location: location), version: .v1beta
     )
     let expectedSystemInstruction = ModelContent(role: nil, parts: systemInstruction.parts)
 

--- a/FirebaseAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseAI/Tests/Unit/VertexComponentTests.swift
@@ -95,6 +95,53 @@ class VertexComponentTests: XCTestCase {
     XCTAssertEqual(vertex.apiConfig.version, .v1beta)
   }
 
+  /// Tests that an agentPlatform instance can be created properly using the default Firebase app.
+  func testAgentPlatformInstanceCreation_defaultApp() throws {
+    let vertex = FirebaseAI.firebaseAI(backend: .agentPlatform())
+
+    XCTAssertNotNil(vertex)
+    XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
+    XCTAssertEqual(vertex.firebaseInfo.apiKey, VertexComponentTests.apiKey)
+    XCTAssertEqual(
+      vertex.apiConfig.service, .vertexAI(endpoint: .firebaseProxyProd, location: "global")
+    )
+    XCTAssertEqual(vertex.apiConfig.service.endpoint, .firebaseProxyProd)
+    XCTAssertEqual(vertex.apiConfig.version, .v1beta)
+  }
+
+  /// Tests that an agentPlatform instance can be created properly using the default Firebase app
+  /// and custom
+  /// location.
+  func testAgentPlatformInstanceCreation_defaultApp_customLocation() throws {
+    let vertex = FirebaseAI.firebaseAI(backend: .agentPlatform(location: location))
+
+    XCTAssertNotNil(vertex)
+    XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
+    XCTAssertEqual(vertex.firebaseInfo.apiKey, VertexComponentTests.apiKey)
+    XCTAssertEqual(
+      vertex.apiConfig.service, .vertexAI(endpoint: .firebaseProxyProd, location: location)
+    )
+    XCTAssertEqual(vertex.apiConfig.service.endpoint, .firebaseProxyProd)
+    XCTAssertEqual(vertex.apiConfig.version, .v1beta)
+  }
+
+  /// Tests that an agentPlatform instance can be created properly.
+  func testAgentPlatformInstanceCreation_customApp() throws {
+    let vertex = FirebaseAI.firebaseAI(
+      app: VertexComponentTests.app,
+      backend: .agentPlatform(location: location)
+    )
+
+    XCTAssertNotNil(vertex)
+    XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
+    XCTAssertEqual(vertex.firebaseInfo.apiKey, VertexComponentTests.apiKey)
+    XCTAssertEqual(
+      vertex.apiConfig.service, .vertexAI(endpoint: .firebaseProxyProd, location: location)
+    )
+    XCTAssertEqual(vertex.apiConfig.service.endpoint, .firebaseProxyProd)
+    XCTAssertEqual(vertex.apiConfig.version, .v1beta)
+  }
+
   /// Tests that Vertex instances are reused properly.
   func testSameAppAndLocation_instanceReused() throws {
     let app = try XCTUnwrap(VertexComponentTests.app)
@@ -263,6 +310,42 @@ class VertexComponentTests: XCTestCase {
   func testGenerativeModel_vertexAI_customLocation() async throws {
     let app = try XCTUnwrap(VertexComponentTests.app)
     let vertex = FirebaseAI.firebaseAI(app: app, backend: .vertexAI(location: location))
+    let modelResourceName = vertex.modelResourceName(modelName: modelName)
+    let expectedAPIConfig = APIConfig(
+      service: .vertexAI(endpoint: .firebaseProxyProd, location: location), version: .v1beta
+    )
+    let expectedSystemInstruction = ModelContent(role: nil, parts: systemInstruction.parts)
+
+    let generativeModel = vertex.generativeModel(
+      modelName: modelName, systemInstruction: systemInstruction
+    )
+
+    XCTAssertEqual(generativeModel.modelResourceName, modelResourceName)
+    XCTAssertEqual(generativeModel.systemInstruction, expectedSystemInstruction)
+    XCTAssertEqual(generativeModel.apiConfig, expectedAPIConfig)
+  }
+
+  func testGenerativeModel_agentPlatform_defaultLocation() async throws {
+    let app = try XCTUnwrap(VertexComponentTests.app)
+    let vertex = FirebaseAI.firebaseAI(app: app, backend: .agentPlatform())
+    let modelResourceName = vertex.modelResourceName(modelName: modelName)
+    let expectedAPIConfig = APIConfig(
+      service: .vertexAI(endpoint: .firebaseProxyProd, location: "global"), version: .v1beta
+    )
+    let expectedSystemInstruction = ModelContent(role: nil, parts: systemInstruction.parts)
+
+    let generativeModel = vertex.generativeModel(
+      modelName: modelName, systemInstruction: systemInstruction
+    )
+
+    XCTAssertEqual(generativeModel.modelResourceName, modelResourceName)
+    XCTAssertEqual(generativeModel.systemInstruction, expectedSystemInstruction)
+    XCTAssertEqual(generativeModel.apiConfig, expectedAPIConfig)
+  }
+
+  func testGenerativeModel_agentPlatform_customLocation() async throws {
+    let app = try XCTUnwrap(VertexComponentTests.app)
+    let vertex = FirebaseAI.firebaseAI(app: app, backend: .agentPlatform(location: location))
     let modelResourceName = vertex.modelResourceName(modelName: modelName)
     let expectedAPIConfig = APIConfig(
       service: .vertexAI(endpoint: .firebaseProxyProd, location: location), version: .v1beta

--- a/FirebaseAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseAI/Tests/Unit/VertexComponentTests.swift
@@ -51,7 +51,7 @@ class VertexComponentTests: XCTestCase {
 
   /// Tests that a vertex instance can be created properly using the default Firebase app.
   func testVertexInstanceCreation_defaultApp() throws {
-    let vertex = FirebaseAI.firebaseAI(backend: .agentPlatform(location: "us-central1"))
+    let vertex = FirebaseAI.firebaseAI(backend: .vertexAI(location: "us-central1"))
 
     XCTAssertNotNil(vertex)
     XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
@@ -69,7 +69,7 @@ class VertexComponentTests: XCTestCase {
   /// Tests that a vertex instance can be created properly using the default Firebase app and custom
   /// location.
   func testVertexInstanceCreation_defaultApp_customLocation() throws {
-    let vertex = FirebaseAI.firebaseAI(backend: .agentPlatform(location: location))
+    let vertex = FirebaseAI.firebaseAI(backend: .vertexAI(location: location))
 
     XCTAssertNotNil(vertex)
     XCTAssertEqual(vertex.firebaseInfo.projectID, VertexComponentTests.projectID)
@@ -85,7 +85,7 @@ class VertexComponentTests: XCTestCase {
   func testVertexInstanceCreation_customApp() throws {
     let vertex = FirebaseAI.firebaseAI(
       app: VertexComponentTests.app,
-      backend: .agentPlatform(location: location)
+      backend: .vertexAI(location: location)
     )
 
     XCTAssertNotNil(vertex)
@@ -312,7 +312,7 @@ class VertexComponentTests: XCTestCase {
 
   func testGenerativeModel_deprecatedVertexAI_customLocation() async throws {
     let app = try XCTUnwrap(VertexComponentTests.app)
-    let vertex = FirebaseAI.firebaseAI(app: app, backend: .agentPlatform(location: location))
+    let vertex = FirebaseAI.firebaseAI(app: app, backend: .vertexAI(location: location))
     let modelResourceName = vertex.modelResourceName(modelName: modelName)
     let expectedAPIConfig = APIConfig(
       service: .agentPlatform(endpoint: .firebaseProxyProd, location: location), version: .v1beta

--- a/FirebaseAI/Wrapper/Tests/APITests.swift
+++ b/FirebaseAI/Wrapper/Tests/APITests.swift
@@ -22,6 +22,7 @@ import XCTest
 #endif
 
 @available(macOS 12.0, watchOS 8.0, *)
+@available(*, deprecated)
 final class APITests: XCTestCase {
   func codeSamples() async throws {
     let app = FirebaseApp.app()

--- a/FirebaseAILogic.podspec
+++ b/FirebaseAILogic.podspec
@@ -76,6 +76,7 @@ Build AI-powered apps and features with the Gemini API using the Firebase AI Log
       unit_tests_dir + 'Snippets/**/*.swift',
       'FirebaseAI/Wrapper/Tests/APITests.swift',
       'FirebaseAI/Tests/Unit/APITests.swift',
+      'FirebaseAI/Tests/Unit/Types/BackendTests.swift',
     ]
     unit_tests.resources = [
       unit_tests_dir + 'vertexai-sdk-test-data/mock-responses',

--- a/FirebaseAILogic.podspec
+++ b/FirebaseAILogic.podspec
@@ -74,6 +74,7 @@ Build AI-powered apps and features with the Gemini API using the Firebase AI Log
     ]
     unit_tests.exclude_files = [
       unit_tests_dir + 'Snippets/**/*.swift',
+      'FirebaseAI/Wrapper/Tests/APITests.swift',
     ]
     unit_tests.resources = [
       unit_tests_dir + 'vertexai-sdk-test-data/mock-responses',

--- a/FirebaseAILogic.podspec
+++ b/FirebaseAILogic.podspec
@@ -77,6 +77,7 @@ Build AI-powered apps and features with the Gemini API using the Firebase AI Log
       'FirebaseAI/Wrapper/Tests/APITests.swift',
       'FirebaseAI/Tests/Unit/APITests.swift',
       'FirebaseAI/Tests/Unit/Types/BackendTests.swift',
+      'FirebaseAI/Tests/Unit/VertexComponentTests.swift',
     ]
     unit_tests.resources = [
       unit_tests_dir + 'vertexai-sdk-test-data/mock-responses',

--- a/FirebaseAILogic.podspec
+++ b/FirebaseAILogic.podspec
@@ -75,6 +75,7 @@ Build AI-powered apps and features with the Gemini API using the Firebase AI Log
     unit_tests.exclude_files = [
       unit_tests_dir + 'Snippets/**/*.swift',
       'FirebaseAI/Wrapper/Tests/APITests.swift',
+      'FirebaseAI/Tests/Unit/APITests.swift',
     ]
     unit_tests.resources = [
       unit_tests_dir + 'vertexai-sdk-test-data/mock-responses',

--- a/FirebaseAILogic.podspec
+++ b/FirebaseAILogic.podspec
@@ -74,10 +74,6 @@ Build AI-powered apps and features with the Gemini API using the Firebase AI Log
     ]
     unit_tests.exclude_files = [
       unit_tests_dir + 'Snippets/**/*.swift',
-      'FirebaseAI/Wrapper/Tests/APITests.swift',
-      'FirebaseAI/Tests/Unit/APITests.swift',
-      'FirebaseAI/Tests/Unit/Types/BackendTests.swift',
-      'FirebaseAI/Tests/Unit/VertexComponentTests.swift',
     ]
     unit_tests.resources = [
       unit_tests_dir + 'vertexai-sdk-test-data/mock-responses',

--- a/scripts/update_vertexai_responses.sh
+++ b/scripts/update_vertexai_responses.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script replaces mock response files for Vertex AI unit tests with a fresh
-# clone of the shared repository of Vertex AI test data.
+# This script replaces mock response files for Gemini Enterprise Agent Platform unit tests with a fresh
+# clone of the shared repository of mock test data.
 
 cd "$(dirname "$0")/../FirebaseAI/Tests/Unit" || exit
 rm -rf vertexai-sdk-test-data || exit


### PR DESCRIPTION
## Description

This PR deprecates the Vertex AI backend configuration (`Backend.vertexAI`) in favor of the **Gemini Enterprise Agent Platform** (`Backend.agentPlatform`). In addition to renaming the public builders, this PR updates the internal representation and shifts the default location from `"us-central1"` to `"global"`. 

The internal code is systematically renamed to fully replace all non-public occurrences of the string `vertexAI` with `agentPlatform` (including staging endpoints, logging message codes, error configurations, and unit tests).

Backward compatibility is preserved: the deprecated public `Backend.vertexAI()` methods are kept functional (and verified in `BackendTests.swift`) by mapping them to the new `.agentPlatform` service case under the hood.

Note: A few tweaks to the pod_lib_tests are done to bypass warnings so we can continue to test the deprecated API.

---
## Changes
### Public API & Documentation
* **`Backend.swift`**:
  * Deprecated `Backend.vertexAI()` (without arguments), directing developers to `Backend.agentPlatform()` and informing them of the default location change to `"global"`.
  * Deprecated `Backend.vertexAI(location:)`, adding the `@available(*, deprecated, renamed: "agentPlatform(location:)")` compiler attribute for Xcode automatic Fix-It refactoring.
  * Added the new recommended builder: `public static func agentPlatform(location: String = "global") -> Backend`.
* **`CHANGELOG.md`**:
  * Added a change entry detailing the deprecation of `Backend.vertexAI` in favor of `Backend.agentPlatform`.
### Internal Service & Error Renaming (`vertexAI` -> `agentPlatform`)
* **`APIConfig.swift`**:
  * Renamed the internal enum case `APIConfig.Service.vertexAI` to `Service.agentPlatform`.
  * Renamed the debug staging bypass case `Endpoint.vertexAIStagingBypassProxy` to `Endpoint.agentPlatformStagingBypassProxy`.
* **`FirebaseAI.swift`**:
  * Renamed internal helper function `vertexAIModelResourceName` to `agentPlatformModelResourceName`.
  * Updated pattern match switches to handle `.agentPlatform` and `.agentPlatformStagingBypassProxy`.
* **`GenerativeModel.swift`**:
  * Updated the debug staging bypass proxy case to `.googleAI(endpoint: .agentPlatformStagingBypassProxy)`.
* **`AILog.swift` & `GenerativeAIService.swift`**:
  * Renamed the logging error code case `vertexAIInFirebaseAPIDisabled` to `agentPlatformInFirebaseAPIDisabled`.
* **Request & Connection Modules**:
  * Updated URL/path compilation matching in `TemplateGenerateContentRequest.swift`, `TemplateImagenGenerationRequest.swift`, `LiveSessionService.swift`, and `CountTokensRequest.swift` to match on `.agentPlatform`.
### Test Suites & Snippets
* **`InstanceConfig.swift`**:
  * Renamed all configuration constants from `vertexAI_v1beta...` to `agentPlatform_v1beta...` and updated `serviceName` display values to `"Agent Platform"`.
* **`VertexComponentTests.swift`**:
  * Renamed test cases (`testModelResourceName_agentPlatform`, `testGenerativeModel_deprecatedVertexAI_defaultLocation`, `testGenerativeModel_deprecatedVertexAI_customLocation`) and updated matching logic.
* **Test Case Names**:
  * Renamed `testGenerateContentStream_failure_vertexAIInFirebaseAPINotEnabled()` to `testGenerateContentStream_failure_agentPlatformInFirebaseAPINotEnabled()` in `GenerativeModelVertexAITests.swift`.
  * Renamed `testGenerateContent_success_mapsGrounding_vertexAI()` to `testGenerateContent_success_mapsGrounding_agentPlatform()` in `TemplateGenerativeModelTests.swift`.
  * Renamed `testDecodeCitationMetadata_vertexAIFormat()` to `testDecodeCitationMetadata_agentPlatformFormat()` in `CitationMetadataTests.swift`.
  * Renamed `testEncodeCountTokensRequest_vertexAI_minimal()` to `testEncodeCountTokensRequest_agentPlatform_minimal()` in `CountTokensRequestTests.swift`.
  * Updated all integration tests and snippets to use `agentPlatform` configurations instead of `vertexAI`.
---
## Verification Plan
### Automated Tests
* Verified compilation checks for the deprecated API endpoints remain intact in `APITests.swift`.
* Verified functional mapping of deprecated methods continues to work in `BackendTests.swift`.