### PR TITLE
[Auth] Fix OAuth string escaping logic

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [fixed] Fixed a bug in `OAuthProvider` where custom parameters containing
+  special URL characters (such as `&` and `=`) were not being properly
+  URL-encoded. (#16394)
+
 # 12.16.0
 - [fixed] Refactored the integrated OAuth sign in UI to not rely on
   the deprecated `UIScreen.main.bounds` API for Mac Catalyst rendering.

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -427,10 +427,12 @@ import Foundation
       : "https://\(authDomain)/__/auth/handler"
     var components = URLComponents(string: urlString)
     components?.queryItems = queryItems
-    components?.percentEncodedQuery = components?.percentEncodedQuery?.replacingOccurrences(
-      of: "+",
-      with: "%2B"
-    )
+    if let percentEncodedQuery = components?.percentEncodedQuery {
+      components?.percentEncodedQuery = percentEncodedQuery.replacingOccurrences(
+        of: "+",
+        with: "%2B"
+      )
+    }
 
     if let appCheck {
       let tokenResult = await appCheck.getToken(forcingRefresh: false)

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -418,12 +418,10 @@ import Foundation
       queryItems.append(URLQueryItem(name: "hl", value: languageCode))
     }
 
-    var components: URLComponents?
-    if (auth.requestConfiguration.emulatorHostAndPort) != nil {
-      components = URLComponents(string: "http://\(authDomain)/emulator/auth/handler")
-    } else {
-      components = URLComponents(string: "https://\(authDomain)/__/auth/handler")
-    }
+    let urlString = auth.requestConfiguration.emulatorHostAndPort != nil
+      ? "http://\(authDomain)/emulator/auth/handler"
+      : "https://\(authDomain)/__/auth/handler"
+    var components = URLComponents(string: urlString)
     components?.queryItems = queryItems
 
     if let appCheck {

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -427,7 +427,10 @@ import Foundation
       : "https://\(authDomain)/__/auth/handler"
     var components = URLComponents(string: urlString)
     components?.queryItems = queryItems
-    components?.percentEncodedQuery = components?.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
+    components?.percentEncodedQuery = components?.percentEncodedQuery?.replacingOccurrences(
+      of: "+",
+      with: "%2B"
+    )
 
     if let appCheck {
       let tokenResult = await appCheck.getToken(forcingRefresh: false)

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -385,51 +385,47 @@ import Foundation
     let appCheck = auth.requestConfiguration.appCheck
 
     // TODO: Should we fail if these strings are empty? Only ibi was explicit in ObjC.
-    var urlArguments = ["apiKey": apiKey,
-                        "authType": "signInWithRedirect",
-                        "ibi": bundleID ?? "",
-                        "sessionId": hash(forString: sessionID),
-                        "v": AuthBackend.authUserAgent(),
-                        "eventId": eventID,
-                        "providerId": providerID]
+    var queryItems = [URLQueryItem(name: "apiKey", value: apiKey),
+                      URLQueryItem(name: "authType", value: "signInWithRedirect"),
+                      URLQueryItem(name: "ibi", value: bundleID ?? ""),
+                      URLQueryItem(name: "sessionId", value: hash(forString: sessionID)),
+                      URLQueryItem(name: "v", value: AuthBackend.authUserAgent()),
+                      URLQueryItem(name: "eventId", value: eventID),
+                      URLQueryItem(name: "providerId", value: providerID)]
 
     if usingClientIDScheme {
-      urlArguments["clientId"] = clientID
+      queryItems.append(URLQueryItem(name: "clientId", value: clientID))
     } else {
-      urlArguments["appId"] = appID
+      queryItems.append(URLQueryItem(name: "appId", value: appID))
     }
     if let tenantID {
-      urlArguments["tid"] = tenantID
+      queryItems.append(URLQueryItem(name: "tid", value: tenantID))
     }
     if let scopes, scopes.count > 0 {
-      urlArguments["scopes"] = scopes.joined(separator: ",")
+      queryItems.append(URLQueryItem(name: "scopes", value: scopes.joined(separator: ",")))
     }
     if let customParameters, customParameters.count > 0 {
       do {
         let customParametersJSONData = try JSONSerialization
           .data(withJSONObject: customParameters)
         let rawJson = String(decoding: customParametersJSONData, as: UTF8.self)
-        urlArguments["customParameters"] = rawJson
+        queryItems.append(URLQueryItem(name: "customParameters", value: rawJson))
       } catch {
         throw AuthErrorUtils.JSONSerializationError(underlyingError: error)
       }
     }
     if let languageCode = auth.requestConfiguration.languageCode {
-      urlArguments["hl"] = languageCode
+      queryItems.append(URLQueryItem(name: "hl", value: languageCode))
     }
-    let argumentsString = httpArgumentsString(forArgsDictionary: urlArguments)
-    var urlString: String
+
+    var components: URLComponents?
     if (auth.requestConfiguration.emulatorHostAndPort) != nil {
-      urlString = "http://\(authDomain)/emulator/auth/handler?\(argumentsString)"
+      components = URLComponents(string: "http://\(authDomain)/emulator/auth/handler?")
     } else {
-      urlString = "https://\(authDomain)/__/auth/handler?\(argumentsString)"
+      components = URLComponents(string: "https://\(authDomain)/__/auth/handler?")
     }
-    guard let percentEncoded = urlString.addingPercentEncoding(
-      withAllowedCharacters: CharacterSet.urlFragmentAllowed
-    ) else {
-      fatalError("Internal Auth Error: failed to percent encode a string")
-    }
-    var components = URLComponents(string: percentEncoded)
+    components?.queryItems = queryItems
+
     if let appCheck {
       let tokenResult = await appCheck.getToken(forcingRefresh: false)
       if let error = tokenResult.error {
@@ -462,16 +458,6 @@ import Foundation
       hexString += String(format: "%02x", UInt8(byte))
     }
     return hexString
-  }
-
-  private func httpArgumentsString(forArgsDictionary argsDictionary: [String: String]) -> String {
-    var argsString: [String] = []
-    for (key, value) in argsDictionary {
-      let keyString = AuthWebUtils.string(byUnescapingFromURLArgument: key)
-      let valueString = AuthWebUtils.string(byUnescapingFromURLArgument: value.description)
-      argsString.append("\(keyString)=\(valueString)")
-    }
-    return argsString.joined(separator: "&")
   }
 
   private let auth: Auth

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -420,9 +420,9 @@ import Foundation
 
     var components: URLComponents?
     if (auth.requestConfiguration.emulatorHostAndPort) != nil {
-      components = URLComponents(string: "http://\(authDomain)/emulator/auth/handler?")
+      components = URLComponents(string: "http://\(authDomain)/emulator/auth/handler")
     } else {
-      components = URLComponents(string: "https://\(authDomain)/__/auth/handler?")
+      components = URLComponents(string: "https://\(authDomain)/__/auth/handler")
     }
     components?.queryItems = queryItems
 

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -394,9 +394,13 @@ import Foundation
                       URLQueryItem(name: "providerId", value: providerID)]
 
     if usingClientIDScheme {
-      queryItems.append(URLQueryItem(name: "clientId", value: clientID))
+      if let clientID {
+        queryItems.append(URLQueryItem(name: "clientId", value: clientID))
+      }
     } else {
-      queryItems.append(URLQueryItem(name: "appId", value: appID))
+      if let appID {
+        queryItems.append(URLQueryItem(name: "appId", value: appID))
+      }
     }
     if let tenantID {
       queryItems.append(URLQueryItem(name: "tid", value: tenantID))

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -427,6 +427,7 @@ import Foundation
       : "https://\(authDomain)/__/auth/handler"
     var components = URLComponents(string: urlString)
     components?.queryItems = queryItems
+    components?.percentEncodedQuery = components?.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
 
     if let appCheck {
       let tokenResult = await appCheck.getToken(forcingRefresh: false)

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -405,10 +405,10 @@ import Foundation
     if let tenantID {
       queryItems.append(URLQueryItem(name: "tid", value: tenantID))
     }
-    if let scopes, scopes.count > 0 {
+    if let scopes, !scopes.isEmpty {
       queryItems.append(URLQueryItem(name: "scopes", value: scopes.joined(separator: ",")))
     }
-    if let customParameters, customParameters.count > 0 {
+    if let customParameters, !customParameters.isEmpty {
       do {
         let customParametersJSONData = try JSONSerialization
           .data(withJSONObject: customParameters)

--- a/FirebaseAuth/Tests/Unit/OAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/OAuthProviderTests.swift
@@ -235,7 +235,7 @@ import FirebaseCore
     func testGetCredentialWithUIDelegateWithCustomParametersInjection() throws {
       initApp(#function)
       OAuthProviderTests.testCustomParametersInjection = true
-      defer {
+      addTeardownBlock {
         OAuthProviderTests.testCustomParametersInjection = false
       }
       try testOAuthFlow(description: #function)

--- a/FirebaseAuth/Tests/Unit/OAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/OAuthProviderTests.swift
@@ -46,6 +46,7 @@ import FirebaseCore
     static var testAppID = false
     static var testEmulator = false
     static var testAppCheck = false
+    static var testCustomParametersInjection = false
 
     static var auth: Auth?
 
@@ -228,6 +229,16 @@ import FirebaseCore
       OAuthProviderTests.testAppCheck = false
     }
 
+    /** @fn testGetCredentialWithUIDelegateWithCustomParametersInjection
+        @brief Tests that custom parameters containing special URL characters do not leak into the top-level query parameters.
+     */
+    func testGetCredentialWithUIDelegateWithCustomParametersInjection() throws {
+      initApp(#function)
+      OAuthProviderTests.testCustomParametersInjection = true
+      try testOAuthFlow(description: #function)
+      OAuthProviderTests.testCustomParametersInjection = false
+    }
+
     /** @fn testOAuthCredentialCoding
         @brief Tests successful archiving and unarchiving of @c GoogleAuthCredential.
      */
@@ -293,6 +304,14 @@ import FirebaseCore
                                with fakeAppCheck: FakeAppCheck? = nil) throws {
       let expectation = self.expectation(description: description)
       let provider = OAuthProvider(providerID: kFakeProviderID, auth: OAuthProviderTests.auth!)
+
+      if OAuthProviderTests.testCustomParametersInjection {
+        provider
+          .customParameters =
+          [
+            "login_hint": "x\"}&tid=attacker-tenant&clientId=000000.apps.googleusercontent.com&junk={\"a\":\"b",
+          ]
+      }
 
       // Use fake authURLPresenter so we can test the parameters that get sent to it.
       OAuthProviderTests.auth?.authURLPresenter = FakePresenter()
@@ -362,6 +381,12 @@ import FirebaseCore
             XCTAssertEqual(params["tid"], OAuthProviderTests.kFakeTenantID)
           } else {
             XCTAssertNil(params["tid"])
+          }
+          if OAuthProviderTests.testCustomParametersInjection {
+            XCTAssertEqual(
+              params["customParameters"],
+              "{\"login_hint\":\"x\\\"}&tid=attacker-tenant&clientId=000000.apps.googleusercontent.com&junk={\\\"a\\\":\\\"b\"}"
+            )
           }
           let appCheckToken = presentURL.fragment
           let verifyAppCheckToken = OAuthProviderTests.testAppCheck ? "fac=fakeAppCheckToken" : nil

--- a/FirebaseAuth/Tests/Unit/OAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/OAuthProviderTests.swift
@@ -235,8 +235,10 @@ import FirebaseCore
     func testGetCredentialWithUIDelegateWithCustomParametersInjection() throws {
       initApp(#function)
       OAuthProviderTests.testCustomParametersInjection = true
+      defer {
+        OAuthProviderTests.testCustomParametersInjection = false
+      }
       try testOAuthFlow(description: #function)
-      OAuthProviderTests.testCustomParametersInjection = false
     }
 
     /** @fn testOAuthCredentialCoding


### PR DESCRIPTION
See internal b/511890711

## Description
Fixes a bug in `OAuthProvider` where custom parameters containing special characters (like `&` and `=`) were not being correctly URL-encoded, leading to malformed authentication handler URLs.
### Root Cause
The previous implementation in `OAuthProvider.swift` manually constructed query strings using `AuthWebUtils.string(byUnescapingFromURLArgument:)` and subsequently called `addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)`. Because `.urlFragmentAllowed` does not encode structural delimiters like `&` and `=`, passing complex strings (like JSON strings) into `customParameters` could unexpectedly split into top-level query parameters instead of remaining properly nested.
### Fix
Refactored the URL construction in `getHeadfulLiteUrl(eventID:sessionID:)` to use Swift's standard `URLComponents` and `URLQueryItem`. `URLComponents` natively handles percent-encoding for all query item values, ensuring that characters like `&` and `=` within `customParameters` are correctly escaped and preserve the intended URL structure. 
This change also removes the need for the internal `httpArgumentsString(forArgsDictionary:)` helper.
### Testing
Added a new unit test, `testGetCredentialWithUIDelegateWithCustomParametersInjection`, to explicitly verify that complex `customParameters` payloads containing structural URL characters (`&` and `=`) are properly encoded and do not leak into the top-level query structure.