### PR TITLE
Validate resource name format and reject malformed document keys during bundle parsing

### DIFF
--- a/Firestore/core/src/bundle/bundle_serializer.cc
+++ b/Firestore/core/src/bundle/bundle_serializer.cc
@@ -405,7 +405,8 @@ ResourcePath BundleSerializer::DecodeName(JsonReader& reader,
   }
   auto path =
       ResourcePath::FromString(document_name.get_ref<const std::string&>());
-  if (!rpc_serializer_.IsLocalResourceName(path)) {
+  if (!rpc_serializer_.IsLocalResourceName(path) || path.size() < 5 ||
+      path[4] != "documents") {
     reader.Fail("Resource name is not valid for current instance: " +
                 path.CanonicalString());
     return {};
@@ -648,8 +649,9 @@ BundledDocumentMetadata BundleSerializer::DecodeDocumentMetadata(
     JsonReader& reader, const json& document_metadata) const {
   ResourcePath path =
       DecodeName(reader, reader.RequiredObject("name", document_metadata));
-  // Return early if !ok(), `DocumentKey` aborts with invalid inputs.
-  if (!reader.ok()) {
+  if (path.empty() || !DocumentKey::IsDocumentKey(path)) {
+    reader.Fail("Resource name is not a valid document key: " +
+                path.CanonicalString());
     return {};
   }
   DocumentKey key = DocumentKey(path);
@@ -679,8 +681,9 @@ BundleDocument BundleSerializer::DecodeDocument(JsonReader& reader,
                                                 const json& document) const {
   ResourcePath path =
       DecodeName(reader, reader.RequiredObject("name", document));
-  // Return early if !ok(), `DocumentKey` aborts with invalid inputs.
-  if (!reader.ok()) {
+  if (path.empty() || !DocumentKey::IsDocumentKey(path)) {
+    reader.Fail("Resource name is not a valid document key: " +
+                path.CanonicalString());
     return {};
   }
   DocumentKey key = DocumentKey(path);

--- a/Firestore/core/src/bundle/bundle_serializer.cc
+++ b/Firestore/core/src/bundle/bundle_serializer.cc
@@ -649,6 +649,9 @@ BundledDocumentMetadata BundleSerializer::DecodeDocumentMetadata(
     JsonReader& reader, const json& document_metadata) const {
   ResourcePath path =
       DecodeName(reader, reader.RequiredObject("name", document_metadata));
+  if (!reader.ok()) {
+    return {};
+  }
   if (path.empty() || !DocumentKey::IsDocumentKey(path)) {
     reader.Fail("Resource name is not a valid document key: " +
                 path.CanonicalString());
@@ -681,6 +684,9 @@ BundleDocument BundleSerializer::DecodeDocument(JsonReader& reader,
                                                 const json& document) const {
   ResourcePath path =
       DecodeName(reader, reader.RequiredObject("name", document));
+  if (!reader.ok()) {
+    return {};
+  }
   if (path.empty() || !DocumentKey::IsDocumentKey(path)) {
     reader.Fail("Resource name is not a valid document key: " +
                 path.CanonicalString());

--- a/Firestore/core/src/remote/serializer.cc
+++ b/Firestore/core/src/remote/serializer.cc
@@ -1521,8 +1521,8 @@ bool Serializer::IsLocalResourceName(const ResourcePath& path) const {
 
 bool Serializer::IsLocalDocumentKey(absl::string_view path) const {
   auto resource = ResourcePath::FromStringView(path);
-  return IsLocalResourceName(resource) &&
-         DocumentKey::IsDocumentKey(resource.PopFirst(5));
+  return IsLocalResourceName(resource) && resource.size() >= 5 &&
+         resource[4] == "documents" && (resource.size() - 5) % 2 == 0;
 }
 
 api::PipelineSnapshot Serializer::DecodePipelineResponse(

--- a/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
+++ b/Firestore/core/test/unit/bundle/bundle_serializer_test.cc
@@ -1166,6 +1166,48 @@ TEST_F(BundleSerializerTest, DecodeInvalidBundledDocumentMetadataFails) {
   }
 }
 
+TEST_F(BundleSerializerTest, DecodeNonDocumentKeyResourceNameFails) {
+  // Resource names that pass the local-resource-name check but are not valid
+  // `DocumentKey`s must be rejected gracefully instead of tripping the
+  // `HARD_ASSERT` inside the `DocumentKey` constructor or the length assert
+  // inside `PopFirst`. Three malformed shapes are covered:
+  //   1. a collection path (odd number of segments after the `documents`
+  //      prefix),
+  //   2. a root `documents` path (resolves to an empty key), and
+  //   3. a short path (fewer than five segments, would crash `PopFirst(5)`).
+  const std::vector<std::string> names = {FullPath("bundle"), FullPath(""),
+                                          "projects/p/databases/default"};
+
+  for (const auto& name : names) {
+    {
+      ProtoDocument document = TestDocument(ProtoValue());
+      document.set_name(name);
+      std::string json_string;
+      MessageToJsonString(document, &json_string);
+
+      JsonReader reader;
+      bundle_serializer.DecodeDocument(reader, Parse(json_string));
+      EXPECT_NOT_OK(reader.status());
+    }
+
+    {
+      ProtoBundledDocumentMetadata metadata;
+      metadata.set_name(name);
+      metadata.set_exists(true);
+      google::protobuf::Timestamp t1;
+      t1.set_seconds(0);
+      t1.set_nanos(0);
+      *metadata.mutable_read_time() = t1;
+      std::string json_string;
+      MessageToJsonString(metadata, &json_string);
+
+      JsonReader reader;
+      bundle_serializer.DecodeDocumentMetadata(reader, Parse(json_string));
+      EXPECT_NOT_OK(reader.status());
+    }
+  }
+}
+
 TEST_F(BundleSerializerTest, DecodeTargetWithoutImplicitOrderByOnName) {
   std::string json(
       R"({"name":"myNamedQuery",


### PR DESCRIPTION
#no-changelog
