### PR TITLE
refactor: remove site key from options; require explicit pass to recaptcha provider

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [changed] The default App Check provider for iOS physical devices no longer
   attempts to configure the reCAPTCHA provider before falling back to
   DeviceCheck. This reverts a change introduced in 12.15.0.
+- [changed] Changed `RecaptchaProvider` and `RecaptchaProviderFactory` to explicitly require a `siteKey` parameter on initialization, rather than reading it from `FirebaseOptions`. Per previous release note disclaimer, this API was not intended for use.
 
 # 12.16.0
 - [changed] Changed error message for missing `FirebaseApp.configure()` to

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -2,7 +2,10 @@
 - [changed] The default App Check provider for iOS physical devices no longer
   attempts to configure the reCAPTCHA provider before falling back to
   DeviceCheck. This reverts a change introduced in 12.15.0.
-- [changed] Changed `RecaptchaProvider` and `RecaptchaProviderFactory` to explicitly require a `siteKey` parameter on initialization, rather than reading it from `FirebaseOptions`. Per previous release note disclaimer, this API was not intended for use.
+- [changed] Changed `RecaptchaProvider` and `RecaptchaProviderFactory` to
+  explicitly require a `siteKey` parameter on initialization, rather than reading
+  it from `FirebaseOptions`. Per previous release note disclaimer, this API
+  was not intended for use.
 
 # 12.16.0
 - [changed] Changed error message for missing `FirebaseApp.configure()` to

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -3,9 +3,9 @@
   attempts to configure the reCAPTCHA provider before falling back to
   DeviceCheck. This reverts a change introduced in 12.15.0.
 - [changed] Changed `RecaptchaProvider` and `RecaptchaProviderFactory` to
-  explicitly require a `siteKey` parameter on initialization, rather than reading
-  it from `FirebaseOptions`. Per previous release note disclaimer, this API
-  was not intended for use.
+  explicitly require a `siteKey` parameter on initialization, rather than
+  reading it from `FirebaseOptions`. Note that the reCAPTCHA provider feature
+  is in public preview.
 
 # 12.16.0
 - [changed] Changed error message for missing `FirebaseApp.configure()` to

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRRecaptchaProvider.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRRecaptchaProvider.h
@@ -32,11 +32,13 @@ API_UNAVAILABLE(macos, tvos, watchos, macCatalyst)
 
 - (instancetype)init NS_UNAVAILABLE;
 
+/// > Warning: This API is a public preview and may be subject to change.
 /// The default initializer.
 /// @param app A `FirebaseApp` instance.
+/// @param siteKey The reCAPTCHA Enterprise iOS site key to be used during attestation.
 /// @return An instance of `RecaptchaProvider` if the provided
 ///     `FirebaseApp` instance contains all required parameters.
-- (nullable instancetype)initWithApp:(FIRApp *)app;
+- (nullable instancetype)initWithApp:(FIRApp *)app siteKey:(NSString *)siteKey;
 
 /* Jazzy doesn't generate documentation for protocol-inherited
  * methods, so this is copied over from the protocol declaration.

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRRecaptchaProviderFactory.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRRecaptchaProviderFactory.h
@@ -31,7 +31,7 @@ API_UNAVAILABLE(macos, tvos, watchos, macCatalyst)
 
 /// Initializes a factory that will use the provided site key.
 /// @param siteKey The reCAPTCHA Enterprise iOS site key.
-- (nullable instancetype)initWithSiteKey:(NSString *)siteKey;
+- (instancetype)initWithSiteKey:(NSString *)siteKey;
 
 @end
 

--- a/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRRecaptchaProviderFactory.h
+++ b/FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRRecaptchaProviderFactory.h
@@ -19,12 +19,19 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// > Warning: This API is a public preview and may be subject to change.
 /// An implementation of `AppCheckProviderFactory` that creates a new instance of
-/// `AppCheckRecaptchaProvider` when requested.
+/// `RecaptchaProvider` when requested.
 NS_SWIFT_NAME(RecaptchaProviderFactory)
 API_AVAILABLE(ios(15.0), visionos(1.0))
 API_UNAVAILABLE(macos, tvos, watchos, macCatalyst)
 @interface FIRRecaptchaProviderFactory : NSObject <FIRAppCheckProviderFactory>
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Initializes a factory that will use the provided site key.
+/// @param siteKey The reCAPTCHA Enterprise iOS site key.
+- (nullable instancetype)initWithSiteKey:(NSString *)siteKey;
 
 @end
 

--- a/FirebaseAppCheck/Sources/RecaptchaProvider/FIRRecaptchaProvider.m
+++ b/FirebaseAppCheck/Sources/RecaptchaProvider/FIRRecaptchaProvider.m
@@ -55,19 +55,15 @@
 #endif
 }
 
-- (nullable instancetype)initWithApp:(FIRApp *)app {
+- (nullable instancetype)initWithApp:(FIRApp *)app siteKey:(NSString *)siteKey {
 #if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_VISION
   // 1. Validate options and raise exceptions on invalid configuration
-  NSString *siteKey = app.options.recaptchaSiteKey;
   if (siteKey.length == 0) {
     NSString *message = [NSString
-        stringWithFormat:
-            @"Cannot instantiate `RecaptchaProvider` for app: %@. "
-            @"`FirebaseOptions.recaptchaSiteKey` "
-            @"is missing or empty. "
-            @"Please ensure you have downloaded the latest `GoogleService-Info.plist` from the "
-            @"Firebase console or set `recaptchaSiteKey` on `FirebaseOptions` programmatically.",
-            app.name];
+        stringWithFormat:@"Cannot instantiate `RecaptchaProvider` for app: %@. "
+                         @"The `siteKey` parameter is missing or empty. "
+                         @"Please ensure you have provided a valid reCAPTCHA Enterprise site key.",
+                         app.name];
     FIRLogError(kFIRLoggerAppCheck, kFIRLoggerAppCheckMessageRecaptchaProviderMissingSiteKey, @"%@",
                 message);
     [NSException raise:NSInvalidArgumentException format:@"%@", message];

--- a/FirebaseAppCheck/Sources/RecaptchaProvider/FIRRecaptchaProviderFactory.m
+++ b/FirebaseAppCheck/Sources/RecaptchaProvider/FIRRecaptchaProviderFactory.m
@@ -18,11 +18,23 @@
 
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRRecaptchaProvider.h"
 
+@interface FIRRecaptchaProviderFactory ()
+@property(nonatomic, copy) NSString *siteKey;
+@end
+
 @implementation FIRRecaptchaProviderFactory
+
+- (nullable instancetype)initWithSiteKey:(NSString *)siteKey {
+  self = [super init];
+  if (self) {
+    _siteKey = [siteKey copy];
+  }
+  return self;
+}
 
 - (nullable id<FIRAppCheckProvider>)createProviderWithApp:(nonnull FIRApp *)app {
 #if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_VISION
-  return [[FIRRecaptchaProvider alloc] initWithApp:app];
+  return [[FIRRecaptchaProvider alloc] initWithApp:app siteKey:self.siteKey];
 #else
   return nil;
 #endif

--- a/FirebaseAppCheck/Sources/RecaptchaProvider/FIRRecaptchaProviderFactory.m
+++ b/FirebaseAppCheck/Sources/RecaptchaProvider/FIRRecaptchaProviderFactory.m
@@ -24,7 +24,12 @@
 
 @implementation FIRRecaptchaProviderFactory
 
-- (nullable instancetype)initWithSiteKey:(NSString *)siteKey {
+- (instancetype)initWithSiteKey:(NSString *)siteKey {
+  if (siteKey.length == 0) {
+    [NSException raise:NSInvalidArgumentException
+                format:@"Cannot instantiate RecaptchaProviderFactory. The siteKey parameter is "
+                       @"missing or empty."];
+  }
   self = [super init];
   if (self) {
     _siteKey = [siteKey copy];

--- a/FirebaseAppCheck/Sources/RecaptchaProvider/FIRRecaptchaProviderFactory.m
+++ b/FirebaseAppCheck/Sources/RecaptchaProvider/FIRRecaptchaProviderFactory.m
@@ -19,10 +19,15 @@
 #import "FirebaseAppCheck/Sources/Public/FirebaseAppCheck/FIRRecaptchaProvider.h"
 
 @interface FIRRecaptchaProviderFactory ()
-@property(nonatomic, copy) NSString *siteKey;
+@property(nonatomic, readonly, copy) NSString *siteKey;
 @end
 
 @implementation FIRRecaptchaProviderFactory
+
+- (instancetype)init {
+  [self doesNotRecognizeSelector:_cmd];
+  return nil;
+}
 
 - (instancetype)initWithSiteKey:(NSString *)siteKey {
   if (siteKey.length == 0) {

--- a/FirebaseAppCheck/Tests/Unit/Swift/RecaptchaProviderTests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/RecaptchaProviderTests.swift
@@ -111,6 +111,17 @@
       }
     }
 
+    func testFactoryInitWithEmptySiteKeyThrows() {
+      XCTAssertThrowsError(try ExceptionCatcher.catchException {
+        _ = RecaptchaProviderFactory(siteKey: "")
+      }) { error in
+        let nsError = error as NSError
+        XCTAssertEqual(nsError.domain, NSExceptionName.invalidArgumentException.rawValue)
+        XCTAssertTrue((nsError.userInfo["ExceptionReason"] as? String)?
+          .contains("The siteKey parameter is missing or empty") ?? false)
+      }
+    }
+
     func testInitWithMissingSDKThrows() {
       let options = FirebaseOptions(googleAppID: "1:123456789:ios:abc123", gcmSenderID: "sender_id")
       options.apiKey = "api_key"

--- a/FirebaseAppCheck/Tests/Unit/Swift/RecaptchaProviderTests.swift
+++ b/FirebaseAppCheck/Tests/Unit/Swift/RecaptchaProviderTests.swift
@@ -56,7 +56,6 @@
     func testInitWithIncompleteApp() {
       let options = FirebaseOptions(googleAppID: "1:123456789:ios:abc123", gcmSenderID: "sender_id")
       options.projectID = "project_id"
-      options.recaptchaSiteKey = "test_site_key"
 
       let appName = "testInitWithIncompleteApp1"
       let missingAPIKeyApp: FirebaseApp
@@ -68,11 +67,10 @@
       }
       missingAPIKeyApp.isDataCollectionDefaultEnabled = false
 
-      XCTAssertNil(RecaptchaProvider(app: missingAPIKeyApp))
+      XCTAssertNil(RecaptchaProvider(app: missingAPIKeyApp, siteKey: "test_site_key"))
 
       options.projectID = nil
       options.apiKey = "api_key"
-      options.recaptchaSiteKey = "test_site_key"
 
       let appName2 = "testInitWithIncompleteApp2"
       let missingProjectIDApp: FirebaseApp
@@ -83,7 +81,7 @@
         missingProjectIDApp = FirebaseApp.app(name: appName2)!
       }
       missingProjectIDApp.isDataCollectionDefaultEnabled = false
-      XCTAssertNil(RecaptchaProvider(app: missingProjectIDApp))
+      XCTAssertNil(RecaptchaProvider(app: missingProjectIDApp, siteKey: "test_site_key"))
     }
 
     func testInitWithMissingSiteKey() {
@@ -103,13 +101,13 @@
       app.isDataCollectionDefaultEnabled = false
 
       XCTAssertThrowsError(try ExceptionCatcher.catchException {
-        _ = RecaptchaProvider(app: app)
+        _ = RecaptchaProvider(app: app, siteKey: "")
       }) { error in
         let nsError = error as NSError
         XCTAssertEqual(nsError.domain, NSExceptionName.invalidArgumentException.rawValue)
         XCTAssertEqual(nsError.code, -114)
         XCTAssertTrue((nsError.userInfo["ExceptionReason"] as? String)?
-          .contains("recaptchaSiteKey") ?? false)
+          .contains("`siteKey` parameter is missing or empty") ?? false)
       }
     }
 
@@ -117,7 +115,6 @@
       let options = FirebaseOptions(googleAppID: "1:123456789:ios:abc123", gcmSenderID: "sender_id")
       options.apiKey = "api_key"
       options.projectID = "project_id"
-      options.recaptchaSiteKey = "test_site_key"
 
       let appName = "testInitWithMissingSDKThrows"
       let app: FirebaseApp
@@ -130,7 +127,7 @@
       app.isDataCollectionDefaultEnabled = false
 
       XCTAssertThrowsError(try ExceptionCatcher.catchException {
-        _ = RecaptchaProvider(app: app)
+        _ = RecaptchaProvider(app: app, siteKey: "test_site_key")
       }) { error in
         let nsError = error as NSError
         XCTAssertEqual(nsError.domain, NSExceptionName.internalInconsistencyException.rawValue)

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -2,7 +2,8 @@
 - [changed] Firebase now requires Swift tools version 6.1 for the Swift Package.
   The package will no longer resolve in Xcode versions older than 16.3. Note that
   the minimum officially supported version for the SDK remains Xcode 26.2+.
-- [changed] Removed the `recaptchaSiteKey` property from `FirebaseOptions`. Per previous release note disclaimer, this API was not intended for use.
+- [changed] Removed the `recaptchaSiteKey` property from `FirebaseOptions`. Per
+  previous release note disclaimer, this API was not intended for use.
 
 # Firebase 12.14.0
 - [fixed] Remove extra comma in Package.swift that caused SPM resolution

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -2,8 +2,8 @@
 - [changed] Firebase now requires Swift tools version 6.1 for the Swift Package.
   The package will no longer resolve in Xcode versions older than 16.3. Note that
   the minimum officially supported version for the SDK remains Xcode 26.2+.
-- [changed] Removed the `recaptchaSiteKey` property from `FirebaseOptions`. Per
-  previous release note disclaimer, this API was not intended for use.
+- [changed] Removed the `recaptchaSiteKey` property from `FirebaseOptions`.
+  This feature was part of the public preview reCAPTCHA provider.
 
 # Firebase 12.14.0
 - [fixed] Remove extra comma in Package.swift that caused SPM resolution

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -3,7 +3,7 @@
   The package will no longer resolve in Xcode versions older than 16.3. Note that
   the minimum officially supported version for the SDK remains Xcode 26.2+.
 - [changed] Removed the `recaptchaSiteKey` property from `FirebaseOptions`.
-  This feature was part of the public preview reCAPTCHA provider.
+  This feature is part of the public preview reCAPTCHA provider.
 
 # Firebase 12.14.0
 - [fixed] Remove extra comma in Package.swift that caused SPM resolution

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [changed] Firebase now requires Swift tools version 6.1 for the Swift Package.
   The package will no longer resolve in Xcode versions older than 16.3. Note that
   the minimum officially supported version for the SDK remains Xcode 26.2+.
+- [changed] Removed the `recaptchaSiteKey` property from `FirebaseOptions`. Per previous release note disclaimer, this API was not intended for use.
 
 # Firebase 12.14.0
 - [fixed] Remove extra comma in Package.swift that caused SPM resolution

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -2,7 +2,7 @@
 - [changed] Firebase now requires Swift tools version 6.1 for the Swift Package.
   The package will no longer resolve in Xcode versions older than 16.3. Note that
   the minimum officially supported version for the SDK remains Xcode 26.2+.
-- [changed] Removed the `recaptchaSiteKey` property from `FirebaseOptions`.
+- [changed] Removed the  (never activated) `recaptchaSiteKey` property from `FirebaseOptions`.
   This feature is part of the public preview reCAPTCHA provider.
 
 # Firebase 12.14.0

--- a/FirebaseCore/Sources/FIROptions.m
+++ b/FirebaseCore/Sources/FIROptions.m
@@ -29,7 +29,6 @@ NSString *const kFIRStorageBucket = @"STORAGE_BUCKET";
 NSString *const kFIRBundleID = @"BUNDLE_ID";
 // The key to locate the project identifier in the plist file.
 NSString *const kFIRProjectID = @"PROJECT_ID";
-NSString *const kFIRRecaptchaSiteKey = @"RECAPTCHA_SITE_KEY";
 
 NSString *const kFIRIsMeasurementEnabled = @"IS_MEASUREMENT_ENABLED";
 NSString *const kFIRIsAnalyticsCollectionEnabled = @"FIREBASE_ANALYTICS_COLLECTION_ENABLED";
@@ -305,15 +304,6 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
 - (void)setStorageBucket:(NSString *)storageBucket {
   [self checkEditingLocked];
   _optionsDictionary[kFIRStorageBucket] = [storageBucket copy];
-}
-
-- (NSString *)recaptchaSiteKey {
-  return self.optionsDictionary[kFIRRecaptchaSiteKey];
-}
-
-- (void)setRecaptchaSiteKey:(NSString *)recaptchaSiteKey {
-  [self checkEditingLocked];
-  _optionsDictionary[kFIRRecaptchaSiteKey] = [recaptchaSiteKey copy];
 }
 
 - (NSString *)bundleID {

--- a/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
+++ b/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
@@ -83,11 +83,6 @@ NS_SWIFT_NAME(FirebaseOptions)
 @property(nonatomic, copy, nullable) NSString *appGroupID;
 
 /**
- * The reCAPTCHA site key used by App Check.
- */
-@property(nonatomic, copy, nullable) NSString *recaptchaSiteKey;
-
-/**
  * Initializes a customized instance of FirebaseOptions from the file at the given plist file path.
  * This will read the file synchronously from disk.
  * For example:

--- a/FirebaseCore/Tests/Unit/FIROptionsTest.m
+++ b/FirebaseCore/Tests/Unit/FIROptionsTest.m
@@ -154,19 +154,6 @@ extern NSString *const kFIRLibraryVersionID;
   XCTAssertFalse(options.usingOptionsFromDefaultPlist);
 }
 
-- (void)testRecaptchaSiteKey {
-  NSString *siteKey = @"placeholder_site_key";
-  NSDictionary *optionsDictionary = @{@"RECAPTCHA_SITE_KEY" : siteKey};
-  FIROptions *options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
-  XCTAssertEqualObjects(options.recaptchaSiteKey, siteKey);
-}
-
-- (void)testSetRecaptchaSiteKey {
-  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@"app_id" GCMSenderID:@"sender_id"];
-  options.recaptchaSiteKey = @"manual_site_key";
-  XCTAssertEqualObjects(options.recaptchaSiteKey, @"manual_site_key");
-}
-
 - (void)assertOptionsMatchDefaults:(FIROptions *)options andProjectID:(BOOL)matchProjectID {
   XCTAssertEqualObjects(options.googleAppID, kGoogleAppID);
   XCTAssertEqualObjects(options.APIKey, kAPIKey);


### PR DESCRIPTION
Remove recaptchaSiteKey from FirebaseOptions and explicitly pass it into FIRRecaptchaProvider instead.

cc: @rlazo 

#no-changelog