### PR TITLE
[Storage,Functions] Fix credentials for emulator

### DIFF
--- a/FirebaseFunctions/CHANGELOG.md
+++ b/FirebaseFunctions/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [changed] Enforced stricter transport layer security when using the emulator:
+  Auth, FCM, and AppCheck tokens are no longer attached to outbound requests if
+  the connection is made over HTTP to a non-loopback host. (#16395)
+
 # 12.13.0
 - [fixed] Fixed a release-build crash in `HTTPSCallable.call()` when using
   Xcode 26.4 (Swift 6.3) that was caused by a Swift regression in `async let`

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -725,7 +725,7 @@ private extension URL {
   var isSecureOrLoopback: Bool {
     let scheme = scheme?.lowercased()
     let host = host?.lowercased() ?? ""
-    let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1"
+    let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]"
     return scheme == "https" || isLoopback
   }
 }

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -601,6 +601,13 @@ enum FunctionsConstants {
           forHTTPHeaderField: Constants.appCheckTokenHeader
         )
       }
+    } else if url.scheme?.lowercased() == "http" {
+      FirebaseLogger.log(
+        level: .warning,
+        service: "[FirebaseFunctions]",
+        code: "I-FUN000001",
+        message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
+      )
     }
 
     return urlRequest
@@ -651,6 +658,13 @@ enum FunctionsConstants {
           forHTTPHeaderField: Constants.appCheckTokenHeader
         )
       }
+    } else if url.scheme?.lowercased() == "http" {
+      FirebaseLogger.log(
+        level: .warning,
+        service: "[FirebaseFunctions]",
+        code: "I-FUN000002",
+        message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
+      )
     }
 
     // Override normal security rules if this is a local test.

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -576,10 +576,7 @@ enum FunctionsConstants {
     urlRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
     urlRequest.httpMethod = "POST"
 
-    let isHttps = url.scheme?.lowercased() == "https"
-    let host = url.host?.lowercased() ?? ""
-    let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1"
-    let shouldAttachTokens = isHttps || isLoopback
+    let shouldAttachTokens = url.isSecureOrLoopback
 
     if shouldAttachTokens {
       if let authToken = context.authToken {
@@ -629,10 +626,7 @@ enum FunctionsConstants {
 
     // Set the headers.
     fetcher.setRequestValue("application/json", forHTTPHeaderField: "Content-Type")
-    let isHttps = url.scheme?.lowercased() == "https"
-    let host = url.host?.lowercased() ?? ""
-    let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1"
-    let shouldAttachTokens = isHttps || isLoopback
+    let shouldAttachTokens = url.isSecureOrLoopback
 
     if shouldAttachTokens {
       if let authToken = context.authToken {
@@ -724,5 +718,14 @@ enum FunctionsConstants {
     }
 
     return dataJSON
+  }
+}
+
+private extension URL {
+  var isSecureOrLoopback: Bool {
+    let scheme = scheme?.lowercased()
+    let host = host?.lowercased() ?? ""
+    let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1"
+    return scheme == "https" || isLoopback
   }
 }

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -576,27 +576,34 @@ enum FunctionsConstants {
     urlRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
     urlRequest.httpMethod = "POST"
 
-    if let authToken = context.authToken {
-      let value = "Bearer \(authToken)"
-      urlRequest.setValue(value, forHTTPHeaderField: "Authorization")
-    }
+    let isHttps = url.scheme?.lowercased() == "https"
+    let host = url.host?.lowercased() ?? ""
+    let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1"
+    let shouldAttachTokens = isHttps || isLoopback
 
-    if let fcmToken = context.fcmToken {
-      urlRequest.setValue(fcmToken, forHTTPHeaderField: Constants.fcmTokenHeader)
-    }
+    if shouldAttachTokens {
+      if let authToken = context.authToken {
+        let value = "Bearer \(authToken)"
+        urlRequest.setValue(value, forHTTPHeaderField: "Authorization")
+      }
 
-    if options?.requireLimitedUseAppCheckTokens == true {
-      if let appCheckToken = context.limitedUseAppCheckToken {
+      if let fcmToken = context.fcmToken {
+        urlRequest.setValue(fcmToken, forHTTPHeaderField: Constants.fcmTokenHeader)
+      }
+
+      if options?.requireLimitedUseAppCheckTokens == true {
+        if let appCheckToken = context.limitedUseAppCheckToken {
+          urlRequest.setValue(
+            appCheckToken,
+            forHTTPHeaderField: Constants.appCheckTokenHeader
+          )
+        }
+      } else if let appCheckToken = context.appCheckToken {
         urlRequest.setValue(
           appCheckToken,
           forHTTPHeaderField: Constants.appCheckTokenHeader
         )
       }
-    } else if let appCheckToken = context.appCheckToken {
-      urlRequest.setValue(
-        appCheckToken,
-        forHTTPHeaderField: Constants.appCheckTokenHeader
-      )
     }
 
     return urlRequest
@@ -622,27 +629,34 @@ enum FunctionsConstants {
 
     // Set the headers.
     fetcher.setRequestValue("application/json", forHTTPHeaderField: "Content-Type")
-    if let authToken = context.authToken {
-      let value = "Bearer \(authToken)"
-      fetcher.setRequestValue(value, forHTTPHeaderField: "Authorization")
-    }
+    let isHttps = url.scheme?.lowercased() == "https"
+    let host = url.host?.lowercased() ?? ""
+    let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1"
+    let shouldAttachTokens = isHttps || isLoopback
 
-    if let fcmToken = context.fcmToken {
-      fetcher.setRequestValue(fcmToken, forHTTPHeaderField: Constants.fcmTokenHeader)
-    }
+    if shouldAttachTokens {
+      if let authToken = context.authToken {
+        let value = "Bearer \(authToken)"
+        fetcher.setRequestValue(value, forHTTPHeaderField: "Authorization")
+      }
 
-    if options?.requireLimitedUseAppCheckTokens == true {
-      if let appCheckToken = context.limitedUseAppCheckToken {
+      if let fcmToken = context.fcmToken {
+        fetcher.setRequestValue(fcmToken, forHTTPHeaderField: Constants.fcmTokenHeader)
+      }
+
+      if options?.requireLimitedUseAppCheckTokens == true {
+        if let appCheckToken = context.limitedUseAppCheckToken {
+          fetcher.setRequestValue(
+            appCheckToken,
+            forHTTPHeaderField: Constants.appCheckTokenHeader
+          )
+        }
+      } else if let appCheckToken = context.appCheckToken {
         fetcher.setRequestValue(
           appCheckToken,
           forHTTPHeaderField: Constants.appCheckTokenHeader
         )
       }
-    } else if let appCheckToken = context.appCheckToken {
-      fetcher.setRequestValue(
-        appCheckToken,
-        forHTTPHeaderField: Constants.appCheckTokenHeader
-      )
     }
 
     // Override normal security rules if this is a local test.

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -578,35 +578,38 @@ enum FunctionsConstants {
 
     let shouldAttachTokens = url.isSecureOrLoopback
 
-    if shouldAttachTokens {
-      if let authToken = context.authToken {
-        let value = "Bearer \(authToken)"
-        urlRequest.setValue(value, forHTTPHeaderField: "Authorization")
+    guard shouldAttachTokens else {
+      if url.scheme?.lowercased() == "http" {
+        FirebaseLogger.log(
+          level: .warning,
+          service: "[FirebaseFunctions]",
+          code: "I-FUN000001",
+          message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
+        )
       }
+      return urlRequest
+    }
 
-      if let fcmToken = context.fcmToken {
-        urlRequest.setValue(fcmToken, forHTTPHeaderField: Constants.fcmTokenHeader)
-      }
+    if let authToken = context.authToken {
+      let value = "Bearer \(authToken)"
+      urlRequest.setValue(value, forHTTPHeaderField: "Authorization")
+    }
 
-      if options?.requireLimitedUseAppCheckTokens == true {
-        if let appCheckToken = context.limitedUseAppCheckToken {
-          urlRequest.setValue(
-            appCheckToken,
-            forHTTPHeaderField: Constants.appCheckTokenHeader
-          )
-        }
-      } else if let appCheckToken = context.appCheckToken {
+    if let fcmToken = context.fcmToken {
+      urlRequest.setValue(fcmToken, forHTTPHeaderField: Constants.fcmTokenHeader)
+    }
+
+    if options?.requireLimitedUseAppCheckTokens == true {
+      if let appCheckToken = context.limitedUseAppCheckToken {
         urlRequest.setValue(
           appCheckToken,
           forHTTPHeaderField: Constants.appCheckTokenHeader
         )
       }
-    } else if url.scheme?.lowercased() == "http" {
-      FirebaseLogger.log(
-        level: .warning,
-        service: "[FirebaseFunctions]",
-        code: "I-FUN000001",
-        message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
+    } else if let appCheckToken = context.appCheckToken {
+      urlRequest.setValue(
+        appCheckToken,
+        forHTTPHeaderField: Constants.appCheckTokenHeader
       )
     }
 
@@ -633,44 +636,47 @@ enum FunctionsConstants {
 
     // Set the headers.
     fetcher.setRequestValue("application/json", forHTTPHeaderField: "Content-Type")
+    // Override normal security rules if this is a local test.
+    if emulatorOrigin != nil {
+      fetcher.allowLocalhostRequest = true
+      fetcher.allowedInsecureSchemes = ["http"]
+    }
+
     let shouldAttachTokens = url.isSecureOrLoopback
 
-    if shouldAttachTokens {
-      if let authToken = context.authToken {
-        let value = "Bearer \(authToken)"
-        fetcher.setRequestValue(value, forHTTPHeaderField: "Authorization")
+    guard shouldAttachTokens else {
+      if url.scheme?.lowercased() == "http" {
+        FirebaseLogger.log(
+          level: .warning,
+          service: "[FirebaseFunctions]",
+          code: "I-FUN000002",
+          message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
+        )
       }
+      return fetcher
+    }
 
-      if let fcmToken = context.fcmToken {
-        fetcher.setRequestValue(fcmToken, forHTTPHeaderField: Constants.fcmTokenHeader)
-      }
+    if let authToken = context.authToken {
+      let value = "Bearer \(authToken)"
+      fetcher.setRequestValue(value, forHTTPHeaderField: "Authorization")
+    }
 
-      if options?.requireLimitedUseAppCheckTokens == true {
-        if let appCheckToken = context.limitedUseAppCheckToken {
-          fetcher.setRequestValue(
-            appCheckToken,
-            forHTTPHeaderField: Constants.appCheckTokenHeader
-          )
-        }
-      } else if let appCheckToken = context.appCheckToken {
+    if let fcmToken = context.fcmToken {
+      fetcher.setRequestValue(fcmToken, forHTTPHeaderField: Constants.fcmTokenHeader)
+    }
+
+    if options?.requireLimitedUseAppCheckTokens == true {
+      if let appCheckToken = context.limitedUseAppCheckToken {
         fetcher.setRequestValue(
           appCheckToken,
           forHTTPHeaderField: Constants.appCheckTokenHeader
         )
       }
-    } else if url.scheme?.lowercased() == "http" {
-      FirebaseLogger.log(
-        level: .warning,
-        service: "[FirebaseFunctions]",
-        code: "I-FUN000002",
-        message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
+    } else if let appCheckToken = context.appCheckToken {
+      fetcher.setRequestValue(
+        appCheckToken,
+        forHTTPHeaderField: Constants.appCheckTokenHeader
       )
-    }
-
-    // Override normal security rules if this is a local test.
-    if emulatorOrigin != nil {
-      fetcher.allowLocalhostRequest = true
-      fetcher.allowedInsecureSchemes = ["http"]
     }
 
     return fetcher

--- a/FirebaseFunctions/Tests/Unit/FunctionsTests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsTests.swift
@@ -361,12 +361,13 @@ class FunctionsTests: XCTestCase {
     let functionsInsecure = Functions(
       projectID: "my-project",
       region: "my-region",
-      customDomain: "http://10.0.0.1",
+      customDomain: nil,
       auth: authFake,
       messaging: nil,
       appCheck: appCheckFake,
       fetcherService: fetcherService
     )
+    functionsInsecure.useEmulator(withHost: "10.0.0.1", port: 5005)
     appCheckFake.tokenResult = FIRAppCheckTokenResultFake(token: "shared_valid_token", error: nil)
 
     let httpRequestExpectation = expectation(description: "HTTPRequestExpectation")
@@ -392,12 +393,13 @@ class FunctionsTests: XCTestCase {
     let functionsLocal = Functions(
       projectID: "my-project",
       region: "my-region",
-      customDomain: "http://localhost",
+      customDomain: nil,
       auth: authFake,
       messaging: nil,
       appCheck: appCheckFake,
       fetcherService: fetcherService
     )
+    functionsLocal.useEmulator(withHost: "localhost", port: 5005)
     appCheckFake.tokenResult = FIRAppCheckTokenResultFake(token: "shared_valid_token", error: nil)
 
     let httpRequestExpectation = expectation(description: "HTTPRequestExpectation")

--- a/FirebaseFunctions/Tests/Unit/FunctionsTests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsTests.swift
@@ -385,4 +385,36 @@ class FunctionsTests: XCTestCase {
 
     waitForExpectations(timeout: 1.5)
   }
+
+  @MainActor func testCallFunctionOverHttpWithLocalhostDoesAttachTokens() {
+    let functionsLocal = Functions(
+      projectID: "my-project",
+      region: "my-region",
+      customDomain: "http://localhost",
+      auth: nil,
+      messaging: nil,
+      appCheck: appCheckFake,
+      fetcherService: fetcherService
+    )
+    appCheckFake.tokenResult = FIRAppCheckTokenResultFake(token: "shared_valid_token", error: nil)
+
+    let httpRequestExpectation = expectation(description: "HTTPRequestExpectation")
+    fetcherService.testBlock = { fetcherToTest, testResponse in
+      XCTAssertEqual(
+        fetcherToTest.request?.value(forHTTPHeaderField: "X-Firebase-AppCheck"),
+        "shared_valid_token"
+      )
+      testResponse(nil, "{\"data\":\"success\"}".data(using: .utf8), nil)
+      httpRequestExpectation.fulfill()
+    }
+
+    let completionExpectation = expectation(description: "completionExpectation")
+    functionsLocal
+      .httpsCallable("fake_func")
+      .call { result, error in
+        completionExpectation.fulfill()
+      }
+
+    waitForExpectations(timeout: 1.5)
+  }
 }

--- a/FirebaseFunctions/Tests/Unit/FunctionsTests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsTests.swift
@@ -357,11 +357,12 @@ class FunctionsTests: XCTestCase {
   }
 
   @MainActor func testCallFunctionOverHttpWithoutLocalhostDoesNotAttachTokens() {
+    let authFake = FIRAuthInteropFake(token: "fake_auth_token", userID: nil, error: nil)
     let functionsInsecure = Functions(
       projectID: "my-project",
       region: "my-region",
       customDomain: "http://10.0.0.1",
-      auth: nil,
+      auth: authFake,
       messaging: nil,
       appCheck: appCheckFake,
       fetcherService: fetcherService
@@ -387,11 +388,12 @@ class FunctionsTests: XCTestCase {
   }
 
   @MainActor func testCallFunctionOverHttpWithLocalhostDoesAttachTokens() {
+    let authFake = FIRAuthInteropFake(token: "fake_auth_token", userID: nil, error: nil)
     let functionsLocal = Functions(
       projectID: "my-project",
       region: "my-region",
       customDomain: "http://localhost",
-      auth: nil,
+      auth: authFake,
       messaging: nil,
       appCheck: appCheckFake,
       fetcherService: fetcherService
@@ -400,6 +402,10 @@ class FunctionsTests: XCTestCase {
 
     let httpRequestExpectation = expectation(description: "HTTPRequestExpectation")
     fetcherService.testBlock = { fetcherToTest, testResponse in
+      XCTAssertEqual(
+        fetcherToTest.request?.value(forHTTPHeaderField: "Authorization"),
+        "Bearer fake_auth_token"
+      )
       XCTAssertEqual(
         fetcherToTest.request?.value(forHTTPHeaderField: "X-Firebase-AppCheck"),
         "shared_valid_token"

--- a/FirebaseFunctions/Tests/Unit/FunctionsTests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsTests.swift
@@ -355,4 +355,34 @@ class FunctionsTests: XCTestCase {
       XCTAssertEqual(error as NSError, networkError)
     }
   }
+
+  @MainActor func testCallFunctionOverHttpWithoutLocalhostDoesNotAttachTokens() {
+    let functionsInsecure = Functions(
+      projectID: "my-project",
+      region: "my-region",
+      customDomain: "http://10.0.0.1",
+      auth: nil,
+      messaging: nil,
+      appCheck: appCheckFake,
+      fetcherService: fetcherService
+    )
+    appCheckFake.tokenResult = FIRAppCheckTokenResultFake(token: "shared_valid_token", error: nil)
+
+    let httpRequestExpectation = expectation(description: "HTTPRequestExpectation")
+    fetcherService.testBlock = { fetcherToTest, testResponse in
+      XCTAssertNil(fetcherToTest.request?.value(forHTTPHeaderField: "Authorization"))
+      XCTAssertNil(fetcherToTest.request?.value(forHTTPHeaderField: "X-Firebase-AppCheck"))
+      testResponse(nil, "{\"data\":\"success\"}".data(using: .utf8), nil)
+      httpRequestExpectation.fulfill()
+    }
+
+    let completionExpectation = expectation(description: "completionExpectation")
+    functionsInsecure
+      .httpsCallable("fake_func")
+      .call { result, error in
+        completionExpectation.fulfill()
+      }
+
+    waitForExpectations(timeout: 1.5)
+  }
 }

--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- [changed] Enforced stricter transport layer security when using the emulator: Auth and AppCheck
+  tokens are no longer attached to outbound requests if the connection is made over HTTP to a
+  non-loopback host. (#16395)
 - [fixed] Fixed an issue where `putFile` could fail on the iOS Simulator with `POSIX errno 40`
   (`EMSGSIZE`) due to a QUIC bug in background sessions, and improved error formatting
   for `NSPOSIXErrorDomain` errors. (#16351)

--- a/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
+++ b/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
@@ -37,37 +37,53 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
 
     var tokenError: NSError?
     let fetchTokenGroup = DispatchGroup()
-    if let auth {
-      fetchTokenGroup.enter()
-      auth.getToken(forcingRefresh: false) { token, error in
-        if let error = error as? NSError {
-          var errorDictionary = error.userInfo
-          errorDictionary["ResponseErrorDomain"] = error.domain
-          errorDictionary["ResponseErrorCode"] = error.code
-          tokenError = StorageError.unauthenticated(serverError: errorDictionary) as NSError
-        } else if let token {
-          let firebaseToken = "Firebase \(token)"
-          request?.setValue(firebaseToken, forHTTPHeaderField: "Authorization")
-        }
-        fetchTokenGroup.leave()
-      }
-    }
-    if let appCheck {
-      fetchTokenGroup.enter()
-      appCheck.getToken(forcingRefresh: false) { tokenResult in
-        request?.setValue(tokenResult.token, forHTTPHeaderField: "X-Firebase-AppCheck")
 
-        if let error = tokenResult.error {
-          FirebaseLogger.log(
-            level: .debug,
-            service: "[FirebaseStorage]",
-            code: "I-STR000001",
-            message: "Failed to fetch AppCheck token. Error: \(error)"
-          )
+    let isHttps = request?.url?.scheme?.lowercased() == "https"
+    let host = request?.url?.host?.lowercased() ?? ""
+    let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1"
+    let shouldFetchTokens = isHttps || isLoopback
+
+    if shouldFetchTokens {
+      if let auth {
+        fetchTokenGroup.enter()
+        auth.getToken(forcingRefresh: false) { token, error in
+          if let error = error as? NSError {
+            var errorDictionary = error.userInfo
+            errorDictionary["ResponseErrorDomain"] = error.domain
+            errorDictionary["ResponseErrorCode"] = error.code
+            tokenError = StorageError.unauthenticated(serverError: errorDictionary) as NSError
+          } else if let token {
+            let firebaseToken = "Firebase \(token)"
+            request?.setValue(firebaseToken, forHTTPHeaderField: "Authorization")
+          }
+          fetchTokenGroup.leave()
         }
-        fetchTokenGroup.leave()
       }
+      if let appCheck {
+        fetchTokenGroup.enter()
+        appCheck.getToken(forcingRefresh: false) { tokenResult in
+          request?.setValue(tokenResult.token, forHTTPHeaderField: "X-Firebase-AppCheck")
+
+          if let error = tokenResult.error {
+            FirebaseLogger.log(
+              level: .debug,
+              service: "[FirebaseStorage]",
+              code: "I-STR000001",
+              message: "Failed to fetch AppCheck token. Error: \(error)"
+            )
+          }
+          fetchTokenGroup.leave()
+        }
+      }
+    } else {
+      FirebaseLogger.log(
+        level: .warning,
+        service: "[FirebaseStorage]",
+        code: "I-STR000002",
+        message: "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host."
+      )
     }
+
     fetchTokenGroup.notify(queue: callbackQueue) {
       handler(tokenError)
     }

--- a/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
+++ b/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
@@ -40,7 +40,7 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
 
     let isHttps = request?.url?.scheme?.lowercased() == "https"
     let host = request?.url?.host?.lowercased() ?? ""
-    let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1"
+    let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]"
     let shouldFetchTokens = isHttps || isLoopback
 
     if shouldFetchTokens {

--- a/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
+++ b/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
@@ -38,12 +38,13 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
     var tokenError: NSError?
     let fetchTokenGroup = DispatchGroup()
 
-    let isHttps = request?.url?.scheme?.lowercased() == "https"
+    let scheme = request?.url?.scheme?.lowercased()
+    let isHttps = scheme == "https"
     let host = request?.url?.host?.lowercased() ?? ""
     let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]"
     let shouldFetchTokens = isHttps || isLoopback
     guard shouldFetchTokens else {
-      if request?.url?.scheme?.lowercased() == "http" {
+      if scheme == "http" {
         FirebaseLogger.log(
           level: .warning,
           service: "[FirebaseStorage]",

--- a/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
+++ b/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
@@ -42,40 +42,7 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
     let host = request?.url?.host?.lowercased() ?? ""
     let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]"
     let shouldFetchTokens = isHttps || isLoopback
-
-    if shouldFetchTokens {
-      if let auth {
-        fetchTokenGroup.enter()
-        auth.getToken(forcingRefresh: false) { token, error in
-          if let error = error as? NSError {
-            var errorDictionary = error.userInfo
-            errorDictionary["ResponseErrorDomain"] = error.domain
-            errorDictionary["ResponseErrorCode"] = error.code
-            tokenError = StorageError.unauthenticated(serverError: errorDictionary) as NSError
-          } else if let token {
-            let firebaseToken = "Firebase \(token)"
-            request?.setValue(firebaseToken, forHTTPHeaderField: "Authorization")
-          }
-          fetchTokenGroup.leave()
-        }
-      }
-      if let appCheck {
-        fetchTokenGroup.enter()
-        appCheck.getToken(forcingRefresh: false) { tokenResult in
-          request?.setValue(tokenResult.token, forHTTPHeaderField: "X-Firebase-AppCheck")
-
-          if let error = tokenResult.error {
-            FirebaseLogger.log(
-              level: .debug,
-              service: "[FirebaseStorage]",
-              code: "I-STR000001",
-              message: "Failed to fetch AppCheck token. Error: \(error)"
-            )
-          }
-          fetchTokenGroup.leave()
-        }
-      }
-    } else {
+    guard shouldFetchTokens else {
       if request?.url?.scheme?.lowercased() == "http" {
         FirebaseLogger.log(
           level: .warning,
@@ -83,6 +50,42 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
           code: "I-STR000002",
           message: "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host."
         )
+      }
+      fetchTokenGroup.notify(queue: callbackQueue) {
+        handler(tokenError)
+      }
+      return
+    }
+
+    if let auth {
+      fetchTokenGroup.enter()
+      auth.getToken(forcingRefresh: false) { token, error in
+        if let error = error as? NSError {
+          var errorDictionary = error.userInfo
+          errorDictionary["ResponseErrorDomain"] = error.domain
+          errorDictionary["ResponseErrorCode"] = error.code
+          tokenError = StorageError.unauthenticated(serverError: errorDictionary) as NSError
+        } else if let token {
+          let firebaseToken = "Firebase \(token)"
+          request?.setValue(firebaseToken, forHTTPHeaderField: "Authorization")
+        }
+        fetchTokenGroup.leave()
+      }
+    }
+    if let appCheck {
+      fetchTokenGroup.enter()
+      appCheck.getToken(forcingRefresh: false) { tokenResult in
+        request?.setValue(tokenResult.token, forHTTPHeaderField: "X-Firebase-AppCheck")
+
+        if let error = tokenResult.error {
+          FirebaseLogger.log(
+            level: .debug,
+            service: "[FirebaseStorage]",
+            code: "I-STR000001",
+            message: "Failed to fetch AppCheck token. Error: \(error)"
+          )
+        }
+        fetchTokenGroup.leave()
       }
     }
 

--- a/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
+++ b/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
@@ -76,12 +76,14 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
         }
       }
     } else {
-      FirebaseLogger.log(
-        level: .warning,
-        service: "[FirebaseStorage]",
-        code: "I-STR000002",
-        message: "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host."
-      )
+      if request?.url?.scheme?.lowercased() == "http" {
+        FirebaseLogger.log(
+          level: .warning,
+          service: "[FirebaseStorage]",
+          code: "I-STR000002",
+          message: "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host."
+        )
+      }
     }
 
     fetchTokenGroup.notify(queue: callbackQueue) {

--- a/FirebaseStorage/Tests/Unit/StorageAuthorizerTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageAuthorizerTests.swift
@@ -188,6 +188,46 @@ class StorageAuthorizerTests: StorageTestHelpers {
     let _ = try await fetcher?.beginFetch()
   }
 
+  func testInsecureHostDoesNotAttachTokens() async throws {
+    appCheck?.tokenResult = appCheckTokenSuccess!
+    let insecureRequest = URLRequest(url: URL(string: "http://10.0.0.1/v0/b/bucket/o/object")!)
+    fetcher = GTMSessionFetcher(request: insecureRequest)
+    fetcher?.authorizer = StorageTokenAuthorizer(
+      googleAppID: "dummyAppID",
+      callbackQueue: DispatchQueue.main,
+      authProvider: auth,
+      appCheck: appCheck
+    )
+
+    setFetcherTestBlock(with: 200) { fetcher in
+      self.checkAuthorizer(fetcher: fetcher, trueFalse: false)
+    }
+    let _ = try await fetcher?.beginFetch()
+    let headers = fetcher!.request?.allHTTPHeaderFields
+    XCTAssertNil(headers?["Authorization"])
+    XCTAssertNil(headers?["X-Firebase-AppCheck"])
+  }
+
+  func testLocalhostDoesAttachTokensOverHttp() async throws {
+    appCheck?.tokenResult = appCheckTokenSuccess!
+    let localRequest = URLRequest(url: URL(string: "http://localhost/v0/b/bucket/o/object")!)
+    fetcher = GTMSessionFetcher(request: localRequest)
+    fetcher?.authorizer = StorageTokenAuthorizer(
+      googleAppID: "dummyAppID",
+      callbackQueue: DispatchQueue.main,
+      authProvider: auth,
+      appCheck: appCheck
+    )
+
+    setFetcherTestBlock(with: 200) { fetcher in
+      self.checkAuthorizer(fetcher: fetcher, trueFalse: true)
+    }
+    let _ = try await fetcher?.beginFetch()
+    let headers = fetcher!.request?.allHTTPHeaderFields
+    XCTAssertEqual(headers?["Authorization"], "Firebase \(StorageTestAuthToken)")
+    XCTAssertEqual(headers?["X-Firebase-AppCheck"], appCheckTokenSuccess?.token)
+  }
+
   // MARK: Helpers
 
   private func setFetcherTestBlock(with statusCode: Int,

--- a/FirebaseStorage/Tests/Unit/StorageAuthorizerTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageAuthorizerTests.swift
@@ -192,6 +192,7 @@ class StorageAuthorizerTests: StorageTestHelpers {
     appCheck?.tokenResult = appCheckTokenSuccess!
     let insecureRequest = URLRequest(url: URL(string: "http://10.0.0.1/v0/b/bucket/o/object")!)
     fetcher = GTMSessionFetcher(request: insecureRequest)
+    fetcher?.allowedInsecureSchemes = ["http"]
     fetcher?.authorizer = StorageTokenAuthorizer(
       googleAppID: "dummyAppID",
       callbackQueue: DispatchQueue.main,
@@ -212,6 +213,7 @@ class StorageAuthorizerTests: StorageTestHelpers {
     appCheck?.tokenResult = appCheckTokenSuccess!
     let localRequest = URLRequest(url: URL(string: "http://localhost/v0/b/bucket/o/object")!)
     fetcher = GTMSessionFetcher(request: localRequest)
+    fetcher?.allowedInsecureSchemes = ["http"]
     fetcher?.authorizer = StorageTokenAuthorizer(
       googleAppID: "dummyAppID",
       callbackQueue: DispatchQueue.main,


### PR DESCRIPTION
See internal b/511890380. Review with https://github.com/firebase/firebase-ios-sdk/pull/16395/changes?w=1

# Enforce token transport security for non-loopback HTTP connections
## Description
This PR introduces stricter transport security checks for how Auth, FCM, and AppCheck tokens are handled over HTTP connections within the Firebase Storage and Firebase Functions iOS SDKs.
Previously, when developers configured their SDK to use an emulator running on a remote, non-loopback host (e.g., `10.0.0.x`) over standard HTTP, the SDKs would unconditionally attach the app's bearer tokens to outgoing network requests. 
To align with modern transport security best practices (and mirror the default behavior of gRPC in Firestore), this change ensures that we only attach session tokens if the underlying request is securely encrypted (`https://`) or targeting a local loopback interface (`localhost`, `127.0.0.1`, `::1`). 
## Changes Include
- **Firebase Storage**: Updated `StorageTokenAuthorizer` to evaluate the outgoing request's scheme and host. If the request is over HTTP and destined for a non-loopback host, the token fetching and attachment logic is safely bypassed, and a warning is logged via `FirebaseLogger`.
- **Firebase Functions**: Updated `makeFetcher` and `makeRequestForStreamableContent` to apply identical scheme/host validation logic before attaching tokens from the `FunctionsContext`.
- **Testing**: Added corresponding unit tests to `StorageAuthorizerTests.swift` and `FunctionsTests.swift` to verify that headers are properly omitted under these conditions while retaining normal behavior for secure/local emulator workflows.
