### PR TITLE
require a local write time in IsServerTimestamp

### DIFF
--- a/Firestore/core/src/model/server_timestamp_util.cc
+++ b/Firestore/core/src/model/server_timestamp_util.cc
@@ -83,18 +83,29 @@ bool IsServerTimestamp(const google_firestore_v1_Value& value) {
     return false;
   }
 
+  // A server timestamp is only produced internally by `EncodeServerTimestamp`,
+  // which always writes both the `__type__` sentinel and a `__local_write_time__`
+  // timestamp. An ordinary user map can legitimately carry a `__type__:
+  // "server_timestamp"` string field on its own, so classifying on the sentinel
+  // alone misreads that user data as a server timestamp and later aborts in
+  // `GetLocalWriteTime` when the write time it assumes is missing.
+  bool has_sentinel = false;
+  bool has_local_write_time = false;
   for (size_t i = 0; i < value.map_value.fields_count; ++i) {
     const auto& field = value.map_value.fields[i];
     absl::string_view key = nanopb::MakeStringView(field.key);
     if (key == kTypeKey) {
-      return field.value.which_value_type ==
-                 google_firestore_v1_Value_string_value_tag &&
-             nanopb::MakeStringView(field.value.string_value) ==
-                 kServerTimestampSentinel;
+      has_sentinel = field.value.which_value_type ==
+                         google_firestore_v1_Value_string_value_tag &&
+                     nanopb::MakeStringView(field.value.string_value) ==
+                         kServerTimestampSentinel;
+    } else if (key == kLocalWriteTimeKey) {
+      has_local_write_time = field.value.which_value_type ==
+                             google_firestore_v1_Value_timestamp_value_tag;
     }
   }
 
-  return false;
+  return has_sentinel && has_local_write_time;
 }
 
 google_protobuf_Timestamp GetLocalWriteTime(

--- a/Firestore/core/test/unit/model/value_util_test.cc
+++ b/Firestore/core/test/unit/model/value_util_test.cc
@@ -186,6 +186,24 @@ TEST(FieldValueTest, ValueHelpers) {
   EXPECT_EQ(double_value->double_value, 2.0);
 }
 
+TEST(FieldValueTest, ServerTimestampSentinelRequiresLocalWriteTime) {
+  // A genuine server timestamp always carries both the sentinel and a write
+  // time, so it still classifies as a server timestamp.
+  auto server_timestamp = EncodeServerTimestamp(kTimestamp1, absl::nullopt);
+  EXPECT_EQ(GetTypeOrder(*server_timestamp), TypeOrder::kServerTimestamp);
+
+  // A user map that only happens to contain the sentinel key is ordinary data
+  // and must be treated as a map. Classifying it as a server timestamp would
+  // route it to GetLocalWriteTime, which aborts when the write time is absent.
+  auto user_map = Map("__type__", "server_timestamp");
+  EXPECT_EQ(GetTypeOrder(*user_map), TypeOrder::kMap);
+  EXPECT_EQ(Compare(*user_map, *user_map), ComparisonResult::Same);
+
+  auto with_wrong_write_time =
+      Map("__type__", "server_timestamp", "__local_write_time__", "not a time");
+  EXPECT_EQ(GetTypeOrder(*with_wrong_write_time), TypeOrder::kMap);
+}
+
 #if __APPLE__
 // Validates that NSNumber/CFNumber normalize NaNs to the same values that
 // Firestore does. This uses CoreFoundation's CFNumber instead of NSNumber just


### PR DESCRIPTION
IsServerTimestamp classifies any small map holding `__type__: "server_timestamp"` as a server timestamp sentinel, looking only at the `__type__` key. A real sentinel is only produced by EncodeServerTimestamp, which also writes a `__local_write_time__` timestamp, but an ordinary document field a client writes can carry that same key on its own. When such a value is read back and compared, GetTypeOrder routes it to TypeOrder::kServerTimestamp and Compare/Equals call GetLocalWriteTime, which HARD_FAILs because the write time it assumes is missing. Require both the sentinel and a timestamp-typed `__local_write_time__` before classifying the value, so those user maps stay maps while genuine sentinels are unaffected.