### PR TITLE
require a terminator within maxlen in FIRCLSReadString

### DIFF
--- a/Crashlytics/Crashlytics/Helpers/FIRCLSUtility.m
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSUtility.m
@@ -90,13 +90,15 @@ bool FIRCLSReadString(vm_address_t src, char** dest, size_t maxlen) {
     }
 
     if (c == 0) {
-      break;
+      *dest = (char*)src;
+
+      return true;
     }
   }
 
-  *dest = (char*)src;
-
-  return true;
+  // Only maxlen bytes have been checked, so a string without a terminator in
+  // that range cannot be handed back - callers walk it with strlen/strchr.
+  return false;
 }
 
 const char* FIRCLSDupString(const char* string) {

--- a/Crashlytics/UnitTests/FIRCLSUtilityTests.m
+++ b/Crashlytics/UnitTests/FIRCLSUtilityTests.m
@@ -77,6 +77,28 @@
   XCTAssertEqualObjects([NSString stringWithUTF8String:string], @"52d04e1f", @"");
 }
 
+- (void)testReadStringWithTerminatorInRange {
+  char buffer[64];
+  memset(buffer, 'a', sizeof(buffer));
+  buffer[31] = 0;
+
+  char *string = NULL;
+
+  XCTAssertTrue(FIRCLSReadString((vm_address_t)buffer, &string, 32));
+  XCTAssertEqual(string, (char *)buffer);
+  XCTAssertEqual(strlen(string), (size_t)31);
+}
+
+- (void)testReadStringWithoutTerminatorInRange {
+  char buffer[64];
+  memset(buffer, 'a', sizeof(buffer));
+  buffer[63] = 0;
+
+  char *string = NULL;
+
+  XCTAssertFalse(FIRCLSReadString((vm_address_t)buffer, &string, 32));
+}
+
 - (void)testRedactUUID {
   // Define a local struct to hold the test data
   struct TestCase {


### PR DESCRIPTION
FIRCLSReadString probes at most maxlen bytes to prove an address points at a readable, terminated string, but when no terminator turns up in that window it still falls through to `*dest = src; return true`. It never copies, so the caller gets a pointer it believes is terminated while only maxlen bytes were actually checked. All three call sites in FIRCLSProcess.c then walk it without a bound: the Swift crash_info message (maxlen 256) goes to FIRCLSRedactUUID, which strchrs past the window and writes '*' bytes into it, and then to FIRCLSFileWriteArrayEntryHexEncodedString, which strlens it, so a fatal-error annotation longer than 256 bytes gets neighbouring library memory hex-encoded into the report, or faults inside the handler and costs us the whole report. Moving the success return into the terminator branch keeps the contract the callers already rely on.