### PR TITLE
test(functions): address PR feedback and fix test timeouts

### DIFF
--- a/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseFunctions/Tests/Integration/IntegrationTests.swift
@@ -102,6 +102,7 @@ class IntegrationTests: XCTestCase {
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
       function.call(data) { result in
+        defer { expectation.fulfill() }
         do {
           let response = try result.get()
           let expected = DataTestResponse(
@@ -113,7 +114,6 @@ class IntegrationTests: XCTestCase {
         } catch {
           XCTFail("Failed to unwrap the function result: \(error)")
         }
-        expectation.fulfill()
       }
       waitForExpectations(timeout: 10)
     }
@@ -161,13 +161,13 @@ class IntegrationTests: XCTestCase {
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
       function.call(17) { result in
+        defer { expectation.fulfill() }
         do {
           let response = try result.get()
           XCTAssertEqual(response, 76)
         } catch {
           XCTAssert(false, "Failed to unwrap the function result: \(error)")
         }
-        expectation.fulfill()
       }
       waitForExpectations(timeout: 10)
     }
@@ -226,13 +226,13 @@ class IntegrationTests: XCTestCase {
       let expectation = expectation(description: #function)
       XCTAssertNotNil(function)
       function.call([:]) { result in
+        defer { expectation.fulfill() }
         do {
           let data = try result.get()
           XCTAssertEqual(data, [:])
         } catch {
           XCTAssert(false, "Failed to unwrap the function result: \(error)")
         }
-        expectation.fulfill()
       }
       waitForExpectations(timeout: 10)
     }
@@ -281,13 +281,13 @@ class IntegrationTests: XCTestCase {
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
       function.call([:]) { result in
+        defer { expectation.fulfill() }
         do {
           let data = try result.get()
           XCTAssertEqual(data, [:])
         } catch {
           XCTAssert(false, "Failed to unwrap the function result: \(error)")
         }
-        expectation.fulfill()
       }
       waitForExpectations(timeout: 10)
     }
@@ -325,13 +325,13 @@ class IntegrationTests: XCTestCase {
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
       function.call(nil) { result in
+        defer { expectation.fulfill() }
         do {
           let data = try result.get()
           XCTAssertEqual(data, nil)
         } catch {
           XCTAssert(false, "Failed to unwrap the function result: \(error)")
         }
-        expectation.fulfill()
       }
       waitForExpectations(timeout: 10)
     }
@@ -369,13 +369,13 @@ class IntegrationTests: XCTestCase {
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
       function.call(nil) { result in
+        defer { expectation.fulfill() }
         do {
           _ = try result.get()
         } catch {
           let error = error as NSError
           XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
           XCTAssertEqual("Response is missing data field.", error.localizedDescription)
-          expectation.fulfill()
           return
         }
         XCTFail("Failed to throw error for missing result")
@@ -422,13 +422,13 @@ class IntegrationTests: XCTestCase {
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
       function.call([]) { result in
+        defer { expectation.fulfill() }
         do {
           _ = try result.get()
         } catch {
           let error = error as NSError
           XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
           XCTAssertEqual("INTERNAL", error.localizedDescription)
-          expectation.fulfill()
           return
         }
         XCTFail("Failed to throw error for missing result")
@@ -475,13 +475,13 @@ class IntegrationTests: XCTestCase {
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
       function.call([]) { result in
+        defer { expectation.fulfill() }
         do {
           _ = try result.get()
         } catch {
           let error = error as NSError
           XCTAssertEqual(FunctionsErrorCode.internal.rawValue, error.code)
           XCTAssertEqual("INTERNAL", error.localizedDescription)
-          expectation.fulfill()
           return
         }
         XCTFail("Failed to throw error for missing result")
@@ -527,6 +527,7 @@ class IntegrationTests: XCTestCase {
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
       function.call([]) { result in
+        defer { expectation.fulfill() }
         do {
           _ = try result.get()
         } catch {
@@ -535,7 +536,6 @@ class IntegrationTests: XCTestCase {
           XCTAssertEqual("explicit nope", error.localizedDescription)
           XCTAssertEqual(["start": 10 as Int32, "end": 20 as Int32, "long": 30],
                          error.userInfo["details"] as? [String: Int32])
-          expectation.fulfill()
           return
         }
         XCTFail("Failed to throw error for missing result")
@@ -584,12 +584,12 @@ class IntegrationTests: XCTestCase {
       let expectation = expectation(description: #function)
       XCTAssertNotNil(function)
       function.call([]) { result in
+        defer { expectation.fulfill() }
         do {
           _ = try result.get()
         } catch {
           let error = error as NSError
           XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code)
-          expectation.fulfill()
           return
         }
         XCTFail("Failed to throw error for missing result")
@@ -635,13 +635,13 @@ class IntegrationTests: XCTestCase {
       let expectation = expectation(description: #function)
       XCTAssertNotNil(function)
       function.call([]) { result in
+        defer { expectation.fulfill() }
         do {
           _ = try result.get()
         } catch {
           let error = error as NSError
           XCTAssertEqual(FunctionsErrorCode.invalidArgument.rawValue, error.code)
           XCTAssertEqual(error.localizedDescription, "Invalid test requested.")
-          expectation.fulfill()
           return
         }
         XCTFail("Failed to throw error for missing result")
@@ -688,6 +688,7 @@ class IntegrationTests: XCTestCase {
       let expectation = expectation(description: #function)
       function.timeoutInterval = 0.05
       function.call([]) { result in
+        defer { expectation.fulfill() }
         do {
           _ = try result.get()
         } catch {
@@ -695,7 +696,6 @@ class IntegrationTests: XCTestCase {
           XCTAssertEqual(FunctionsErrorCode.deadlineExceeded.rawValue, error.code)
           XCTAssertEqual("DEADLINE EXCEEDED", error.localizedDescription)
           XCTAssertNil(error.userInfo["details"])
-          expectation.fulfill()
           return
         }
         XCTFail("Failed to throw error for missing result")
@@ -748,6 +748,7 @@ class IntegrationTests: XCTestCase {
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
       function(data) { result in
+        defer { expectation.fulfill() }
         do {
           let response = try result.get()
           let expected = DataTestResponse(
@@ -756,7 +757,6 @@ class IntegrationTests: XCTestCase {
             code: 42
           )
           XCTAssertEqual(response, expected)
-          expectation.fulfill()
         } catch {
           XCTAssert(false, "Failed to unwrap the function result: \(error)")
         }
@@ -810,6 +810,7 @@ class IntegrationTests: XCTestCase {
     for function in [byName, byURL] {
       let expectation = expectation(description: #function)
       function(data) { result in
+        defer { expectation.fulfill() }
         do {
           let response = try result.get()
           let expected = DataTestResponse(
@@ -818,7 +819,6 @@ class IntegrationTests: XCTestCase {
             code: 42
           )
           XCTAssertEqual(response, expected)
-          expectation.fulfill()
         } catch {
           XCTAssert(false, "Failed to unwrap the function result: \(error)")
         }
@@ -860,11 +860,11 @@ class IntegrationTests: XCTestCase {
       requestAs: Int16.self,
       responseAs: Int.self
     ).call(17) { result in
+      defer { expectation.fulfill() }
       guard case .success = result else {
         return XCTFail("Unexpected failure.")
       }
       XCTAssert(Thread.isMainThread)
-      expectation.fulfill()
     }
     waitForExpectations(timeout: 10)
   }
@@ -876,11 +876,11 @@ class IntegrationTests: XCTestCase {
       requestAs: [Int].self,
       responseAs: Int.self
     ).call([]) { result in
+      defer { expectation.fulfill() }
       guard case .failure = result else {
         return XCTFail("Unexpected failure.")
       }
       XCTAssert(Thread.isMainThread)
-      expectation.fulfill()
     }
     waitForExpectations(timeout: 10)
   }

--- a/FirebaseFunctions/Tests/Unit/FunctionsStreamTests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsStreamTests.swift
@@ -17,8 +17,7 @@ import XCTest
 
 @testable import FirebaseFunctions
 
-#if !os(watchOS)
-  @available(macOS 12.0, iOS 15.0, tvOS 15.0, *)
+  @available(macOS 12.0, watchOS 8.0, *)
   class FunctionsStreamTests: XCTestCase {
     private struct EmptyRequest: Encodable, Sendable {}
 
@@ -157,5 +156,4 @@ import XCTest
         XCTFail("Stream threw unexpected error type: \(error)")
       }
     }
-  }
-#endif
+

--- a/agents.md
+++ b/agents.md
@@ -1,8 +1,9 @@
 # agents.md - Context for AI Assisted Development
 
-This file highlights key aspects of the development environment, coding practices, and
-architectural patterns covered in this repo. When an agents.md file is present in a product's
-subdirectory, prefer using the workflow defined there.
+This file highlights key aspects of the development environment, coding
+practices, and architectural patterns covered in this repo. When an agents.md
+file is present in a product's subdirectory, prefer using the workflow defined
+there.
 
 ## Setup Commands
 
@@ -104,6 +105,10 @@ Thorough testing is essential for maintaining the quality and stability of the F
     *   When adding a new feature, include tests to validate the new or modified APIs.
 *   **Tests as Documentation**: Well-written tests can serve as examples of how to use an API.
 *   **Code Coverage**: Aim for good code coverage to ensure all critical paths are tested.
+*   **Preventing Timeout Masking in Tests**: When using `waitForExpectations(timeout:)`
+    in XCTest, always ensure `expectation.fulfill()` is called (e.g., via `defer`)
+    even if the test fails inside a callback. Otherwise, failures will manifest
+    as obscure 10-second timeouts instead of clear, actionable error messages.
 
 ### Running Tests
 


### PR DESCRIPTION
- Refactored IntegrationTests.swift to use 'defer { expectation.fulfill() }' so that test failures correctly trigger XCTFail instead of causing obscure 10-second timeouts.
- Updated FunctionsStreamTests availability to macOS 12.0 and watchOS 8.0, and removed '#if !os(watchOS)' to resolve watchOS test failures.
- Wrapped agents.md intro to 80 chars and added a learning about preventing timeout masking in XCTest.

#no-changelog