### PR TITLE
fix(ai): add `geminiLanguageModel()` availability annotation

### DIFF
--- a/FirebaseAI/Sources/FirebaseAI.swift
+++ b/FirebaseAI/Sources/FirebaseAI.swift
@@ -106,7 +106,9 @@ public final class FirebaseAI: Sendable {
     )
   }
 
-  #if compiler(>=6.4)
+  #if compiler(>=6.4) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    @available(tvOS, unavailable)
     public func geminiLanguageModel(name: String, safetySettings: [SafetySetting]? = nil,
                                     options: GeminiGenerationOptions? = nil,
                                     serverTools: [any GeminiTool]? = nil,
@@ -123,7 +125,7 @@ public final class FirebaseAI: Sendable {
         requestOptions: requestOptions,
       )
     }
-  #endif // compiler(>=6.4)
+  #endif // compiler(>=6.4) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
 
   // TODO: Remove the `#if compiler(>=6.2.3)` when Xcode 26.2 is the minimum supported version.
   #if compiler(>=6.2.3)


### PR DESCRIPTION
This fixes a compile error on Xcode 27, introduced in #16371 which was not caught by CI (only runs on Xcode 26). Since the method is guarded by `#if compiler(>=6.4)`, this evaluated to `false`, skipping compilation and allowing CI to pass. Added `@available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)` to match `GeminiLanguageModel`.

#no-changelog
