### PR TITLE
reject path separators in fileExtensionForResponse

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessagingExtensionHelper.m
+++ b/FirebaseMessaging/Sources/FIRMessagingExtensionHelper.m
@@ -143,8 +143,14 @@ pb_bytes_array_t *FIRMessagingEncodeString(NSString *string) {
     return [NSString stringWithFormat:@".%@", suggestedPathExtension];
   }
   if ([response.MIMEType containsString:kImagePathPrefix]) {
-    return [response.MIMEType stringByReplacingOccurrencesOfString:kImagePathPrefix
-                                                        withString:@"."];
+    NSString *fileExtension =
+        [response.MIMEType stringByReplacingOccurrencesOfString:kImagePathPrefix withString:@"."];
+    // A MIME subtype does not contain a path separator. A server can set an arbitrary
+    // Content-Type on the downloaded image, so reject a value that carries one before it
+    // is appended to the temporary file path.
+    if (![fileExtension containsString:@"/"]) {
+      return fileExtension;
+    }
   }
   return kNoExtension;
 }

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
@@ -157,6 +157,17 @@ static NSString *const kValidImageURL =
   }
 }
 
+- (void)testFileExtensionRejectsPathSeparatorInMimeType {
+  if (@available(macOS 10.14, iOS 10.0, *)) {
+    // suggestedFilename has no extension so the MIME type branch is used.
+    OCMStub([_mockURLResponse suggestedFilename]).andReturn(@"image");
+    OCMStub([_mockURLResponse MIMEType]).andReturn(@"image/../../../../evil");
+    NSString *const extension = [_mockExtensionHelper fileExtensionForResponse:_mockURLResponse];
+    XCTAssertFalse([extension containsString:@"/"]);
+    XCTAssertTrue([extension isEqualToString:@""]);
+  }
+}
+
 - (void)testDeliveryMetricsLoggingWithEmptyPayload {
   OCMStub([_mockUtilClass isAppExtension]).andReturn(YES);
   NSDictionary *fakeMessageInfo = @{@"aps" : @{}};


### PR DESCRIPTION
**Server-controlled MIME type reaches the image download path**
The push payload chooses the image URL, so the responding server controls the `Content-Type` that `fileExtensionForResponse:` turns into the downloaded file's extension, and it gets appended to the temp path with `stringByAppendingString:`. A value like `image/../../../../evil` becomes a suffix carrying path separators that relocates the saved attachment outside its temp file, so I reject any MIME-derived extension that contains a separator. Added a test that stubs the response the same way the existing extension tests do.