### PR TITLE
guard IsNumericId against non-numeric __id segments

### DIFF
--- a/Firestore/core/src/model/base_path.h
+++ b/Firestore/core/src/model/base_path.h
@@ -27,6 +27,8 @@
 #include "Firestore/core/src/util/comparison.h"
 #include "Firestore/core/src/util/hard_assert.h"
 #include "Firestore/core/src/util/hashing.h"
+#include "absl/strings/numbers.h"
+#include "absl/strings/string_view.h"
 
 namespace firebase {
 namespace firestore {
@@ -206,15 +208,33 @@ class BasePath {
     }
   }
 
+  // Parses a segment of the form "__id<n>__" where <n> is a base-10 integer.
+  // Returns false (leaving *value untouched) when the segment is not a
+  // well-formed numeric id, including when <n> is absent, non-numeric, or does
+  // not fit in an int64_t. Segments reach this path from document names decoded
+  // out of untrusted server responses and bundles, so a malformed "__id...__"
+  // must be rejected here rather than reaching a throwing conversion.
+  static bool ParseNumericId(const std::string& segment, int64_t* value) {
+    if (segment.size() <= kNumericIdTotalOverhead ||
+        segment.compare(0, kNumericIdPrefixLength, "__id") != 0 ||
+        segment.compare(segment.size() - kNumericIdSuffixLength,
+                        kNumericIdSuffixLength, "__") != 0) {
+      return false;
+    }
+    absl::string_view numeric_part(segment.data() + kNumericIdPrefixLength,
+                                   segment.size() - kNumericIdTotalOverhead);
+    return absl::SimpleAtoi(numeric_part, value);
+  }
+
   static bool IsNumericId(const std::string& segment) {
-    return segment.size() > kNumericIdTotalOverhead &&
-           segment.substr(0, kNumericIdPrefixLength) == "__id" &&
-           segment.substr(segment.size() - kNumericIdSuffixLength) == "__";
+    int64_t value = 0;
+    return ParseNumericId(segment, &value);
   }
 
   static int64_t ExtractNumericId(const std::string& segment) {
-    return std::stol(segment.substr(kNumericIdPrefixLength,
-                                    segment.size() - kNumericIdSuffixLength));
+    int64_t value = 0;
+    ParseNumericId(segment, &value);
+    return value;
   }
 };
 

--- a/Firestore/core/test/unit/model/resource_path_test.cc
+++ b/Firestore/core/test/unit/model/resource_path_test.cc
@@ -72,6 +72,26 @@ TEST(ResourcePath, Comparison) {
   EXPECT_TRUE(ab > a);
 }
 
+TEST(ResourcePath, ComparisonWithMalformedNumericIds) {
+  // Segments shaped like "__id<n>__" are ordered numerically, but the numeric
+  // part must be a real integer. A crafted document name whose middle is not a
+  // valid int64 (non-numeric, or larger than an int64 can hold) must not abort
+  // when two such paths are compared.
+  const ResourcePath non_numeric_a{"__idABC__"};
+  const ResourcePath non_numeric_b{"__idXYZ__"};
+  const ResourcePath overflow{"__id99999999999999999999__"};
+  const ResourcePath numeric{"__id123__"};
+
+  EXPECT_TRUE(non_numeric_a < non_numeric_b);
+  EXPECT_TRUE(non_numeric_b > non_numeric_a);
+  EXPECT_EQ(non_numeric_a, ResourcePath{"__idABC__"});
+  EXPECT_NE(numeric, non_numeric_a);
+  EXPECT_NE(numeric, overflow);
+  // Real numeric ids still sort ahead of ones that fail to parse.
+  EXPECT_TRUE(numeric < non_numeric_a);
+  EXPECT_TRUE(overflow > numeric);
+}
+
 TEST(ResourcePath, Parsing) {
   const auto parse = [](const std::pair<std::string, size_t> expected) {
     const auto path = ResourcePath::FromString(expected.first);


### PR DESCRIPTION
**Aborts on malformed `__id...__` segments during key comparison**
`IsNumericId` only checks the `__id` prefix and `__` suffix, so a document-name segment like `__idABC__` (or one whose digits overflow int64) is classified as numeric, and `ExtractNumericId` then runs `std::stol` on a non-number and throws, aborting the process. Those segments come from document names decoded out of server responses and loadBundle payloads, so two such documents in one result set crash the client when their keys are ordered; validating with `absl::SimpleAtoi` inside the numeric-id helpers keeps the check and the parse in the same place.