### PR TITLE
Fix simulator putfile posix error

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- [fixed] Fixed an issue where `putFile` could fail on the iOS Simulator with `POSIX errno 40`
+  (`EMSGSIZE`) due to a QUIC bug in background sessions, and improved error formatting
+  for `NSPOSIXErrorDomain` errors. (#16351)
 - [fixed] Fixed a race condition in Storage task cancellation and improved Swift 6 strict
   concurrency compliance for `StorageTask`. (#16353)
 - [fixed] Fixed a crash that could occur when parsing malformed `gs://` URLs, and improved

--- a/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
+++ b/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
@@ -63,6 +63,11 @@ actor StorageFetcherService {
     if let _fetcherService {
       _fetcherService.testBlock = testBlock
     }
+    for (_, bucketMap) in fetcherServiceMap {
+      for (_, fetcherService) in bucketMap {
+        fetcherService.testBlock = testBlock
+      }
+    }
   }
 
   private var testBlock: GTMSessionFetcherTestBlock?

--- a/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
+++ b/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
@@ -63,8 +63,8 @@ actor StorageFetcherService {
     if let _fetcherService {
       _fetcherService.testBlock = testBlock
     }
-    for (_, bucketMap) in fetcherServiceMap {
-      for (_, fetcherService) in bucketMap {
+    for bucketMap in fetcherServiceMap.values {
+      for fetcherService in bucketMap.values {
         fetcherService.testBlock = testBlock
       }
     }

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -77,9 +77,17 @@ public let StorageErrorDomain: String = "FIRStorageErrorDomain"
     case 404: StorageError.objectNotFound(
         object: ref.path.object ?? "<object-entity-internal-error>", serverError: errorDictionary
       )
-    default: StorageError.unknown(
-        message: "Unexpected \(serverError.code) code from backend", serverError: errorDictionary
-      )
+    default:
+      if serverError.domain == NSPOSIXErrorDomain {
+        StorageError.unknown(
+          message: "POSIX errno \(serverError.code) (\(String(cString: strerror(Int32(serverError.code)))))",
+          serverError: errorDictionary
+        )
+      } else {
+        StorageError.unknown(
+          message: "Unexpected \(serverError.code) code from backend", serverError: errorDictionary
+        )
+      }
     }
     return storageError as NSError
   }

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -79,8 +79,11 @@ public let StorageErrorDomain: String = "FIRStorageErrorDomain"
       )
     default:
       if serverError.domain == NSPOSIXErrorDomain {
+        let errorCode = Int32(truncatingIfNeeded: serverError.code)
+        var buffer = [CChar](repeating: 0, count: 128)
+        _ = strerror_r(errorCode, &buffer, buffer.count)
         StorageError.unknown(
-          message: "POSIX errno \(serverError.code) (\(String(cString: strerror(Int32(truncatingIfNeeded: serverError.code)))))",
+          message: "POSIX errno \(serverError.code) (\(String(cString: buffer)))",
           serverError: errorDictionary
         )
       } else {

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -80,7 +80,7 @@ public let StorageErrorDomain: String = "FIRStorageErrorDomain"
     default:
       if serverError.domain == NSPOSIXErrorDomain {
         StorageError.unknown(
-          message: "POSIX errno \(serverError.code) (\(String(cString: strerror(Int32(serverError.code)))))",
+          message: "POSIX errno \(serverError.code) (\(String(cString: strerror(Int32(truncatingIfNeeded: serverError.code)))))",
           serverError: errorDictionary
         )
       } else {

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -77,23 +77,16 @@ public let StorageErrorDomain: String = "FIRStorageErrorDomain"
     case 404: StorageError.objectNotFound(
         object: ref.path.object ?? "<object-entity-internal-error>", serverError: errorDictionary
       )
+    case _ where serverError.domain == NSPOSIXErrorDomain:
+      StorageError.unknown(
+        message: "POSIX errno \(serverError.code) (\(serverError.localizedDescription))",
+        serverError: errorDictionary
+      )
     default:
-      { () -> StorageError in
-        if serverError.domain == NSPOSIXErrorDomain {
-          let errorCode = Int32(truncatingIfNeeded: serverError.code)
-          var buffer = [CChar](repeating: 0, count: 128)
-          _ = strerror_r(errorCode, &buffer, buffer.count)
-          return StorageError.unknown(
-            message: "POSIX errno \(serverError.code) (\(String(cString: buffer)))",
-            serverError: errorDictionary
-          )
-        } else {
-          return StorageError.unknown(
-            message: "Unexpected \(serverError.code) code from backend",
-            serverError: errorDictionary
-          )
-        }
-      }()
+      StorageError.unknown(
+        message: "Unexpected \(serverError.code) code from backend",
+        serverError: errorDictionary
+      )
     }
     return storageError as NSError
   }

--- a/FirebaseStorage/Sources/StorageError.swift
+++ b/FirebaseStorage/Sources/StorageError.swift
@@ -78,19 +78,22 @@ public let StorageErrorDomain: String = "FIRStorageErrorDomain"
         object: ref.path.object ?? "<object-entity-internal-error>", serverError: errorDictionary
       )
     default:
-      if serverError.domain == NSPOSIXErrorDomain {
-        let errorCode = Int32(truncatingIfNeeded: serverError.code)
-        var buffer = [CChar](repeating: 0, count: 128)
-        _ = strerror_r(errorCode, &buffer, buffer.count)
-        StorageError.unknown(
-          message: "POSIX errno \(serverError.code) (\(String(cString: buffer)))",
-          serverError: errorDictionary
-        )
-      } else {
-        StorageError.unknown(
-          message: "Unexpected \(serverError.code) code from backend", serverError: errorDictionary
-        )
-      }
+      { () -> StorageError in
+        if serverError.domain == NSPOSIXErrorDomain {
+          let errorCode = Int32(truncatingIfNeeded: serverError.code)
+          var buffer = [CChar](repeating: 0, count: 128)
+          _ = strerror_r(errorCode, &buffer, buffer.count)
+          return StorageError.unknown(
+            message: "POSIX errno \(serverError.code) (\(String(cString: buffer)))",
+            serverError: errorDictionary
+          )
+        } else {
+          return StorageError.unknown(
+            message: "Unexpected \(serverError.code) code from backend",
+            serverError: errorDictionary
+          )
+        }
+      }()
     }
     return storageError as NSError
   }

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -113,12 +113,13 @@ import Foundation
           uploadFetcher.comment = "File UploadTask"
 
           #if targetEnvironment(simulator)
-            uploadFetcher.useBackgroundSession = false
+            let supportsBackground = false
           #else
-            if !GULAppEnvironmentUtil.supportsBackgroundURLSessionUploads() {
-              uploadFetcher.useBackgroundSession = false
-            }
+            let supportsBackground = GULAppEnvironmentUtil.supportsBackgroundURLSessionUploads()
           #endif
+          if !supportsBackground {
+            uploadFetcher.useBackgroundSession = false
+          }
         }
         uploadFetcher.maxRetryInterval = self.reference.storage.maxUploadRetryInterval
 

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -113,13 +113,12 @@ import Foundation
           uploadFetcher.comment = "File UploadTask"
 
           #if targetEnvironment(simulator)
-            let supportsBackground = false
-          #else
-            let supportsBackground = GULAppEnvironmentUtil.supportsBackgroundURLSessionUploads()
-          #endif
-          if !supportsBackground {
             uploadFetcher.useBackgroundSession = false
-          }
+          #else
+            if !GULAppEnvironmentUtil.supportsBackgroundURLSessionUploads() {
+              uploadFetcher.useBackgroundSession = false
+            }
+          #endif
         }
         uploadFetcher.maxRetryInterval = self.reference.storage.maxUploadRetryInterval
 

--- a/FirebaseStorage/Sources/StorageUploadTask.swift
+++ b/FirebaseStorage/Sources/StorageUploadTask.swift
@@ -112,9 +112,13 @@ import Foundation
           uploadFetcher.uploadFileURL = fileURL
           uploadFetcher.comment = "File UploadTask"
 
-          if !GULAppEnvironmentUtil.supportsBackgroundURLSessionUploads() {
+          #if targetEnvironment(simulator)
             uploadFetcher.useBackgroundSession = false
-          }
+          #else
+            if !GULAppEnvironmentUtil.supportsBackgroundURLSessionUploads() {
+              uploadFetcher.useBackgroundSession = false
+            }
+          #endif
         }
         uploadFetcher.maxRetryInterval = self.reference.storage.maxUploadRetryInterval
 

--- a/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
+++ b/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
@@ -1,0 +1,23 @@
+import Foundation
+@testable import FirebaseStorage
+import GTMSessionFetcherCore
+import XCTest
+
+@available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)
+class StoragePOSIXErrorTest: StorageIntegrationCommon {
+  func testPutFileWithPOSIXError40() async throws {
+    let ref = storage.reference(withPath: "ios/public/testPOSIX40")
+    
+    let data = try XCTUnwrap("Hello".data(using: .utf8))
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
+    try data.write(to: fileURL, options: .atomicWrite)
+    
+    do {
+      let metadata = try await ref.putFileAsync(from: fileURL)
+      XCTAssertEqual(metadata.size, Int64(data.count))
+    } catch {
+      XCTFail("Unexpected failure: \(error)")
+    }
+  }
+}

--- a/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
+++ b/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
@@ -34,11 +34,7 @@ class StoragePOSIXErrorTest: StorageIntegrationCommon {
       try? FileManager.default.removeItem(at: fileURL)
     }
 
-    do {
-      let metadata = try await ref.putFileAsync(from: fileURL)
-      XCTAssertEqual(metadata.size, Int64(data.count))
-    } catch {
-      XCTFail("Unexpected failure: \(error)")
-    }
+    let metadata = try await ref.putFileAsync(from: fileURL)
+    XCTAssertEqual(metadata.size, Int64(data.count))
   }
 }

--- a/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
+++ b/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
@@ -30,7 +30,7 @@ class StoragePOSIXErrorTest: StorageIntegrationCommon {
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
     try data.write(to: fileURL, options: .atomicWrite)
-    defer {
+    addTeardownBlock {
       try? FileManager.default.removeItem(at: fileURL)
     }
 

--- a/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
+++ b/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 @testable import FirebaseStorage
 import Foundation
 #if COCOAPODS

--- a/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
+++ b/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
@@ -30,6 +30,9 @@ class StoragePOSIXErrorTest: StorageIntegrationCommon {
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
     try data.write(to: fileURL, options: .atomicWrite)
+    defer {
+      try? FileManager.default.removeItem(at: fileURL)
+    }
 
     do {
       let metadata = try await ref.putFileAsync(from: fileURL)

--- a/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
+++ b/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
@@ -1,18 +1,22 @@
-import Foundation
 @testable import FirebaseStorage
-import GTMSessionFetcherCore
+import Foundation
+#if COCOAPODS
+  import GTMSessionFetcher
+#else
+  import GTMSessionFetcherCore
+#endif
 import XCTest
 
 @available(iOS 13.0, macOS 10.15, macCatalyst 13.0, tvOS 13.0, watchOS 6.0, *)
 class StoragePOSIXErrorTest: StorageIntegrationCommon {
   func testPutFileWithPOSIXError40() async throws {
     let ref = storage.reference(withPath: "ios/public/testPOSIX40")
-    
+
     let data = try XCTUnwrap("Hello".data(using: .utf8))
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
     try data.write(to: fileURL, options: .atomicWrite)
-    
+
     do {
       let metadata = try await ref.putFileAsync(from: fileURL)
       XCTAssertEqual(metadata.size, Int64(data.count))

--- a/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import FirebaseStorage
+import Foundation
+#if COCOAPODS
+  import GTMSessionFetcher
+#else
+  import GTMSessionFetcherCore
+#endif
+import XCTest
+
+class StoragePutFileTests: StorageTestHelpers {
+  func testPutFileWithPOSIXError40UpdatesExistingFetcherService() async throws {
+    // Initialize storage *before* setting the testBlock to verify that
+    // `StorageFetcherService.updateTestBlock` correctly updates pre-existing instances.
+    let storageInstance = storage()
+    let ref = storageInstance.reference(withPath: "ios/public/testPOSIX40")
+    
+    let testBlock: GTMSessionFetcherTestBlock = { (fetcher, response) in
+      let error = NSError(domain: NSPOSIXErrorDomain, code: 40, userInfo: nil)
+      response(nil, nil, error)
+    }
+    
+    await StorageFetcherService.shared.updateTestBlock(testBlock)
+    
+    let data = try XCTUnwrap("Hello".data(using: .utf8))
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
+    try data.write(to: fileURL, options: .atomicWrite)
+    
+    do {
+      _ = try await ref.putFileAsync(from: fileURL)
+      XCTFail("Unexpected success")
+    } catch let error as NSError {
+      XCTAssertEqual(error.domain, StorageErrorDomain)
+      XCTAssertEqual(error.code, StorageErrorCode.unknown.rawValue)
+      let message = error.localizedDescription
+      XCTAssertTrue(message.contains("POSIX errno 40 (Message too long)"),
+                    "Error message should contain 'POSIX errno 40 (Message too long)', but got \(message)")
+    }
+    
+    try? FileManager.default.removeItem(at: fileURL)
+    await StorageFetcherService.shared.updateTestBlock(nil)
+  }
+}

--- a/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
@@ -41,7 +41,7 @@ class StoragePutFileTests: StorageTestHelpers {
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
     try data.write(to: fileURL, options: .atomicWrite)
-    defer {
+    addTeardownBlock {
       try? FileManager.default.removeItem(at: fileURL)
     }
 
@@ -52,8 +52,8 @@ class StoragePutFileTests: StorageTestHelpers {
       XCTAssertEqual(error.domain, StorageErrorDomain)
       XCTAssertEqual(error.code, StorageErrorCode.unknown.rawValue)
       let message = error.localizedDescription
-      XCTAssertTrue(message.contains("POSIX errno 40 (Message too long)"),
-                    "Error message should contain 'POSIX errno 40 (Message too long)', but got \(message)")
+      XCTAssertTrue(message.contains("POSIX errno 40 (The operation couldn’t be completed. Message too long)"),
+                    "Error message should contain 'POSIX errno 40 (The operation couldn’t be completed. Message too long)', but got \(message)")
     }
   }
 }

--- a/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
@@ -37,8 +37,6 @@ class StoragePutFileTests: StorageTestHelpers {
       await StorageFetcherService.shared.updateTestBlock(nil)
     }
 
-    await StorageFetcherService.shared.updateTestBlock(testBlock)
-
     let data = try XCTUnwrap("Hello".data(using: .utf8))
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
@@ -57,8 +55,5 @@ class StoragePutFileTests: StorageTestHelpers {
       XCTAssertTrue(message.contains("POSIX errno 40 (Message too long)"),
                     "Error message should contain 'POSIX errno 40 (Message too long)', but got \(message)")
     }
-
-    try? FileManager.default.removeItem(at: fileURL)
-    await StorageFetcherService.shared.updateTestBlock(nil)
   }
 }

--- a/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
@@ -27,19 +27,26 @@ class StoragePutFileTests: StorageTestHelpers {
     // `StorageFetcherService.updateTestBlock` correctly updates pre-existing instances.
     let storageInstance = storage()
     let ref = storageInstance.reference(withPath: "ios/public/testPOSIX40")
-    
-    let testBlock: GTMSessionFetcherTestBlock = { (fetcher, response) in
+
+    let testBlock: GTMSessionFetcherTestBlock = { fetcher, response in
       let error = NSError(domain: NSPOSIXErrorDomain, code: 40, userInfo: nil)
       response(nil, nil, error)
     }
-    
     await StorageFetcherService.shared.updateTestBlock(testBlock)
-    
+    addTeardownBlock {
+      await StorageFetcherService.shared.updateTestBlock(nil)
+    }
+
+    await StorageFetcherService.shared.updateTestBlock(testBlock)
+
     let data = try XCTUnwrap("Hello".data(using: .utf8))
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
     try data.write(to: fileURL, options: .atomicWrite)
-    
+    defer {
+      try? FileManager.default.removeItem(at: fileURL)
+    }
+
     do {
       _ = try await ref.putFileAsync(from: fileURL)
       XCTFail("Unexpected success")
@@ -50,7 +57,7 @@ class StoragePutFileTests: StorageTestHelpers {
       XCTAssertTrue(message.contains("POSIX errno 40 (Message too long)"),
                     "Error message should contain 'POSIX errno 40 (Message too long)', but got \(message)")
     }
-    
+
     try? FileManager.default.removeItem(at: fileURL)
     await StorageFetcherService.shared.updateTestBlock(nil)
   }

--- a/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
@@ -52,8 +52,10 @@ class StoragePutFileTests: StorageTestHelpers {
       XCTAssertEqual(error.domain, StorageErrorDomain)
       XCTAssertEqual(error.code, StorageErrorCode.unknown.rawValue)
       let message = error.localizedDescription
-      XCTAssertTrue(message.contains("POSIX errno 40 (The operation couldn’t be completed. Message too long)"),
-                    "Error message should contain 'POSIX errno 40 (The operation couldn’t be completed. Message too long)', but got \(message)")
+      XCTAssertTrue(
+        message.contains("POSIX errno 40 (The operation couldn’t be completed. Message too long)"),
+        "Error message should contain 'POSIX errno 40 (The operation couldn’t be completed. Message too long)', but got \(message)"
+      )
     }
   }
 }

--- a/FirebaseStorage/Tests/Unit/StorageTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageTests.swift
@@ -256,6 +256,17 @@ class StorageTests: XCTestCase {
     XCTAssertEqual(storage.maxOperationRetryInterval, 8)
   }
 
+  func testPOSIXErrorFormatting() throws {
+    let app = try getApp(bucket: "bucket")
+    let storage = Storage.storage(app: app)
+    let ref = storage.reference(withPath: "ios/public/testPOSIX40")
+    let posixError = NSError(domain: NSPOSIXErrorDomain, code: 40, userInfo: nil)
+    let storageError = StorageErrorCode.error(withServerError: posixError, ref: ref)
+    XCTAssertEqual(storageError.domain, StorageErrorDomain)
+    XCTAssertEqual(storageError.code, StorageErrorCode.unknown.rawValue)
+    XCTAssertEqual(storageError.userInfo[NSLocalizedDescriptionKey] as? String, "POSIX errno 40 (Message too long)")
+  }
+
   // MARK: Private Helpers
 
   // Cache the app associated with each Storage bucket

--- a/FirebaseStorage/Tests/Unit/StorageTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageTests.swift
@@ -264,7 +264,10 @@ class StorageTests: XCTestCase {
     let storageError = StorageErrorCode.error(withServerError: posixError, ref: ref)
     XCTAssertEqual(storageError.domain, StorageErrorDomain)
     XCTAssertEqual(storageError.code, StorageErrorCode.unknown.rawValue)
-    XCTAssertEqual(storageError.userInfo[NSLocalizedDescriptionKey] as? String, "POSIX errno 40 (Message too long)")
+    XCTAssertEqual(
+      storageError.userInfo[NSLocalizedDescriptionKey] as? String,
+      "POSIX errno 40 (Message too long)"
+    )
   }
 
   // MARK: Private Helpers

--- a/FirebaseStorage/Tests/Unit/StorageTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageTests.swift
@@ -266,7 +266,7 @@ class StorageTests: XCTestCase {
     XCTAssertEqual(storageError.code, StorageErrorCode.unknown.rawValue)
     XCTAssertEqual(
       storageError.userInfo[NSLocalizedDescriptionKey] as? String,
-      "POSIX errno 40 (Message too long)"
+      "POSIX errno 40 (The operation couldn’t be completed. Message too long)"
     )
   }
 


### PR DESCRIPTION
# Fix Storage `putFile` POSIX error 40 on iOS Simulator

## Description
This PR addresses issue #16351 where `putFile` fails on the iOS Simulator roughly 1.5–2.5 seconds after starting with `Error Domain=FIRStorageErrorDomain Code=-13000 "Unexpected 40 code from backend"`. 

The root cause is a known bug in the `nsurlsessiond` QUIC receive path on the iOS Simulator, which incorrectly surfaces a `POSIX errno 40` (`EMSGSIZE` / Message too long) when transferring large datagrams via a background URL session.

### Fixes implemented:
1. **Disabled Background Sessions on Simulator:** Updated `StorageUploadTask` to explicitly disable background sessions when running on the simulator (`#if targetEnvironment(simulator)`). This routes the upload through a standard foreground `NSURLSession` in the app process, cleanly bypassing the buggy `nsurlsessiond` QUIC path. The behavior on real physical devices remains completely unchanged.
2. **Improved POSIX Error Formatting:** Updated `StorageError.swift` to properly catch and format underlying `NSPOSIXErrorDomain` errors. Instead of the confusing and incorrect `"Unexpected 40 code from backend"` message, developers will now see an accurate translation, such as `"POSIX errno 40 (Message too long)"`, preventing wasted time debugging backend configurations for local networking failures.
3. **Internal `GTMSessionFetcherService` caching fix:** Updated `StorageFetcherService` so that when `updateTestBlock` is called during test suites, the test block is correctly applied and propagated to all pre-cached `GTMSessionFetcherService` buckets, ensuring reliable mock interception during tests.
4. **Integration Test Coverage:** Added an integration test (`StoragePOSIXErrorTest`) that naturally validates the `putFileAsync` flow successfully uploads the payload on the simulator without throwing EMSGSIZE.

## Related Issues
Fixes #16351

## Testing
- Verified `FirebaseStorageIntegration` test suite locally.
- Confirmed `StoragePOSIXErrorTest` properly completes a file upload task on the iOS simulator environment without throwing an `EMSGSIZE` abort.
- Validated error message formatting intercepts and correctly translates POSIX errno codes.
