### PR TITLE
guard IsLocalResourceName against names missing documents segment

### DIFF
--- a/Firestore/core/src/bundle/bundle_serializer.cc
+++ b/Firestore/core/src/bundle/bundle_serializer.cc
@@ -405,8 +405,7 @@ ResourcePath BundleSerializer::DecodeName(JsonReader& reader,
   }
   auto path =
       ResourcePath::FromString(document_name.get_ref<const std::string&>());
-  if (!rpc_serializer_.IsLocalResourceName(path) || path.size() < 5 ||
-      path[4] != "documents") {
+  if (!rpc_serializer_.IsLocalResourceName(path)) {
     reader.Fail("Resource name is not valid for current instance: " +
                 path.CanonicalString());
     return {};

--- a/Firestore/core/src/remote/serializer.cc
+++ b/Firestore/core/src/remote/serializer.cc
@@ -1527,8 +1527,7 @@ bool Serializer::IsLocalResourceName(const ResourcePath& path) const {
 
 bool Serializer::IsLocalDocumentKey(absl::string_view path) const {
   auto resource = ResourcePath::FromStringView(path);
-  return IsLocalResourceName(resource) &&
-         DocumentKey::IsDocumentKey(resource.PopFirst(5));
+  return IsLocalResourceName(resource) && (resource.size() - 5) % 2 == 0;
 }
 
 api::PipelineSnapshot Serializer::DecodePipelineResponse(

--- a/Firestore/core/src/remote/serializer.cc
+++ b/Firestore/core/src/remote/serializer.cc
@@ -1515,14 +1515,20 @@ ExistenceFilter Serializer::DecodeExistenceFilter(
 }
 
 bool Serializer::IsLocalResourceName(const ResourcePath& path) const {
-  return IsValidResourceName(path) && path[1] == database_id_.project_id() &&
-         path[3] == database_id_.database_id();
+  // A local document resource name is
+  // `projects/{p}/databases/{d}/documents/...`, so it needs the `documents`
+  // segment in addition to the project and database. Requiring it here keeps
+  // callers that strip the five-segment prefix with `PopFirst(5)` from
+  // asserting on a shorter name such as `projects/{p}/databases/{d}`.
+  return IsValidResourceName(path) && path.size() >= 5 &&
+         path[1] == database_id_.project_id() &&
+         path[3] == database_id_.database_id() && path[4] == "documents";
 }
 
 bool Serializer::IsLocalDocumentKey(absl::string_view path) const {
   auto resource = ResourcePath::FromStringView(path);
-  return IsLocalResourceName(resource) && resource.size() >= 5 &&
-         resource[4] == "documents" && (resource.size() - 5) % 2 == 0;
+  return IsLocalResourceName(resource) &&
+         DocumentKey::IsDocumentKey(resource.PopFirst(5));
 }
 
 api::PipelineSnapshot Serializer::DecodePipelineResponse(

--- a/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
+++ b/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
@@ -1273,6 +1273,15 @@ TEST_F(BundleSerializerTest, DecodePrimitiveAsObjectFails) {
   EXPECT_NOT_OK(reader.status());
 }
 
+TEST_F(BundleSerializerTest, DecodeReferenceValueMissingDocumentsSegmentFails) {
+  // The reference matches the local project and database but stops before the
+  // "documents" segment, so `IsLocalDocumentKey` must reject it rather than
+  // stripping a five-segment prefix off a four-segment path.
+  ProtoValue value;
+  value.set_reference_value("projects/p/databases/default");
+  VerifyFieldValueDecodeFails(value);
+}
+
 }  //  namespace
 }  //  namespace bundle
 }  //  namespace firestore


### PR DESCRIPTION
A bundle whose document name matches the local project and database but stops before the `documents` segment, such as `projects/<id>/databases/<db>`, passes `IsLocalResourceName` and then reaches `PopFirst(5)` on a four-segment path, which trips a `HARD_ASSERT` and aborts the process. The same predicate gates `DecodeName` and `IsLocalDocumentKey` (the latter reachable from a document field's `referenceValue`), and bundle payloads handed to `loadBundle` are untrusted. Require the five-segment documents prefix in `IsLocalResourceName` so short names are rejected the way `ExtractLocalPathFromResourceName` already rejects them.