### PR TITLE
zero image details in FIRCLSBinaryImageFindImageForUUID

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.m
@@ -163,6 +163,7 @@ bool FIRCLSBinaryImageFindImageForUUID(const char* uuidString,
     const struct mach_header* mh = _dyld_get_image_header(i);
 
     FIRCLSBinaryImageDetails image;
+    memset(&image, 0, sizeof(FIRCLSBinaryImageDetails));
 
     image.slice = FIRCLSMachOSliceWithHeader((void*)mh);
     FIRCLSBinaryImageFillInImageDetails(&image);


### PR DESCRIPTION
FIRCLSBinaryImageFillInImageDetails treats vmaddr_slide as an input rather than something it sets: it never assigns the field, but reads it to build node.unwindInfo, node.ehFrame and node.crashInfo, and it only fills uuidString, encrypted and the SDK versions when the matching load commands are present. FIRCLSBinaryImageFindImageForUUID is the only one of the three call sites that passes a stack struct without zeroing it first, so those three pointers come out of a garbage slide value and a UUID match copies them back to the caller. Zero the struct before filling it, the way FIRCLSBinaryImageChanged and FIRCLSBinaryImageRecordMainExecutable already do.