### PR TITLE
bound array access in ActionCodeURL query parser

### DIFF
--- a/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeURL.swift
+++ b/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeURL.swift
@@ -70,6 +70,7 @@ import Foundation
     let urlComponents = linkURL.components(separatedBy: "&")
     for component in urlComponents {
       let splitArray = component.split(separator: "=")
+      guard splitArray.count >= 2 else { continue }
       if let queryItemKey = String(splitArray[0]).removingPercentEncoding,
          let queryItemValue = String(splitArray[1]).removingPercentEncoding {
         queryItems[queryItemKey] = queryItemValue

--- a/FirebaseAuth/Tests/Unit/ActionCodeURLTests.swift
+++ b/FirebaseAuth/Tests/Unit/ActionCodeURLTests.swift
@@ -85,4 +85,16 @@ class ActionCodeURLTests: XCTestCase {
     let actionCodeURL = ActionCodeURL(link: urlString)
     XCTAssertEqual(actionCodeURL?.languageCode, "fr")
   }
+
+  /// Tests parsing a URL whose query has a component without a '=' separator.
+  func testParseURLQueryComponentWithoutEquals() {
+    // The trailing "foo" component has no '=' and must not index past the split
+    // result. The valid parameters should still be parsed.
+    let urlString = "https://www.example.com?apiKey=API_KEY&mode=resetPassword&oobCode=OOB_CODE&foo"
+    let actionCodeURL = ActionCodeURL(link: urlString)
+    XCTAssertNotNil(actionCodeURL)
+    XCTAssertEqual(actionCodeURL?.apiKey, "API_KEY")
+    XCTAssertEqual(actionCodeURL?.operation, .passwordReset)
+    XCTAssertEqual(actionCodeURL?.code, "OOB_CODE")
+  }
 }


### PR DESCRIPTION
ActionCodeURL.parseURL splits each `&`-delimited query component on `=` and then reads splitArray[0] and splitArray[1] without checking how many pieces the split produced. A component with no `=` (a bare flag) or a lone `=` leaves fewer than two elements, so the second index is out of range and the app traps. This is reachable from an untrusted out-of-band link handed to ActionCodeURL(link:), for example `...?apiKey=abc&mode=signIn&foo`. Guard that the split has at least two elements before indexing, matching how the sibling AuthWebUtils.parseURL already handles it. Added a regression test covering a query component without a separator.