### PR TITLE
fix(RemoteConfig): prevent activate from hanging with named apps

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,9 +1,11 @@
+# Unreleased
+- [fixed] Fixed an issue where Remote Config activation would hang indefinitely
+  when used with a named Firebase app instance. (#16354)
+
 # 12.13.0
 - [fixed] Remote Config Realtime updates now trigger when a parameter's experiment
   or variant assignment changes, ensuring more accurate A/B test analytics and
   consistent user experiences.
-- [fixed] Fixed an issue where Remote Config activation would hang indefinitely
-  when used with a named Firebase app instance. (#16354)
 
 # 12.12.0
 - [added] Introduced a new `configUpdates` property to `RemoteConfig` that

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -2,6 +2,8 @@
 - [fixed] Remote Config Realtime updates now trigger when a parameter's experiment
   or variant assignment changes, ensuring more accurate A/B test analytics and
   consistent user experiences.
+- [fixed] Fixed an issue where Remote Config activation would hang indefinitely
+  when used with a named Firebase app instance. (#16354)
 
 # 12.12.0
 - [added] Introduced a new `configUpdates` property to `RemoteConfig` that

--- a/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
@@ -158,9 +158,7 @@ static NSString *const kMethodNameLatestStartTime =
                          completionHandler:handler];
   } else {
     if (handler) {
-      dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
-        handler(nil);
-      });
+      handler(nil);
     }
   }
 }

--- a/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
@@ -158,7 +158,7 @@ static NSString *const kMethodNameLatestStartTime =
                          completionHandler:handler];
   } else {
     if (handler) {
-      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+      dispatch_async(dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0), ^{
         handler(nil);
       });
     }

--- a/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
@@ -158,7 +158,7 @@ static NSString *const kMethodNameLatestStartTime =
                          completionHandler:handler];
   } else {
     if (handler) {
-      dispatch_async(dispatch_get_main_queue(), ^{
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
         handler(nil);
       });
     }

--- a/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
@@ -144,6 +144,10 @@ static NSString *const kMethodNameLatestStartTime =
 
   // Update the last experiment start time with the latest payload.
   [self updateExperimentStartTime];
+
+  /// Update activated experiments payload and metadata in DB.
+  [self updateActiveExperimentsInDB];
+
   if (self.experimentController) {
     [self.experimentController
         updateExperimentsWithServiceOrigin:kServiceOrigin
@@ -157,9 +161,6 @@ static NSString *const kMethodNameLatestStartTime =
       handler(nil);
     }
   }
-
-  /// Update activated experiments payload and metadata in DB.
-  [self updateActiveExperimentsInDB];
 }
 
 - (void)updateExperimentStartTime {

--- a/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
@@ -144,13 +144,19 @@ static NSString *const kMethodNameLatestStartTime =
 
   // Update the last experiment start time with the latest payload.
   [self updateExperimentStartTime];
-  [self.experimentController
-      updateExperimentsWithServiceOrigin:kServiceOrigin
-                                  events:lifecycleEvent
-                                  policy:ABTExperimentPayloadExperimentOverflowPolicyDiscardOldest
-                           lastStartTime:lastStartTime
-                                payloads:_experimentPayloads
-                       completionHandler:handler];
+  if (self.experimentController) {
+    [self.experimentController
+        updateExperimentsWithServiceOrigin:kServiceOrigin
+                                    events:lifecycleEvent
+                                    policy:ABTExperimentPayloadExperimentOverflowPolicyDiscardOldest
+                             lastStartTime:lastStartTime
+                                  payloads:_experimentPayloads
+                         completionHandler:handler];
+  } else {
+    if (handler) {
+      handler(nil);
+    }
+  }
 
   /// Update activated experiments payload and metadata in DB.
   [self updateActiveExperimentsInDB];
@@ -193,8 +199,12 @@ static NSString *const kMethodNameLatestStartTime =
 }
 
 - (NSTimeInterval)latestStartTimeWithExistingLastStartTime:(NSTimeInterval)existingLastStartTime {
-  return [self.experimentController
-      latestExperimentStartTimestampBetweenTimestamp:existingLastStartTime
-                                         andPayloads:_experimentPayloads];
+  if (self.experimentController) {
+    return [self.experimentController
+        latestExperimentStartTimestampBetweenTimestamp:existingLastStartTime
+                                           andPayloads:_experimentPayloads];
+  } else {
+    return existingLastStartTime;
+  }
 }
 @end

--- a/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
@@ -158,7 +158,7 @@ static NSString *const kMethodNameLatestStartTime =
                          completionHandler:handler];
   } else {
     if (handler) {
-      dispatch_async(dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0), ^{
+      dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
         handler(nil);
       });
     }

--- a/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
@@ -158,7 +158,9 @@ static NSString *const kMethodNameLatestStartTime =
                          completionHandler:handler];
   } else {
     if (handler) {
-      handler(nil);
+      dispatch_async(dispatch_get_main_queue(), ^{
+        handler(nil);
+      });
     }
   }
 }

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
@@ -239,6 +239,26 @@
   }];
 }
 
+- (void)testUpdateExperimentsWithNilExperimentController {
+  RCNConfigExperiment *experiment = [[RCNConfigExperiment alloc] initWithDBManager:_DBManagerMock
+                                                              experimentController:nil];
+
+  NSData *payloadData = [[self class] payloadDataFromTestFile];
+  experiment.experimentPayloads = [@[ payloadData ] mutableCopy];
+
+  XCTestExpectation *expectation = [self
+      expectationWithDescription:@"Completion handler is called when experimentController is nil"];
+
+  [experiment updateExperimentsWithHandler:^(NSError *_Nullable error) {
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(experiment.experimentMetadata[@"last_experiment_start_time"], @(0));
+    XCTAssertEqualObjects(experiment.activeExperimentPayloads, @[ payloadData ]);
+    [expectation fulfill];
+  }];
+
+  [self waitForExpectationsWithTimeout:_expectationTimeout handler:nil];
+}
+
 #pragma mark Helpers.
 
 - (ABTExperimentPayload *)deserializeABTData:(NSData *)payload {

--- a/agents.md
+++ b/agents.md
@@ -498,6 +498,7 @@ document current will improve the efficiency and accuracy of future AI-assisted 
     *   `setCustomSignals:` also strongly captures `self` via `self->_settings.customSignals`.
     *   There is a deadlock hazard in `configValueForKey:` due to synchronous dispatch to `_queue` which then dispatches asynchronously back to `_queue` via `callListeners:`.
     *   `RCNConfigExperiment` has data race risks on `_experimentPayloads` and other mutable collections as they are mutated from different queues (e.g., `loadExperimentFromTable` vs `updateExperimentsWithResponse:`).
+    *   In `RCNConfigExperiment`, `updateActiveExperimentsInDB` performs asynchronous DB operations. Subsequent code in `updateExperimentsWithHandler:` (such as `updateExperimentsWithServiceOrigin:`) is not guaranteed to execute after the DB updates complete, leading to a potential race condition.
 
 ## AI Subagent Personas
 

--- a/agents.md
+++ b/agents.md
@@ -491,6 +491,14 @@ If, during the course of completing new tasks, you identify:
 Please consider updating this `agents.md` file to reflect those new findings. Keeping this
 document current will improve the efficiency and accuracy of future AI-assisted development.
 
+## Technical Debt & Known Issues
+
+*   **Remote Config Memory & Concurrency**:
+    *   `FIRRemoteConfig` has pre-existing retain cycles in `activateWithCompletion:` (where `applyBlock` strongly captures `self`) and `activateRolloutMetadata:` (where the completion block strongly captures `self` and is held by the DBManager's queue).
+    *   `setCustomSignals:` also strongly captures `self` via `self->_settings.customSignals`.
+    *   There is a deadlock hazard in `configValueForKey:` due to synchronous dispatch to `_queue` which then dispatches asynchronously back to `_queue` via `callListeners:`.
+    *   `RCNConfigExperiment` has data race risks on `_experimentPayloads` and other mutable collections as they are mutated from different queues (e.g., `loadExperimentFromTable` vs `updateExperimentsWithResponse:`).
+
 ## AI Subagent Personas
 
 The following personas are defined for use by AI orchestrators (like the


### PR DESCRIPTION
Fixes an issue where `activate` or `fetchAndActivate` hung indefinitely when used with a named Firebase app instance because the `FIRExperimentController` returns `nil` if no default app is configured. Now properly checks for `nil` and bypasses A/B testing payload evaluation safely.

Fixes #16354
