### PR TITLE
fix(RemoteConfig): prevent retain cycle in activateWithCompletion

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [fixed] Fixed a memory leak in Remote Config where `activateWithCompletion:`
-  retained the `FIRRemoteConfig` instance indefinitely.
+  retained the `FIRRemoteConfig` instance indefinitely (#16413).
 - [fixed] Fixed an issue where Remote Config activation would hang indefinitely
   when used with a named Firebase app instance. (#16354)
 

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- [fixed] Fixed a memory leak in Remote Config where `activateWithCompletion:`
+  retained the `FIRRemoteConfig` instance indefinitely.
 - [fixed] Fixed an issue where Remote Config activation would hang indefinitely
   when used with a named Firebase app instance. (#16354)
 

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -6,6 +6,8 @@
 - [fixed] Remote Config Realtime updates now trigger when a parameter's experiment
   or variant assignment changes, ensuring more accurate A/B test analytics and
   consistent user experiences.
+- [fixed] Fixed an issue where Remote Config activation would hang indefinitely
+  when used with a named Firebase app instance. (#16354)
 
 # 12.12.0
 - [added] Introduced a new `configUpdates` property to `RemoteConfig` that

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -6,8 +6,6 @@
 - [fixed] Remote Config Realtime updates now trigger when a parameter's experiment
   or variant assignment changes, ensuring more accurate A/B test analytics and
   consistent user experiences.
-- [fixed] Fixed an issue where Remote Config activation would hang indefinitely
-  when used with a named Firebase app instance. (#16354)
 
 # 12.12.0
 - [added] Introduced a new `configUpdates` property to `RemoteConfig` that

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -436,20 +436,19 @@ typedef void (^FIRRemoteConfigActivateChangeCompletion)(BOOL changed, NSError *_
       }
       return;
     }
-    [strongSelf->_configContent copyFromDictionary:self->_configContent.fetchedConfig
+    [strongSelf->_configContent copyFromDictionary:strongSelf->_configContent.fetchedConfig
                                           toSource:RCNDBSourceActive
-                                      forNamespace:self->_FIRNamespace];
+                                      forNamespace:strongSelf->_FIRNamespace];
     strongSelf->_settings.lastApplyTimeInterval = [[NSDate date] timeIntervalSince1970];
     // New config has been activated at this point
     FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000069", @"Config activated.");
     [strongSelf->_configContent activatePersonalization];
     // Update last active template version number in setting and userDefaults.
     [strongSelf->_settings updateLastActiveTemplateVersion];
-    // Update activeRolloutMetadata
     [strongSelf->_configContent activateRolloutMetadata:^(BOOL success) {
       if (success) {
-        [self notifyRolloutsStateChange:strongSelf->_configContent.activeRolloutMetadata
-                          versionNumber:strongSelf->_settings.lastActiveTemplateVersion];
+        [strongSelf notifyRolloutsStateChange:strongSelf->_configContent.activeRolloutMetadata
+                                versionNumber:strongSelf->_settings.lastActiveTemplateVersion];
       }
     }];
 
@@ -458,7 +457,7 @@ typedef void (^FIRRemoteConfigActivateChangeCompletion)(BOOL changed, NSError *_
         substringToIndex:[strongSelf->_FIRNamespace rangeOfString:@":"].location];
     if ([namespace isEqualToString:FIRRemoteConfigConstants.FIRNamespaceGoogleMobilePlatform]) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        [self notifyConfigHasActivated];
+        [strongSelf notifyConfigHasActivated];
       });
       [strongSelf->_configExperiment updateExperimentsWithHandler:^(NSError *_Nullable error) {
         if (completion) {

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -446,9 +446,11 @@ typedef void (^FIRRemoteConfigActivateChangeCompletion)(BOOL changed, NSError *_
     // Update last active template version number in setting and userDefaults.
     [strongSelf->_settings updateLastActiveTemplateVersion];
     [strongSelf->_configContent activateRolloutMetadata:^(BOOL success) {
-      if (success) {
-        [strongSelf notifyRolloutsStateChange:strongSelf->_configContent.activeRolloutMetadata
-                                versionNumber:strongSelf->_settings.lastActiveTemplateVersion];
+      FIRRemoteConfig *strongSelfForRollout = weakSelf;
+      if (strongSelfForRollout && success) {
+        [strongSelfForRollout
+            notifyRolloutsStateChange:strongSelfForRollout->_configContent.activeRolloutMetadata
+                        versionNumber:strongSelfForRollout->_settings.lastActiveTemplateVersion];
       }
     }];
 

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -2017,12 +2017,18 @@ static NSString *UTCToLocal(NSString *utcTime) {
     }
 
     RCNConfigContent *configContent = [[RCNConfigContent alloc] initWithDBManager:_DBManager];
+    NSString *fullyQualifiedNamespace = [NSString stringWithFormat:@"test_namespace:%@", app.name];
+    RCNConfigSettings *settings =
+        [[RCNConfigSettings alloc] initWithDatabaseManager:_DBManager
+                                                 namespace:fullyQualifiedNamespace
+                                           firebaseAppName:app.name
+                                               googleAppID:app.options.googleAppID];
     FIRRemoteConfig *instance =
         [[FIRRemoteConfig alloc] initWithAppName:app.name
                                       FIROptions:app.options
                                        namespace:@"test_namespace"
                                        DBManager:_DBManager
-                                        settings:_settings
+                                        settings:settings
                                    configContent:configContent
                                 configExperiment:nil
                                            queue:dispatch_queue_create("test", nil)

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -2017,15 +2017,16 @@ static NSString *UTCToLocal(NSString *utcTime) {
     }
 
     RCNConfigContent *configContent = [[RCNConfigContent alloc] initWithDBManager:_DBManager];
-    FIRRemoteConfig *instance = [[FIRRemoteConfig alloc] initWithAppName:app.name
-                                                              FIROptions:app.options
-                                                               namespace:@"test_namespace"
-                                                               DBManager:_DBManager
-                                                           configContent:configContent
-                                                               analytics:nil];
+    __block FIRRemoteConfig *instance = [[FIRRemoteConfig alloc] initWithAppName:app.name
+                                                                      FIROptions:app.options
+                                                                       namespace:@"test_namespace"
+                                                                       DBManager:_DBManager
+                                                                   configContent:configContent
+                                                                       analytics:nil];
     weakInstance = instance;
 
     [instance activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+      instance = nil;
       [expectation fulfill];
     }];
   }

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -2025,6 +2025,11 @@ static NSString *UTCToLocal(NSString *utcTime) {
                                                                        analytics:nil];
     weakInstance = instance;
 
+    // Set settings to ensure the activation path is fully executed and does not return early.
+    RCNConfigSettings *settings = [instance valueForKey:@"_settings"];
+    settings.lastETagUpdateTime = 100;
+    settings.lastApplyTimeInterval = 0;
+
     [instance activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
       instance = nil;
       [expectation fulfill];

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -2003,6 +2003,42 @@ static NSString *UTCToLocal(NSString *utcTime) {
   [self waitForExpectationsWithTimeout:_expectationTimeout handler:nil];
 }
 
+#pragma mark - Memory Leak Tests
+
+- (void)testActivateWithCompletionMemoryLeak {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"activate completes"];
+  __weak FIRRemoteConfig *weakInstance = nil;
+
+  @autoreleasepool {
+    FIRApp *app = [FIRApp appNamed:@"fir-app-name-test"];
+    if (!app) {
+      [FIRApp configureWithName:@"fir-app-name-test" options:[self firstAppOptions]];
+      app = [FIRApp appNamed:@"fir-app-name-test"];
+    }
+
+    RCNConfigContent *configContent = [[RCNConfigContent alloc] initWithDBManager:_DBManager];
+    FIRRemoteConfig *instance =
+        [[FIRRemoteConfig alloc] initWithAppName:app.name
+                                      FIROptions:app.options
+                                       namespace:@"test_namespace"
+                                       DBManager:_DBManager
+                                        settings:_settings
+                                   configContent:configContent
+                                configExperiment:nil
+                                           queue:dispatch_queue_create("test", nil)
+                                  configRealtime:nil];
+    weakInstance = instance;
+
+    [instance activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+      [expectation fulfill];
+    }];
+  }
+
+  [self waitForExpectationsWithTimeout:_expectationTimeout handler:nil];
+  XCTAssertNil(weakInstance,
+               @"FIRRemoteConfig instance was not deallocated. Retain cycle present!");
+}
+
 #pragma mark - Test Helpers
 
 - (FIROptions *)firstAppOptions {

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -2017,22 +2017,12 @@ static NSString *UTCToLocal(NSString *utcTime) {
     }
 
     RCNConfigContent *configContent = [[RCNConfigContent alloc] initWithDBManager:_DBManager];
-    NSString *fullyQualifiedNamespace = [NSString stringWithFormat:@"test_namespace:%@", app.name];
-    RCNConfigSettings *settings =
-        [[RCNConfigSettings alloc] initWithDatabaseManager:_DBManager
-                                                 namespace:fullyQualifiedNamespace
-                                           firebaseAppName:app.name
-                                               googleAppID:app.options.googleAppID];
-    FIRRemoteConfig *instance =
-        [[FIRRemoteConfig alloc] initWithAppName:app.name
-                                      FIROptions:app.options
-                                       namespace:@"test_namespace"
-                                       DBManager:_DBManager
-                                        settings:settings
-                                   configContent:configContent
-                                configExperiment:nil
-                                           queue:dispatch_queue_create("test", nil)
-                                  configRealtime:nil];
+    FIRRemoteConfig *instance = [[FIRRemoteConfig alloc] initWithAppName:app.name
+                                                              FIROptions:app.options
+                                                               namespace:@"test_namespace"
+                                                               DBManager:_DBManager
+                                                           configContent:configContent
+                                                               analytics:nil];
     weakInstance = instance;
 
     [instance activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {

--- a/agents.md
+++ b/agents.md
@@ -494,7 +494,6 @@ document current will improve the efficiency and accuracy of future AI-assisted 
 ## Technical Debt & Known Issues
 
 *   **Remote Config Memory & Concurrency**:
-    *   `FIRRemoteConfig` has pre-existing retain cycles in `activateWithCompletion:` (where `applyBlock` strongly captures `self`) and `activateRolloutMetadata:` (where the completion block strongly captures `self` and is held by the DBManager's queue).
     *   `setCustomSignals:` also strongly captures `self` via `self->_settings.customSignals`.
     *   There is a deadlock hazard in `configValueForKey:` due to synchronous dispatch to `_queue` which then dispatches asynchronously back to `_queue` via `callListeners:`.
     *   `RCNConfigExperiment` has data race risks on `_experimentPayloads` and other mutable collections as they are mutated from different queues (e.g., `loadExperimentFromTable` vs `updateExperimentsWithResponse:`).


### PR DESCRIPTION
Replaces strong 'self' captures with 'strongSelf' within the 'activateWithCompletion' applyBlock to resolve a retain cycle. Added a unit test to verify memory leak is fixed.
