### PR TITLE
docs: add column wrapping guidelines for AI agents

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,10 @@
+# Code Generation Style Guidelines
+
+## Formatting and Column Widths
+
+* **Markdown Documents**: Limit Markdown content and prose to a maximum of
+  80 columns per line where reasonable.
+* **Swift Code**: Wrap Swift code to a maximum of 100 columns.
+  * **Long Strings**: Since the project's automatic Swift formatter may not
+    wrap long string literals, wrap them manually using multi-line triple
+    quotes (`"""..."""`).


### PR DESCRIPTION
Adds rules to wrap Markdown to 80 columns and Swift to 100 columns (using triple quotes for long strings). These were added in `.agents/AGENTS.md` based on guidance from Antigravity.

#no-changelog