### PR TITLE
fix(firebaseai): prevent stream leak on cancellation

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,6 +1,8 @@
-# 12.16.0
+# Unreleased
 - [fixed] Fixed a stream leak in the Live API where the WebSocket connection
   would remain open indefinitely if the consumer cancelled the stream. (#16393)
+
+# 12.16.0
 - [fixed] Fixed a decoding failure in `GenerateContentResponse` when the Vertex AI
   backend returns citation metadata with a missing `endIndex`. (#16328)
 - [fixed] Fixed an issue where `generateContentStream` could stall indefinitely

--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,4 +1,6 @@
 # 12.16.0
+- [fixed] Fixed a stream leak in the Live API where the WebSocket connection
+  would remain open indefinitely if the consumer cancelled the stream. (#16393)
 - [fixed] Fixed a decoding failure in `GenerateContentResponse` when the Vertex AI
   backend returns citation metadata with a missing `endIndex`. (#16328)
 - [fixed] Fixed an issue where `generateContentStream` could stall indefinitely

--- a/FirebaseAI/Sources/Types/Internal/Live/AsyncWebSocket.swift
+++ b/FirebaseAI/Sources/Types/Internal/Live/AsyncWebSocket.swift
@@ -34,6 +34,10 @@ final class AsyncWebSocket: Sendable {
     (stream, continuation) = AsyncThrowingStream<URLSessionWebSocketTask.Message, Error>
       .makeStream()
     closeError = UnfairLock(nil)
+
+    continuation.onTermination = { [weak self] _ in
+      self?.disconnect()
+    }
   }
 
   deinit {


### PR DESCRIPTION
Handles the onTermination event of the AsyncThrowingStream continuation to explicitly disconnect the underlying WebSocket when the consumer cancels the iteration or drops the stream. Without this, the internal unstructured Task stays alive indefinitely waiting for the socket to receive data.

Note on Testing: A regression test was written and verified locally using a non-routable IP (10.255.255.1) to simulate a hanging socket. However, this test was deliberately omitted from the commit because URLSessionWebSocketTask ignores URLProtocol subclasses, making it impossible to deterministically mock the connection without spinning up a local websocket server or heavily refactoring the class to use a protocol wrapper. Leaving the test in would introduce CI flakiness due to environment-dependent fast-reject routing on the non-routable IP.