### PR TITLE
Run codeQL for Swift code

### DIFF
--- a/.github/workflows/infra.spm_global.yml
+++ b/.github/workflows/infra.spm_global.yml
@@ -216,7 +216,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@3b0bd1d116c0bde30213346b22d4f634d96a2fb0 # v3
       with:
         languages: ${{ matrix.language }}
     - uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
@@ -238,6 +238,6 @@ jobs:
     - name: Build for CodeQL
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@3b0bd1d116c0bde30213346b22d4f634d96a2fb0 # v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/infra.spm_global.yml
+++ b/.github/workflows/infra.spm_global.yml
@@ -216,7 +216,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@3b0bd1d116c0bde30213346b22d4f634d96a2fb0 # v3
+      uses: github/codeql-action/init@adfda868f108ac4222129de456ea554034a27db7 # v4
       with:
         languages: ${{ matrix.language }}
     - uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
@@ -238,6 +238,6 @@ jobs:
     - name: Build for CodeQL
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@3b0bd1d116c0bde30213346b22d4f634d96a2fb0 # v3
+      uses: github/codeql-action/analyze@adfda868f108ac4222129de456ea554034a27db7 # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/infra.spm_global.yml
+++ b/.github/workflows/infra.spm_global.yml
@@ -197,3 +197,47 @@ jobs:
         name: spm-platforms-${{ matrix.target }}-${{ matrix.os }}-${{ matrix.xcode }}-logs
         path: xcodebuild-*.log
         if-no-files-found: error
+
+  codeql-analysis:
+    # Don't run on private repo unless it is a PR.
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    needs: [spm-package-resolved]
+    runs-on: macos-26
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'swift' ]
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        persist-credentials: false
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+    - uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      with:
+        path: .build
+        key: ${{needs.spm-package-resolved.outputs.cache_key}}
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
+    - name: Install simulators in case they are missing.
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        timeout_minutes: 15
+        max_attempts: 5
+        retry_wait_seconds: 120
+        continue_on_error: true
+        command: xcodebuild -downloadPlatform iOS
+    - name: Initialize xcodebuild
+      run: scripts/setup_spm_tests.sh
+    - name: Build for CodeQL
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/scripts/run_codeql_locally.sh
+++ b/scripts/run_codeql_locally.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+# Make sure CodeQL CLI is installed and in your PATH
+if ! command -v codeql &> /dev/null; then
+    echo "CodeQL CLI could not be found."
+    echo "Please download it from: https://github.com/github/codeql-cli-binaries/releases"
+    echo "And add it to your PATH."
+    exit 1
+fi
+
+DB_DIR="codeql-db-swift"
+RESULTS_FILE="codeql-results.sarif"
+
+echo "🧹 Cleaning up previous CodeQL databases..."
+rm -rf "$DB_DIR"
+rm -f "$RESULTS_FILE"
+
+echo "🏗️ Initializing CodeQL database and running build..."
+# We use the exact same build command that was added to the GitHub Action
+codeql database create "$DB_DIR" \
+    --language=swift \
+    --command="scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly"
+
+echo "🔍 Downloading Swift query pack..."
+codeql pack download codeql/swift-queries
+
+echo "🔍 Analyzing the database..."
+# Run the standard default queries for Swift using the official query pack
+codeql database analyze "$DB_DIR" codeql/swift-queries \
+    --format=sarif-latest \
+    --output="$RESULTS_FILE"
+
+echo "✅ CodeQL analysis complete! Results have been saved to $RESULTS_FILE"

--- a/scripts/run_codeql_locally.sh
+++ b/scripts/run_codeql_locally.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # Make sure CodeQL CLI is installed and in your PATH
 if ! command -v codeql &> /dev/null; then
@@ -17,13 +17,13 @@ rm -rf "$DB_DIR"
 rm -f "$RESULTS_FILE"
 
 echo "🏗️ Initializing CodeQL database and running build..."
-# We use the exact same build command that was added to the GitHub Action
+# We use the build command directly without the Travis retry script for faster local feedback
 codeql database create "$DB_DIR" \
     --language=swift \
-    --command="scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS-device spmbuildonly"
+    --command="./scripts/build.sh Firebase-Package iOS-device spmbuildonly"
 
 echo "🔍 Downloading Swift query pack..."
-codeql pack download codeql/swift-queries
+codeql pack download codeql/swift-queries || echo "⚠️ Warning: Failed to download/update Swift query pack. Proceeding with cached version if available..."
 
 echo "🔍 Analyzing the database..."
 # Run the standard default queries for Swift using the official query pack

--- a/scripts/run_codeql_locally.sh
+++ b/scripts/run_codeql_locally.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euo pipefail
+
+# Ensure we are in the repository root so relative paths work correctly
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 # Make sure CodeQL CLI is installed and in your PATH
 if ! command -v codeql &> /dev/null; then


### PR DESCRIPTION
## Description
This PR introduces CodeQL Static Application Security Testing (SAST) for Swift to both the CI pipeline and local development environments. CodeQL requires explicit build tracing for compiled languages like Swift, which often causes default organization-level auto-build setups to fail on iOS SDKs.
This update resolves that by explicitly dictating the Xcode build environment and SPM build commands for CodeQL to trace.
### Changes Made
**1. CI Workflow Updates (`.github/workflows/infra.spm_global.yml`)**
* Added a new `codeql-analysis` job at the end of the global SPM workflow.
* Initializes the `github/codeql-action` specifically for the `swift` language matrix.
* Mirrors the environment setup from the existing `iOS-Device` job (restoring SPM caches, setting Xcode version, downloading iOS simulators).
* Traces the build using `scripts/build.sh Firebase-Package iOS-device spmbuildonly` so the CodeQL extractor can build the relational database.
* Analyzes the database and automatically uploads the SARIF results to the repository's Security tab.
**2. Local Tooling (`scripts/run_codeql_locally.sh`)**
* Created a new bash script to allow developers to run the exact same CodeQL analysis locally.
* The script automatically handles:
  * Cleaning up previous local databases.
  * Creating the database by tracing the identical build command used in CI.
  * Fetching the `codeql/swift-queries` pack to ensure parity with GitHub Actions.
  * Running the local analysis and outputting a `codeql-results.sarif` file for local review.
## Testing
* **CI Verification**: The GitHub Action job successfully builds the package and extracts the AST for ~460+ production Swift files.
* **Local Verification**: `run_codeql_locally.sh` successfully produces a SARIF file matching the CI behavior without requiring commits to test rule changes.