### PR TITLE
ci(ai): add Xcode 27 support to FirebaseAI CI

### DIFF
--- a/.github/workflows/_cocoapods.yml
+++ b/.github/workflows/_cocoapods.yml
@@ -116,10 +116,21 @@ on:
         required: false
         default: 20
 
+      # Whether to test Xcode 27. Defaults to false.
+      test_xcode27:
+        type: boolean
+        required: false
+        default: false
+
 jobs:
   pod-lib-lint:
     # Run on the main repo's scheduled jobs or pull requests and manual workflow invocations.
-    if: (github.repository == 'firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
+    if: >-
+      ((github.repository == 'firebase/firebase-ios-sdk' &&
+        github.event_name == 'schedule') ||
+       contains(fromJSON('["pull_request", "workflow_dispatch"]'),
+                github.event_name)) &&
+      (matrix.xcode != 'Xcode_27.0' || inputs.test_xcode27)
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_cocoapods.yml
+++ b/.github/workflows/_cocoapods.yml
@@ -125,12 +125,7 @@ on:
 jobs:
   pod-lib-lint:
     # Run on the main repo's scheduled jobs or pull requests and manual workflow invocations.
-    if: >-
-      ((github.repository == 'firebase/firebase-ios-sdk' &&
-        github.event_name == 'schedule') ||
-       contains(fromJSON('["pull_request", "workflow_dispatch"]'),
-                github.event_name)) &&
-      (matrix.xcode != 'Xcode_27.0' || inputs.test_xcode27)
+    if: (github.repository == 'firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
     strategy:
       fail-fast: false
       matrix:
@@ -150,6 +145,7 @@ jobs:
             xcode: Xcode_26.2
           - os: xcode-27
             xcode: Xcode_26.4
+          - xcode: ${{ !inputs.test_xcode27 && 'Xcode_27.0' || 'none' }}
     runs-on: ${{ matrix.os }}
     steps:
     - name: Skip, if applicable.

--- a/.github/workflows/_cocoapods.yml
+++ b/.github/workflows/_cocoapods.yml
@@ -123,14 +123,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15, macos-26]
-        xcode: [Xcode_26.2, Xcode_26.4]
+        os: [macos-15, macos-26, xcode-27]
+        xcode: [Xcode_26.2, Xcode_26.4, Xcode_27.0]
         platform: [iOS, tvOS, macOS, watchOS]
         exclude:
           - os: macos-15
             xcode: Xcode_26.4
+          - os: macos-15
+            xcode: Xcode_27.0
           - os: macos-26
             xcode: Xcode_26.2
+          - os: macos-26
+            xcode: Xcode_27.0
+          - os: xcode-27
+            xcode: Xcode_26.2
+          - os: xcode-27
+            xcode: Xcode_26.4
     runs-on: ${{ matrix.os }}
     steps:
     - name: Skip, if applicable.

--- a/.github/workflows/_spm.yml
+++ b/.github/workflows/_spm.yml
@@ -61,6 +61,12 @@ on:
         required: false
         default: false
 
+      # Whether to test Xcode 27. Defaults to false.
+      test_xcode27:
+        type: boolean
+        required: false
+        default: false
+
       # Custom environment variables to inject into the jobs.
       # Expected to be a JSON-formatted string.
       # Example: '{"FIREBASE_APP_CHECK_BRANCH": "nc/target-split"}'
@@ -119,7 +125,12 @@ jobs:
 
   spm:
     # Run on the main repo's scheduled jobs or pull requests and manual workflow invocations.
-    if: (github.repository == 'firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
+    if: >-
+      ((github.repository == 'firebase/firebase-ios-sdk' &&
+        github.event_name == 'schedule') ||
+       contains(fromJSON('["pull_request", "workflow_dispatch"]'),
+                github.event_name)) &&
+      (matrix.xcode != 'Xcode_27.0' || inputs.test_xcode27)
     needs: [spm-package-resolved]
     env:
         FIREBASE_IS_NIGHTLY_TESTING: ${{ inputs.is_nightly && '1' || '' }}

--- a/.github/workflows/_spm.yml
+++ b/.github/workflows/_spm.yml
@@ -125,12 +125,7 @@ jobs:
 
   spm:
     # Run on the main repo's scheduled jobs or pull requests and manual workflow invocations.
-    if: >-
-      ((github.repository == 'firebase/firebase-ios-sdk' &&
-        github.event_name == 'schedule') ||
-       contains(fromJSON('["pull_request", "workflow_dispatch"]'),
-                github.event_name)) &&
-      (matrix.xcode != 'Xcode_27.0' || inputs.test_xcode27)
+    if: (github.repository == 'firebase/firebase-ios-sdk' && github.event_name == 'schedule') || contains(fromJSON('["pull_request", "workflow_dispatch"]'), github.event_name)
     needs: [spm-package-resolved]
     env:
         FIREBASE_IS_NIGHTLY_TESTING: ${{ inputs.is_nightly && '1' || '' }}
@@ -153,6 +148,7 @@ jobs:
             xcode: Xcode_26.2
           - os: xcode-27
             xcode: Xcode_26.4
+          - xcode: ${{ !inputs.test_xcode27 && 'Xcode_27.0' || 'none' }}
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/_spm.yml
+++ b/.github/workflows/_spm.yml
@@ -126,14 +126,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15, macos-26]
-        xcode: [Xcode_26.2, Xcode_26.4]
+        os: [macos-15, macos-26, xcode-27]
+        xcode: [Xcode_26.2, Xcode_26.4, Xcode_27.0]
         platform: [iOS, tvOS, macOS, watchOS, catalyst, visionOS]
         exclude:
           - os: macos-15
             xcode: Xcode_26.4
+          - os: macos-15
+            xcode: Xcode_27.0
           - os: macos-26
             xcode: Xcode_26.2
+          - os: macos-26
+            xcode: Xcode_27.0
+          - os: xcode-27
+            xcode: Xcode_26.2
+          - os: xcode-27
+            xcode: Xcode_26.4
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -63,6 +63,11 @@ jobs:
             xcode: Xcode_26.2
             test_filter_arg: --filter IntegrationTests-SPM/LiveSessionTests
             log_prefix: xcodebuild-live
+          - os: xcode-27
+            target: iOS
+            xcode: Xcode_27.0
+            test_filter_arg: --exclude IntegrationTests-SPM/LiveSessionTests
+            log_prefix: xcodebuild
     runs-on: ${{ matrix.os }}
     needs: spm
     env:
@@ -109,6 +114,8 @@ jobs:
           # TODO: Bump to 26.4 when "Unable to find a destination matching the provided destination specifier" is resolved.
           - os: macos-26
             xcode: Xcode_26.2
+          - os: xcode-27
+            xcode: Xcode_27.0
     runs-on: ${{ matrix.os }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name || 'main' }}

--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -33,6 +33,7 @@ jobs:
     uses: ./.github/workflows/_spm.yml
     with:
       target: ${{  matrix.target }}
+      test_xcode27: true
       setup_command: scripts/update_vertexai_responses.sh
       env_vars: '{"FIREBASE_APP_CHECK_BRANCH": "main"}'
 
@@ -101,6 +102,7 @@ jobs:
     uses: ./.github/workflows/_cocoapods.yml
     with:
       product: ${{  matrix.product }}
+      test_xcode27: true
       supports_swift6: true
       setup_command: scripts/update_vertexai_responses.sh
 

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let shouldUseSourceFirestore = Context.environment["FIREBASE_SOURCE_FIRESTORE"] 
 
 let package = Package(
   name: "Firebase",
-  platforms: [.iOS(.v15), .macCatalyst(.v15), .macOS(.v10_15), .tvOS(.v15), .watchOS(.v7)],
+  platforms: supportedPlatforms(),
   products: [
     .library(
       name: "FirebaseAI",
@@ -1366,6 +1366,20 @@ let package = Package(
 )
 
 // MARK: - Helper Functions
+
+/// Returns the list of platforms supported by the package.
+///
+/// Under Xcode 27 (Swift 6.4+), watchOS 9 and macOS 12 are now the minimum deployment targets. For
+/// Xcode 26.x and earlier, the deployment targets are watchOS 7 and macOS 10.15. The iOS, tvOS and
+/// Mac Catalyst minimums remain the same for both.
+func supportedPlatforms() -> [SupportedPlatform] {
+  // TODO: Remove the `compiler(>=6.4)` check when Xcode 27.x is the minimum supported version.
+  #if compiler(>=6.4)
+    return [.iOS(.v15), .macCatalyst(.v15), .macOS(.v12), .tvOS(.v15), .watchOS(.v9)]
+  #else
+    return [.iOS(.v15), .macCatalyst(.v15), .macOS(.v10_15), .tvOS(.v15), .watchOS(.v7)]
+  #endif
+}
 
 func firebaseCrashlyticsTarget() -> Target {
   var cSettings: [CSetting] = [


### PR DESCRIPTION
Updates the CI setup to test FirebaseAI on the Xcode 27 public preview runner image (`xcode-27`). To avoid impacting other SDK workflows, a new `test_xcode27` boolean input (defaulting to `false`) is added to the reusable workflows to run Xcode 27 conditionally.

- **`_spm.yml` & `_cocoapods.yml`**: Add the `test_xcode27` input, add `xcode-27` to the matrix, and skip Xcode 27 runs if `test_xcode27` is `false`.
- **`sdk.ai.yml`**: Pass `test_xcode27: true` to the reusable jobs, and add Xcode 27 configurations to the custom `testapp-integration` and `quickstart` matrices.

#no-changelog