### PR TITLE
fix(ai): resolve build failures with Xcode 27 Beta 3

### DIFF
--- a/FirebaseAI/Sources/AILog.swift
+++ b/FirebaseAI/Sources/AILog.swift
@@ -36,6 +36,7 @@ enum AILog {
     case unsupportedGeminiModel = 1001
     case invalidSchemaFormat = 1002
     case unsupportedGeminiServerTool = 1003
+    case invalidSeedValue = 1004
 
     // Imagen Model Configuration
     case unsupportedImagenModel = 1200

--- a/FirebaseAI/Sources/GenerationConfig.swift
+++ b/FirebaseAI/Sources/GenerationConfig.swift
@@ -65,7 +65,7 @@ public struct GenerationConfig: Sendable, Equatable {
   var speechConfig: ProtoSpeechConfig?
 
   /// Optional random seed to make generation deterministic.
-  var seed: Int?
+  var seed: Int32?
 
   /// Creates a new `GenerationConfig` value.
   ///
@@ -198,7 +198,7 @@ public struct GenerationConfig: Sendable, Equatable {
     self.thinkingConfig = thinkingConfig
     self.imageConfig = imageConfig
     self.speechConfig = speechConfig?.speechConfig
-    self.seed = seed
+    self.seed = GenerationConfig.validateSeed(seed)
   }
 
   init(temperature: Float? = nil, topP: Float? = nil, topK: Int? = nil, candidateCount: Int? = nil,
@@ -221,7 +221,7 @@ public struct GenerationConfig: Sendable, Equatable {
     self.thinkingConfig = thinkingConfig
     self.imageConfig = imageConfig
     self.speechConfig = speechConfig?.speechConfig
-    self.seed = seed
+    self.seed = GenerationConfig.validateSeed(seed)
   }
 
   /// Merges two configurations, giving precedence to values found in the `overrides` parameter.
@@ -273,6 +273,18 @@ public struct GenerationConfig: Sendable, Equatable {
     }
 
     return config
+  }
+
+  static func validateSeed<T: BinaryInteger>(_ seed: T?) -> Int32? {
+    guard let seed else { return nil }
+    if let validatedSeed = Int32(exactly: seed) {
+      return validatedSeed
+    } else {
+      AILog.log(level: .error, code: .invalidSeedValue, """
+      Ignoring invalid seed value: \(seed); must be in range [\(Int32.min), \(Int32.max)].
+      """)
+      return nil
+    }
   }
 }
 

--- a/FirebaseAI/Sources/GenerationConfig.swift
+++ b/FirebaseAI/Sources/GenerationConfig.swift
@@ -277,14 +277,14 @@ public struct GenerationConfig: Sendable, Equatable {
 
   static func validateSeed<T: BinaryInteger>(_ seed: T?) -> Int32? {
     guard let seed else { return nil }
-    if let validatedSeed = Int32(exactly: seed) {
-      return validatedSeed
-    } else {
+    guard let validatedSeed = Int32(exactly: seed) else {
       AILog.log(level: .error, code: .invalidSeedValue, """
       Ignoring invalid seed value: \(seed); must be in range [\(Int32.min), \(Int32.max)].
       """)
       return nil
     }
+  
+    return validatedSeed
   }
 }
 

--- a/FirebaseAI/Sources/GenerationConfig.swift
+++ b/FirebaseAI/Sources/GenerationConfig.swift
@@ -283,7 +283,7 @@ public struct GenerationConfig: Sendable, Equatable {
       """)
       return nil
     }
-  
+
     return validatedSeed
   }
 }

--- a/FirebaseAI/Sources/Types/Public/GeminiLanguageModel.swift
+++ b/FirebaseAI/Sources/Types/Public/GeminiLanguageModel.swift
@@ -97,7 +97,7 @@
   @available(tvOS, unavailable)
   extension GeminiLanguageModel: FoundationModels.LanguageModel {
     public var capabilities: LanguageModelCapabilities {
-      return LanguageModelCapabilities(capabilities: [
+      return LanguageModelCapabilities([
         .toolCalling,
         .vision,
         .reasoning,

--- a/FirebaseAI/Sources/Types/Public/GeminiLanguageModelExecutor.swift
+++ b/FirebaseAI/Sources/Types/Public/GeminiLanguageModelExecutor.swift
@@ -202,12 +202,12 @@
           switch samplingMode.kind {
           case .greedy:
             generationConfig.temperature = 0.0
-          case let .top(k, seed):
-            generationConfig.topK = k
-            generationConfig.seed = seed.map { Int(truncatingIfNeeded: $0) }
-          case let .nucleus(threshold, seed):
-            generationConfig.topP = Float(threshold)
-            generationConfig.seed = seed.map { Int(truncatingIfNeeded: $0) }
+          case let .randomTopK(topK, seed: seed):
+            generationConfig.topK = topK
+            generationConfig.seed = GenerationConfig.validateSeed(seed)
+          case let .randomProbabilityThreshold(topP, seed: seed):
+            generationConfig.topP = Float(topP)
+            generationConfig.seed = GenerationConfig.validateSeed(seed)
           @unknown default:
             break
           }
@@ -486,9 +486,7 @@
             await channel.send(
               .response(
                 entryID: responseEntryID,
-                action: .updateUsage(
-                  .init(input: input, output: output)
-                )
+                action: .updateUsage(input: input, output: output)
               )
             )
           }

--- a/FirebaseAI/Tests/Unit/ResponseStreamTests.swift
+++ b/FirebaseAI/Tests/Unit/ResponseStreamTests.swift
@@ -108,6 +108,17 @@
              case .decodingFailure = genError {
             return // Expected error.
           }
+
+          // TODO: Remove `compiler(>=6.4)` when Xcode 27 is our minimum supported version.
+          #if compiler(>=6.4)
+            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+              if let genError = error as? FoundationModels.GeneratedContent.ParsingError {
+                XCTAssertEqual(genError.rawContent, "null")
+                return // Expected error.
+              }
+            }
+          #endif // compiler(>=6.4)
+
           #if !os(watchOS)
             if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *),
                let foundationError = error as? FoundationModels.LanguageModelSession


### PR DESCRIPTION
Update sources and tests based on the new APIs and types introduced in Xcode 27 Beta 3 (Foundation Models framework changes).

- Change `GenerationConfig.seed` from `Int` to `Int32` and add validation.
- Update `LanguageModelCapabilities` initialization.
- Match updated `.randomTopK` and `.randomProbabilityThreshold` case names in `samplingMode.kind`.
- Update token counting `.updateUsage()` API call.

#no-changelog