### PR TITLE
limit cursor lookup to values_count in Target bound helpers

### DIFF
--- a/Firestore/core/src/core/target.cc
+++ b/Firestore/core/src/core/target.cc
@@ -16,6 +16,7 @@
 
 #include "Firestore/core/src/core/target.h"
 
+#include <algorithm>
 #include <ostream>
 #include <set>
 #include <unordered_map>
@@ -251,10 +252,14 @@ Target::IndexBoundValue Target::GetAscendingBound(
   // If there is an additional bound, compare the values against the existing
   // range to see if we can narrow the scope.
   if (bound.has_value()) {
-    for (size_t i = 0; i < order_bys_.size(); ++i) {
+    const auto& position = *bound.value().position();
+    // A cursor may have fewer components than the target has order-bys; only
+    // the leading order-bys have a corresponding cursor value.
+    size_t count = std::min<size_t>(order_bys_.size(), position.values_count);
+    for (size_t i = 0; i < count; ++i) {
       const auto& order_by = order_bys_[i];
       if (order_by.field() == segment.field_path()) {
-        auto cursor_value = bound.value().position()->values[i];
+        auto cursor_value = position.values[i];
         // Increase segment_value to cursor_value if cursor_value is larger.
         if (model::LowerBoundCompare(segment_value, segment_inclusive,
                                      cursor_value, bound.value().inclusive()) ==
@@ -316,10 +321,14 @@ Target::IndexBoundValue Target::GetDescendingBound(
   // If there is an additional bound, compare the values against the existing
   // range to see if we can narrow the scope.
   if (bound.has_value()) {
-    for (size_t i = 0; i < order_bys_.size(); ++i) {
+    const auto& position = *bound.value().position();
+    // A cursor may have fewer components than the target has order-bys; only
+    // the leading order-bys have a corresponding cursor value.
+    size_t count = std::min<size_t>(order_bys_.size(), position.values_count);
+    for (size_t i = 0; i < count; ++i) {
       const auto& order_by = order_bys_[i];
       if (order_by.field() == segment.field_path()) {
-        auto cursor_value = bound.value().position()->values[i];
+        auto cursor_value = position.values[i];
         // Decrease segment_value to cursor_value if cursor_value is smaller.
         if (model::UpperBoundCompare(segment_value, segment_inclusive,
                                      cursor_value, bound.value().inclusive()) ==

--- a/Firestore/core/src/core/target.cc
+++ b/Firestore/core/src/core/target.cc
@@ -252,7 +252,7 @@ Target::IndexBoundValue Target::GetAscendingBound(
   // If there is an additional bound, compare the values against the existing
   // range to see if we can narrow the scope.
   if (bound.has_value()) {
-    auto position = bound.value().position();
+    const auto& position = bound.value().position();
     // A cursor may have fewer components than the target has order-bys; only
     // the leading order-bys have a corresponding cursor value.
     size_t count = std::min<size_t>(order_bys_.size(), position->values_count);
@@ -321,7 +321,7 @@ Target::IndexBoundValue Target::GetDescendingBound(
   // If there is an additional bound, compare the values against the existing
   // range to see if we can narrow the scope.
   if (bound.has_value()) {
-    auto position = bound.value().position();
+    const auto& position = bound.value().position();
     // A cursor may have fewer components than the target has order-bys; only
     // the leading order-bys have a corresponding cursor value.
     size_t count = std::min<size_t>(order_bys_.size(), position->values_count);

--- a/Firestore/core/src/core/target.cc
+++ b/Firestore/core/src/core/target.cc
@@ -252,14 +252,14 @@ Target::IndexBoundValue Target::GetAscendingBound(
   // If there is an additional bound, compare the values against the existing
   // range to see if we can narrow the scope.
   if (bound.has_value()) {
-    const auto& position = *bound.value().position();
+    auto position = bound.value().position();
     // A cursor may have fewer components than the target has order-bys; only
     // the leading order-bys have a corresponding cursor value.
-    size_t count = std::min<size_t>(order_bys_.size(), position.values_count);
+    size_t count = std::min<size_t>(order_bys_.size(), position->values_count);
     for (size_t i = 0; i < count; ++i) {
       const auto& order_by = order_bys_[i];
       if (order_by.field() == segment.field_path()) {
-        auto cursor_value = position.values[i];
+        auto cursor_value = position->values[i];
         // Increase segment_value to cursor_value if cursor_value is larger.
         if (model::LowerBoundCompare(segment_value, segment_inclusive,
                                      cursor_value, bound.value().inclusive()) ==
@@ -321,14 +321,14 @@ Target::IndexBoundValue Target::GetDescendingBound(
   // If there is an additional bound, compare the values against the existing
   // range to see if we can narrow the scope.
   if (bound.has_value()) {
-    const auto& position = *bound.value().position();
+    auto position = bound.value().position();
     // A cursor may have fewer components than the target has order-bys; only
     // the leading order-bys have a corresponding cursor value.
-    size_t count = std::min<size_t>(order_bys_.size(), position.values_count);
+    size_t count = std::min<size_t>(order_bys_.size(), position->values_count);
     for (size_t i = 0; i < count; ++i) {
       const auto& order_by = order_bys_[i];
       if (order_by.field() == segment.field_path()) {
-        auto cursor_value = position.values[i];
+        auto cursor_value = position->values[i];
         // Decrease segment_value to cursor_value if cursor_value is smaller.
         if (model::UpperBoundCompare(segment_value, segment_inclusive,
                                      cursor_value, bound.value().inclusive()) ==

--- a/Firestore/core/test/unit/core/target_test.cc
+++ b/Firestore/core/test/unit/core/target_test.cc
@@ -279,6 +279,33 @@ TEST(TargetTest, StartAfterDoesNotChangeBoundIfNotApplicable) {
   VerifyBound(upper_bound, false, {*BlobValue(), *Value("b2")});
 }
 
+TEST(TargetTest, StartingAtWithFewerValuesThanOrderBys) {
+  // A cursor is allowed to have fewer components than the target has order-bys.
+  Target target = Query("c")
+                      .AddingOrderBy(OrderBy("a"))
+                      .AddingOrderBy(OrderBy("b"))
+                      .StartingAt(Bound::FromValue(Array("a1"), true))
+                      .ToTarget();
+  FieldIndex index = MakeFieldIndex("c", "a", Segment::Kind::kAscending, "b",
+                                    Segment::Kind::kAscending);
+
+  auto lower_bound = target.GetLowerBound(index);
+  VerifyBound(lower_bound, true, {*Value("a1"), model::MinValue()});
+}
+
+TEST(TargetTest, EndingAtWithFewerValuesThanOrderBys) {
+  Target target = Query("c")
+                      .AddingOrderBy(OrderBy("a"))
+                      .AddingOrderBy(OrderBy("b"))
+                      .EndingAt(Bound::FromValue(Array("a1"), true))
+                      .ToTarget();
+  FieldIndex index = MakeFieldIndex("c", "a", Segment::Kind::kAscending, "b",
+                                    Segment::Kind::kAscending);
+
+  auto upper_bound = target.GetUpperBound(index);
+  VerifyBound(upper_bound, true, {*Value("a1"), model::MaxValue()});
+}
+
 TEST(TargetTest, EndingAtQueryBound) {
   Target target = Query("c")
                       .AddingOrderBy(OrderBy("foo"))


### PR DESCRIPTION
GetAscendingBound and GetDescendingBound walk `order_bys_` but index the cursor's `position()->values` array with the same counter, and a cursor is allowed to carry fewer components than the query has order-bys, so `query.orderBy("a").orderBy("b").startAt(["a1"])` served by an index on (a asc, b asc) reads one `google_firestore_v1_Value` past the end of that array. The garbage struct goes straight into LowerBoundCompare/UpperBoundCompare, which dereferences whichever union member its uninitialized `which_value_type` selects; in a debug build it trips the `Invalid type value: 0` assertion in GetTypeOrder, and otherwise the value can end up in the returned bound. Everywhere else that reads a cursor iterates `values_count` instead (Bound::CompareToDocument even asserts `values_count <= order_by.size()`), so this clamps the two loops the same way and adds regression tests for both bound directions.