### PR TITLE
fix(ai): fix 12.17 changelog entry

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,16 +1,15 @@
 # 12.17.0
 - [fixed] Fixed a stream leak in the Live API where the WebSocket connection
   would remain open indefinitely if the consumer cancelled the stream. (#16393)
-
-# 12.16.0
 - [changed] Deprecated `Backend.vertexAI` in favor of `Backend.agentPlatform` to
   reflect the renaming of Vertex AI to Gemini Enterprise Agent Platform.
   (#16372)
-
   Note: The default location is now `global` instead of `us-central1` (no other
   functionality has changed). To continue using `us-central1`, specify
   `FirebaseAI.firebaseAI(backend: .agentPlatform(location: "us-central1"))` when
   initializing the SDK.
+
+# 12.16.0
 - [fixed] Fixed a decoding failure in `GenerateContentResponse` when the Vertex AI
   backend returns citation metadata with a missing `endIndex`. (#16328)
 - [fixed] Fixed an issue where `generateContentStream` could stall indefinitely


### PR DESCRIPTION
Move `agentPlatform` changelog entry from 12.16 to 12.17 release notes. Context: https://github.com/firebase/firebase-ios-sdk/commit/6b581ae875d66b93896d8e24b1d002f5bbae0e29#diff-1c19474472c2207ac937331bb0366b99ab8211f5be5622b04335781523faf78c