### PR TITLE
feat(ai): add support for RealtimeInputConfig

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
-- [feature] Added support for `RealtimeInputConfig` in `LiveGenerationConfig`. (#TODO)
+- [feature] Added support for `RealtimeInputConfig` in `LiveGenerationConfig`. (#16441)
 - [feature] Added support for `sendStartActivityRealtime` and `sendStopActivityRealtime`
-  in `LiveSession`. (#TODO)
+  in `LiveSession`. (#16441)
 
 # 12.16.0
 - [changed] Deprecated `Backend.vertexAI` in favor of `Backend.agentPlatform` to

--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [feature] Added support for `RealtimeInputConfig` in `LiveGenerationConfig`. (#TODO)
+- [feature] Added support for `sendStartActivityRealtime` and `sendStopActivityRealtime`
+  in `LiveSession`. (#TODO)
+
 # 12.16.0
 - [changed] Deprecated `Backend.vertexAI` in favor of `Backend.agentPlatform` to
   reflect the renaming of Vertex AI to Gemini Enterprise Agent Platform.

--- a/FirebaseAI/Sources/Types/Internal/Live/BidiActivityDetectionConfig.swift
+++ b/FirebaseAI/Sources/Types/Internal/Live/BidiActivityDetectionConfig.swift
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+struct BidiActivityDetectionConfig: Encodable, Sendable {
+  enum StartSensitivity: String, Encodable {
+    case unspecified = "START_SENSITIVITY_UNSPECIFIED"
+    case high = "START_SENSITIVITY_HIGH"
+    case low = "START_SENSITIVITY_LOW"
+  }
+
+  enum EndSensitivity: String, Encodable {
+    case unspecified = "END_SENSITIVITY_UNSPECIFIED"
+    case high = "END_SENSITIVITY_HIGH"
+    case low = "END_SENSITIVITY_LOW"
+  }
+
+  let startOfSpeechSensitivity: StartSensitivity?
+  let endOfSpeechSensitivity: EndSensitivity?
+  let prefixPaddingMs: Int32?
+  let silenceDurationMs: Int32?
+  let disabled: Bool?
+
+  init(startOfSpeechSensitivity: StartSensitivity? = nil,
+       endOfSpeechSensitivity: EndSensitivity? = nil, prefixPaddingMs: Int32? = nil,
+       silenceDurationMs: Int32? = nil, disabled: Bool? = nil) {
+    self.startOfSpeechSensitivity = startOfSpeechSensitivity
+    self.endOfSpeechSensitivity = endOfSpeechSensitivity
+    self.prefixPaddingMs = prefixPaddingMs
+    self.silenceDurationMs = silenceDurationMs
+    self.disabled = disabled
+  }
+}

--- a/FirebaseAI/Sources/Types/Internal/Live/BidiGenerateContentSetup.swift
+++ b/FirebaseAI/Sources/Types/Internal/Live/BidiGenerateContentSetup.swift
@@ -61,6 +61,8 @@ struct BidiGenerateContentSetup: Encodable {
   /// If included, the server will compress the context window to fit the given length.
   let contextWindowCompression: BidiContextWindowCompressionConfig?
 
+  let realtimeInputConfig: BidiRealtimeInputConfig?
+
   init(model: String,
        generationConfig: BidiGenerationConfig? = nil,
        systemInstruction: ModelContent? = nil,
@@ -69,7 +71,8 @@ struct BidiGenerateContentSetup: Encodable {
        inputAudioTranscription: BidiAudioTranscriptionConfig? = nil,
        outputAudioTranscription: BidiAudioTranscriptionConfig? = nil,
        sessionResumption: BidiSessionResumptionConfig? = nil,
-       contextWindowCompression: BidiContextWindowCompressionConfig? = nil) {
+       contextWindowCompression: BidiContextWindowCompressionConfig? = nil,
+       realtimeInputConfig: BidiRealtimeInputConfig? = nil) {
     self.model = model
     self.generationConfig = generationConfig
     self.systemInstruction = systemInstruction
@@ -79,6 +82,7 @@ struct BidiGenerateContentSetup: Encodable {
     self.outputAudioTranscription = outputAudioTranscription
     self.sessionResumption = sessionResumption
     self.contextWindowCompression = contextWindowCompression
+    self.realtimeInputConfig = realtimeInputConfig
   }
 }
 

--- a/FirebaseAI/Sources/Types/Internal/Live/BidiRealtimeInputConfig.swift
+++ b/FirebaseAI/Sources/Types/Internal/Live/BidiRealtimeInputConfig.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+struct BidiRealtimeInputConfig: Encodable, Sendable {
+  enum TurnCoverage: String, Encodable {
+    case unspecified = "TURN_COVERAGE_UNSPECIFIED"
+    case onlyActivity = "TURN_INCLUDES_ONLY_ACTIVITY"
+    case allInput = "TURN_INCLUDES_ALL_INPUT"
+    case audioActivityAndAllVideo = "TURN_INCLUDES_AUDIO_ACTIVITY_AND_ALL_VIDEO"
+  }
+
+  enum ActivityHandling: String, Encodable {
+    case unspecified = "ACTIVITY_HANDLING_UNSPECIFIED"
+    case startOfInterrupts = "START_OF_ACTIVITY_INTERRUPTS"
+    case noInterruption = "NO_INTERRUPTION"
+  }
+
+  let automaticActivityDetection: BidiActivityDetectionConfig?
+  let activityHandling: ActivityHandling?
+  let turnCoverage: TurnCoverage?
+
+  init(automaticActivityDetection: BidiActivityDetectionConfig? = nil,
+       activityHandling: ActivityHandling? = nil, turnCoverage: TurnCoverage? = nil) {
+    self.automaticActivityDetection = automaticActivityDetection
+    self.activityHandling = activityHandling
+    self.turnCoverage = turnCoverage
+  }
+}

--- a/FirebaseAI/Sources/Types/Internal/Live/LiveSessionService.swift
+++ b/FirebaseAI/Sources/Types/Internal/Live/LiveSessionService.swift
@@ -157,7 +157,8 @@ actor LiveSessionService {
         inputAudioTranscription: generationConfig?.inputAudioTranscription,
         outputAudioTranscription: generationConfig?.outputAudioTranscription,
         sessionResumption: sessionResumption?.bidiSessionResumptionConfig,
-        contextWindowCompression: generationConfig?.contextWindowCompression
+        contextWindowCompression: generationConfig?.contextWindowCompression,
+        realtimeInputConfig: generationConfig?.realtimeInputConfig
       )
       let data = try jsonEncoder.encode(BidiGenerateContentClientMessage.setup(setup))
       try await webSocket.send(.data(data))

--- a/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
@@ -16,11 +16,15 @@ import Foundation
 
 /// Configures the model's automatic detection of user activity.
 ///
+/// **Public Preview**: This API is a public preview and may be subject to change.
+///
 ///  - seealso: ``RealtimeInputConfig``
 public struct ActivityDetectionConfig: Sendable {
   let bidiActivitiyDetectionConfig: BidiActivityDetectionConfig
 
   /// How sensitive the model interprets speech activity.
+  ///
+  /// **Public Preview**: This API is a public preview and may be subject to change.
   public enum Sensitivity: Sendable {
     /// The model will detect speech less often.
     ///

--- a/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
@@ -94,7 +94,7 @@ public struct ActivityDetectionConfig: Sendable {
   ///     activity but this will increase the model's latency.
   ///  - seealso: ``ActivityDetectionConfig/init(startSensitivity:endSensitivity:prefixPadding:silenceDuration:)-(_,_,TimeInterval?,_)``
   ///  - seealso: ``ActivityDetectionConfig/disabled()``
-  @available(iOS 16.0, macOS 13.0, *)
+  @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
   public init(startSensitivity: Sensitivity? = nil,
               endSensitivity: Sensitivity? = nil,
               prefixPadding: Duration? = nil,
@@ -148,7 +148,7 @@ private extension TimeInterval {
   }
 }
 
-@available(iOS 16.0, macOS 13.0, *)
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 private extension Duration {
   var milliseconds: Int32 {
     return Int32(self / .milliseconds(1))

--- a/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
@@ -1,0 +1,147 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Configures the model's automatic detection of user activity.
+///
+///  - seealso: ``RealtimeInputConfig``
+public struct ActivityDetectionConfig: Sendable {
+  let bidiActivitiyDetectionConfig: BidiActivityDetectionConfig
+
+  /// How sensitive the model interprets speech activity.
+  public enum Sensitivity: Sendable {
+    /// The model will detect speech less often.
+    ///
+    /// In other words, a higher volume of speech is required for the model
+    /// to consider the user is speaking.
+    case low
+
+    /// The model will detect speech more often.
+    ///
+    /// In other words, a lower volume of speech is required for the model
+    /// to consider the user is speaking.
+    case high
+  }
+
+  init(_ bidiActivityDetectionConfig: BidiActivityDetectionConfig) {
+    bidiActivitiyDetectionConfig = bidiActivityDetectionConfig
+  }
+
+  /// Creates a new ``ActivityDetectionConfig`` value.
+  ///
+  /// - Parameters:
+  ///   - startSensitivity: Determines how likely the start of speech is detected.
+  ///   - endSensitivity: Determines how likely the end of speech is detected.
+  ///   - prefixPadding: How long detected speech should be present before start-of-speech is commited.
+  ///
+  ///     The lower this value, the more sensitive the start-of-speech detection is and the shorter
+  ///     speech can be recognized. However, this also increases the probability of false positives.
+  ///   - silenceDuration: How long silence (or non-speech) should be present before end-of-speech is committed.
+  ///
+  ///     The larger this value, the longer speech gaps can be without interrupting the user's activity
+  ///     but this will increase the model's latency.
+  ///  - seealso: ``ActivityDetectionConfig/init(startSensitivity:endSensitivity:prefixPadding:silenceDuration:)-(_,_,Duration?,_)``
+  ///  - seealso: ``ActivityDetectionConfig/disabled()``
+  public init(startSensitivity: Sensitivity? = nil,
+              endSensitivity: Sensitivity? = nil,
+              prefixPadding: TimeInterval? = nil,
+              silenceDuration: TimeInterval? = nil) {
+    self.init(BidiActivityDetectionConfig(
+      startOfSpeechSensitivity: startSensitivity
+        .map(BidiActivityDetectionConfig.StartSensitivity.init),
+      endOfSpeechSensitivity: endSensitivity.map(BidiActivityDetectionConfig.EndSensitivity.init),
+      prefixPaddingMs: prefixPadding?.milliseconds,
+      silenceDurationMs: silenceDuration?.milliseconds
+    ))
+  }
+
+  /// Creates a new ``ActivityDetectionConfig`` value.
+  ///
+  /// This method uses `Duration` for timing related properties instead of `TimeInterval`. See the "See Also" section for
+  /// the alternative initializer if you don't have access to the `Duration` API.
+  ///
+  /// - Parameters:
+  ///   - startSensitivity: Determines how likely the start of speech is detected.
+  ///   - endSensitivity: Determines how likely the end of speech is detected.
+  ///   - prefixPadding: How long detected speech should be present before start-of-speech is commited.
+  ///
+  ///     The lower this value, the more sensitive the start-of-speech detection is and the shorter
+  ///     speech can be recognized. However, this also increases the probability of false positives.
+  ///   - silenceDuration: How long silence (or non-speech) should be present before end-of-speech is committed.
+  ///
+  ///     The larger this value, the longer speech gaps can be without interrupting the user's activity
+  ///     but this will increase the model's latency.
+  ///  - seealso: ``ActivityDetectionConfig/init(startSensitivity:endSensitivity:prefixPadding:silenceDuration:)-(_,_,TimeInterval?,_)``
+  ///  - seealso: ``ActivityDetectionConfig/disabled()``
+  @available(iOS 16.0, macOS 13.0, *)
+  public init(startSensitivity: Sensitivity? = nil,
+              endSensitivity: Sensitivity? = nil,
+              prefixPadding: Duration? = nil,
+              silenceDuration: Duration? = nil) {
+    self.init(BidiActivityDetectionConfig(
+      startOfSpeechSensitivity: startSensitivity
+        .map(BidiActivityDetectionConfig.StartSensitivity.init),
+      endOfSpeechSensitivity: endSensitivity.map(BidiActivityDetectionConfig.EndSensitivity.init),
+      prefixPaddingMs: prefixPadding?.milliseconds,
+      silenceDurationMs: silenceDuration?.milliseconds
+    ))
+  }
+
+  /// Disables automatic activity detection.
+  ///
+  /// When automatic activity detection is enabled, the model will interpet detected voices and text
+  /// as the start of activity.
+  ///
+  /// When automatic activity detection is disabled, the user must send activity signals manually.
+  ///
+  ///  - seealso: ``LiveSession/sendStartActivityRealtime()``
+  ///  - seealso: ``LiveSession/sendStopActivityRealtime()``
+  public static func disabled() -> Self {
+    self.init(BidiActivityDetectionConfig(
+      disabled: true
+    ))
+  }
+}
+
+private extension BidiActivityDetectionConfig.StartSensitivity {
+  init(_ sensitivity: ActivityDetectionConfig.Sensitivity) {
+    switch sensitivity {
+    case .low: self = .low
+    case .high: self = .high
+    }
+  }
+}
+
+private extension BidiActivityDetectionConfig.EndSensitivity {
+  init(_ sensitivity: ActivityDetectionConfig.Sensitivity) {
+    switch sensitivity {
+    case .low: self = .low
+    case .high: self = .high
+    }
+  }
+}
+
+private extension TimeInterval {
+  var milliseconds: Int32 {
+    return Int32((self * 1000).rounded())
+  }
+}
+
+@available(iOS 16.0, macOS 13.0, *)
+private extension Duration {
+  var milliseconds: Int32 {
+    return Int32(self / .milliseconds(1))
+  }
+}

--- a/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
@@ -44,14 +44,16 @@ public struct ActivityDetectionConfig: Sendable {
   /// - Parameters:
   ///   - startSensitivity: Determines how likely the start of speech is detected.
   ///   - endSensitivity: Determines how likely the end of speech is detected.
-  ///   - prefixPadding: How long detected speech should be present before start-of-speech is commited.
+  ///   - prefixPadding: How long detected speech should be present before start-of-speech is
+  ///     commited.
   ///
   ///     The lower this value, the more sensitive the start-of-speech detection is and the shorter
   ///     speech can be recognized. However, this also increases the probability of false positives.
-  ///   - silenceDuration: How long silence (or non-speech) should be present before end-of-speech is committed.
+  ///   - silenceDuration: How long silence (or non-speech) should be present before end-of-speech
+  ///     is committed.
   ///
-  ///     The larger this value, the longer speech gaps can be without interrupting the user's activity
-  ///     but this will increase the model's latency.
+  ///     The larger this value, the longer speech gaps can be without interrupting the user's
+  ///     activity but this will increase the model's latency.
   ///  - seealso: ``ActivityDetectionConfig/init(startSensitivity:endSensitivity:prefixPadding:silenceDuration:)-(_,_,Duration?,_)``
   ///  - seealso: ``ActivityDetectionConfig/disabled()``
   public init(startSensitivity: Sensitivity? = nil,
@@ -69,20 +71,23 @@ public struct ActivityDetectionConfig: Sendable {
 
   /// Creates a new ``ActivityDetectionConfig`` value.
   ///
-  /// This method uses `Duration` for timing related properties instead of `TimeInterval`. See the "See Also" section for
+  /// This method uses `Duration` for timing related properties instead of `TimeInterval`. See the
+  /// "See Also" section for
   /// the alternative initializer if you don't have access to the `Duration` API.
   ///
   /// - Parameters:
   ///   - startSensitivity: Determines how likely the start of speech is detected.
   ///   - endSensitivity: Determines how likely the end of speech is detected.
-  ///   - prefixPadding: How long detected speech should be present before start-of-speech is commited.
+  ///   - prefixPadding: How long detected speech should be present before start-of-speech is
+  ///     commited.
   ///
   ///     The lower this value, the more sensitive the start-of-speech detection is and the shorter
   ///     speech can be recognized. However, this also increases the probability of false positives.
-  ///   - silenceDuration: How long silence (or non-speech) should be present before end-of-speech is committed.
+  ///   - silenceDuration: How long silence (or non-speech) should be present before end-of-speech
+  ///     is committed.
   ///
-  ///     The larger this value, the longer speech gaps can be without interrupting the user's activity
-  ///     but this will increase the model's latency.
+  ///     The larger this value, the longer speech gaps can be without interrupting the user's
+  ///     activity but this will increase the model's latency.
   ///  - seealso: ``ActivityDetectionConfig/init(startSensitivity:endSensitivity:prefixPadding:silenceDuration:)-(_,_,TimeInterval?,_)``
   ///  - seealso: ``ActivityDetectionConfig/disabled()``
   @available(iOS 16.0, macOS 13.0, *)

--- a/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
@@ -94,7 +94,7 @@ public struct ActivityDetectionConfig: Sendable {
   ///     activity but this will increase the model's latency.
   ///  - seealso: ``ActivityDetectionConfig/init(startSensitivity:endSensitivity:prefixPadding:silenceDuration:)-(_,_,TimeInterval?,_)``
   ///  - seealso: ``ActivityDetectionConfig/disabled()``
-  @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+  @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
   public init(startSensitivity: Sensitivity? = nil,
               endSensitivity: Sensitivity? = nil,
               prefixPadding: Duration? = nil,
@@ -148,7 +148,7 @@ private extension TimeInterval {
   }
 }
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 private extension Duration {
   var milliseconds: Int32 {
     return Int32(self / .milliseconds(1))

--- a/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
@@ -40,7 +40,7 @@ public struct ActivityDetectionConfig: Sendable {
   }
 
   init(_ bidiActivityDetectionConfig: BidiActivityDetectionConfig) {
-    bidiActivityDetectionConfig = bidiActivityDetectionConfig
+    self.bidiActivityDetectionConfig = bidiActivityDetectionConfig
   }
 
   /// Creates a new ``ActivityDetectionConfig`` value.

--- a/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
@@ -20,7 +20,7 @@ import Foundation
 ///
 ///  - seealso: ``RealtimeInputConfig``
 public struct ActivityDetectionConfig: Sendable {
-  let bidiActivitiyDetectionConfig: BidiActivityDetectionConfig
+  let bidiActivityDetectionConfig: BidiActivityDetectionConfig
 
   /// How sensitive the model interprets speech activity.
   ///
@@ -40,7 +40,7 @@ public struct ActivityDetectionConfig: Sendable {
   }
 
   init(_ bidiActivityDetectionConfig: BidiActivityDetectionConfig) {
-    bidiActivitiyDetectionConfig = bidiActivityDetectionConfig
+    bidiActivityDetectionConfig = bidiActivityDetectionConfig
   }
 
   /// Creates a new ``ActivityDetectionConfig`` value.
@@ -49,7 +49,7 @@ public struct ActivityDetectionConfig: Sendable {
   ///   - startSensitivity: Determines how likely the start of speech is detected.
   ///   - endSensitivity: Determines how likely the end of speech is detected.
   ///   - prefixPadding: How long detected speech should be present before start-of-speech is
-  ///     commited.
+  ///     committed.
   ///
   ///     The lower this value, the more sensitive the start-of-speech detection is and the shorter
   ///     speech can be recognized. However, this also increases the probability of false positives.
@@ -83,7 +83,7 @@ public struct ActivityDetectionConfig: Sendable {
   ///   - startSensitivity: Determines how likely the start of speech is detected.
   ///   - endSensitivity: Determines how likely the end of speech is detected.
   ///   - prefixPadding: How long detected speech should be present before start-of-speech is
-  ///     commited.
+  ///     committed.
   ///
   ///     The lower this value, the more sensitive the start-of-speech detection is and the shorter
   ///     speech can be recognized. However, this also increases the probability of false positives.
@@ -110,7 +110,7 @@ public struct ActivityDetectionConfig: Sendable {
 
   /// Disables automatic activity detection.
   ///
-  /// When automatic activity detection is enabled, the model will interpet detected voices and text
+  /// When automatic activity detection is enabled, the model will interpret detected voices and text
   /// as the start of activity.
   ///
   /// When automatic activity detection is disabled, the user must send activity signals manually.

--- a/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/ActivityDetectionConfig.swift
@@ -110,8 +110,8 @@ public struct ActivityDetectionConfig: Sendable {
 
   /// Disables automatic activity detection.
   ///
-  /// When automatic activity detection is enabled, the model will interpret detected voices and text
-  /// as the start of activity.
+  /// When automatic activity detection is enabled, the model will interpret detected voices and
+  /// text as the start of activity.
   ///
   /// When automatic activity detection is disabled, the user must send activity signals manually.
   ///

--- a/FirebaseAI/Sources/Types/Public/Live/LiveGenerationConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/LiveGenerationConfig.swift
@@ -21,6 +21,7 @@ public struct LiveGenerationConfig: Sendable {
   let inputAudioTranscription: BidiAudioTranscriptionConfig?
   let outputAudioTranscription: BidiAudioTranscriptionConfig?
   let contextWindowCompression: BidiContextWindowCompressionConfig?
+  let realtimeInputConfig: BidiRealtimeInputConfig?
 
   /// Creates a new ``LiveGenerationConfig`` value.
   ///
@@ -123,6 +124,8 @@ public struct LiveGenerationConfig: Sendable {
   ///     context window.
   ///
   ///     This mechanism prevents the context from exceeding a given length.
+  ///   - realtimeInputConfig: Configures model input behavior when generating content via the
+  ///     realtime supported methods
   public init(temperature: Float? = nil, topP: Float? = nil, topK: Int? = nil,
               candidateCount: Int? = nil, maxOutputTokens: Int? = nil,
               presencePenalty: Float? = nil, frequencyPenalty: Float? = nil,
@@ -130,7 +133,8 @@ public struct LiveGenerationConfig: Sendable {
               speech: SpeechConfig? = nil,
               inputAudioTranscription: AudioTranscriptionConfig? = nil,
               outputAudioTranscription: AudioTranscriptionConfig? = nil,
-              contextWindowCompression: ContextWindowCompressionConfig? = nil) {
+              contextWindowCompression: ContextWindowCompressionConfig? = nil,
+              realtimeInputConfig: RealtimeInputConfig? = nil) {
     self.init(
       BidiGenerationConfig(
         temperature: temperature,
@@ -145,17 +149,20 @@ public struct LiveGenerationConfig: Sendable {
       ),
       inputAudioTranscription: inputAudioTranscription?.audioTranscriptionConfig,
       outputAudioTranscription: outputAudioTranscription?.audioTranscriptionConfig,
-      contextWindowCompression: contextWindowCompression?.bidiContextWindowCompressionConfig
+      contextWindowCompression: contextWindowCompression?.bidiContextWindowCompressionConfig,
+      realtimeInputConfig: realtimeInputConfig?.bidiRealtimeInputConfig
     )
   }
 
   init(_ bidiGenerationConfig: BidiGenerationConfig,
        inputAudioTranscription: BidiAudioTranscriptionConfig? = nil,
        outputAudioTranscription: BidiAudioTranscriptionConfig? = nil,
-       contextWindowCompression: BidiContextWindowCompressionConfig? = nil) {
+       contextWindowCompression: BidiContextWindowCompressionConfig? = nil,
+       realtimeInputConfig: BidiRealtimeInputConfig? = nil) {
     self.bidiGenerationConfig = bidiGenerationConfig
     self.inputAudioTranscription = inputAudioTranscription
     self.outputAudioTranscription = outputAudioTranscription
     self.contextWindowCompression = contextWindowCompression
+    self.realtimeInputConfig = realtimeInputConfig
   }
 }

--- a/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
@@ -59,7 +59,6 @@ public final class LiveSession: Sendable {
   ///   - audio: Raw 16-bit PCM audio at 16Hz, used to update the model on the client's
   ///     conversation.
   public func sendAudioRealtime(_ audio: Data) async {
-    // TODO: (b/443984790) address when we add RealtimeInputConfig support
     let message = BidiGenerateContentRealtimeInput(
       audio: InlineData(data: audio, mimeType: "audio/pcm")
     )

--- a/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
@@ -97,6 +97,34 @@ public final class LiveSession: Sendable {
     await service.send(.realtimeInput(message))
   }
 
+  /// Manually marks the start of user activity, using the realtime API.
+  ///
+  /// The start of user activity is effectively the start of a user's turn, but depending on the configuration defined
+  /// in ``RealtimeInputConfig``, it may not be interpreted as an interruption. An example of
+  /// the start of user activity could be the user speaking (not silence).
+  ///
+  /// Should be followed with a call to ``LiveSession/sendStopActivityRealtime()``; after all the data
+  /// has been sent for the user's turn.
+  ///
+  /// Only required when automatic activity detection is disabled via ``ActivityDetectionConfig/disabled()``.
+  public func sendStartActivityRealtime() async {
+    let message = BidiGenerateContentRealtimeInput(activityStart: .init())
+    await service.send(.realtimeInput(message))
+  }
+
+  /// Manually marks the end of user activity, using the realtime API.
+  ///
+  /// The end of user activity is effectively the end of a user's turn, and signals that the model can start
+  /// sending responses.
+  ///
+  /// Should follow after a previous call to ``LiveSession/sendStartActivityRealtime()``.
+  ///
+  /// Only required when automatic activity detection is disabled via ``ActivityDetectionConfig/disabled()``.
+  public func sendStopActivityRealtime() async {
+    let message = BidiGenerateContentRealtimeInput(activityEnd: .init())
+    await service.send(.realtimeInput(message))
+  }
+
   /// Incremental update of the current conversation.
   ///
   /// The content is unconditionally appended to the conversation history and used as part of the

--- a/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
@@ -99,8 +99,9 @@ public final class LiveSession: Sendable {
   /// Manually marks the start of user activity, using the realtime API.
   ///
   /// The start of user activity is effectively the start of a user's turn, but depending on the
-  /// configuration defined in ``RealtimeInputConfig``, it may not be interpreted as an interruption.
-  /// An example of the start of user activity could be the user speaking (not silence).
+  /// configuration defined in ``RealtimeInputConfig``, it may not be interpreted as an
+  /// interruption. An example of the start of user activity could be the user speaking
+  /// (not silence).
   ///
   /// Should be followed with a call to ``LiveSession/sendStopActivityRealtime()``; after all the
   /// data has been sent for the user's turn.

--- a/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
@@ -98,14 +98,15 @@ public final class LiveSession: Sendable {
 
   /// Manually marks the start of user activity, using the realtime API.
   ///
-  /// The start of user activity is effectively the start of a user's turn, but depending on the configuration defined
-  /// in ``RealtimeInputConfig``, it may not be interpreted as an interruption. An example of
-  /// the start of user activity could be the user speaking (not silence).
+  /// The start of user activity is effectively the start of a user's turn, but depending on the
+  /// configuration defined in ``RealtimeInputConfig``, it may not be interpreted as an interruption.
+  /// An example of the start of user activity could be the user speaking (not silence).
   ///
-  /// Should be followed with a call to ``LiveSession/sendStopActivityRealtime()``; after all the data
-  /// has been sent for the user's turn.
+  /// Should be followed with a call to ``LiveSession/sendStopActivityRealtime()``; after all the
+  /// data has been sent for the user's turn.
   ///
-  /// Only required when automatic activity detection is disabled via ``ActivityDetectionConfig/disabled()``.
+  /// Only required when automatic activity detection is disabled via
+  /// ``ActivityDetectionConfig/disabled()``.
   public func sendStartActivityRealtime() async {
     let message = BidiGenerateContentRealtimeInput(activityStart: .init())
     await service.send(.realtimeInput(message))
@@ -113,12 +114,13 @@ public final class LiveSession: Sendable {
 
   /// Manually marks the end of user activity, using the realtime API.
   ///
-  /// The end of user activity is effectively the end of a user's turn, and signals that the model can start
-  /// sending responses.
+  /// The end of user activity is effectively the end of a user's turn, and signals that the model
+  /// can start sending responses.
   ///
   /// Should follow after a previous call to ``LiveSession/sendStartActivityRealtime()``.
   ///
-  /// Only required when automatic activity detection is disabled via ``ActivityDetectionConfig/disabled()``.
+  /// Only required when automatic activity detection is disabled via
+  /// ``ActivityDetectionConfig/disabled()``.
   public func sendStopActivityRealtime() async {
     let message = BidiGenerateContentRealtimeInput(activityEnd: .init())
     await service.send(.realtimeInput(message))

--- a/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/LiveSession.swift
@@ -103,7 +103,7 @@ public final class LiveSession: Sendable {
   /// interruption. An example of the start of user activity could be the user speaking
   /// (not silence).
   ///
-  /// Should be followed with a call to ``LiveSession/sendStopActivityRealtime()``; after all the
+  /// Should be followed with a call to ``LiveSession/sendStopActivityRealtime()``, after all the
   /// data has been sent for the user's turn.
   ///
   /// Only required when automatic activity detection is disabled via

--- a/FirebaseAI/Sources/Types/Public/Live/RealtimeInputConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/RealtimeInputConfig.swift
@@ -14,10 +14,14 @@
 
 /// Configures model input behavior when generating content in the Live API via the realtime
 /// supported methods
+///
+/// **Public Preview**: This API is a public preview and may be subject to change.
 public struct RealtimeInputConfig: Sendable {
   let bidiRealtimeInputConfig: BidiRealtimeInputConfig
 
   /// How a model handles user input activity.
+  ///
+  /// **Public Preview**: This API is a public preview and may be subject to change.
   public enum ActivityHandling: Sendable {
     /// When the user sends input marking the start of activity, the model's current response will
     /// be cut-off immediately.
@@ -36,6 +40,8 @@ public struct RealtimeInputConfig: Sendable {
   }
 
   /// How the model considers which input is included in the user's turn.
+  ///
+  /// **Public Preview**: This API is a public preview and may be subject to change.
   public enum TurnCoverage: Sendable {
     /// The model will exclude inactivity (e.g, silence on the audio stream) from the user's input.
     case onlyActivity

--- a/FirebaseAI/Sources/Types/Public/Live/RealtimeInputConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/RealtimeInputConfig.swift
@@ -12,21 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Configures model input behavior when generating content in the Live API via the realtime supported methods
+/// Configures model input behavior when generating content in the Live API via the realtime
+/// supported methods
 public struct RealtimeInputConfig: Sendable {
   let bidiRealtimeInputConfig: BidiRealtimeInputConfig
 
   /// How a model handles user input activity.
   public enum ActivityHandling: Sendable {
-    /// When the user sends input marking the start of activity, the model's current response will be cut-off immediately.
+    /// When the user sends input marking the start of activity, the model's current response will
+    /// be cut-off immediately.
     ///
-    /// The start of activity could be manually specified in the call, or the model could interpret it
-    /// automatically (depending on the value of `automaticActivityDetectionConfig`).
+    /// The start of activity could be manually specified in the call, or the model could interpret
+    /// it automatically (depending on the value of `automaticActivityDetectionConfig`).
     ///
     /// An example of activity starting implicitly could be the user speaking over the model.
     case interrupt
 
-    /// When the user sends input marking the start of activity, the model will process it, but won't cut-off its current response.
+    /// When the user sends input marking the start of activity, the model will process it, but
+    /// won't cut-off its current response.
     ///
     /// This is the inverse of `interrupt`.
     case noInterrupt
@@ -37,7 +40,8 @@ public struct RealtimeInputConfig: Sendable {
     /// The model will exclude inactivity (e.g, silence on the audio stream) from the user's input.
     case onlyActivity
 
-    /// The model will include all input (including inactivity) since the last turn as the user's input.
+    /// The model will include all input (including inactivity) since the last turn as the user's
+    /// input.
     case allInput
 
     /// Includes audio activity and all video since the last turn. With automatic
@@ -54,9 +58,11 @@ public struct RealtimeInputConfig: Sendable {
   /// - Parameters:
   ///   - automaticActivityDetection:Configures automatic activity detection on the model.
   ///
-  ///     When not set, automatic activity detection is enabled by default. If set, the user must send activity signals.
+  ///     When not set, automatic activity detection is enabled by default. If set, the user must
+  ///     send activity signals.
   ///   - activityHandling: Defines how the model treats user input activity.
-  ///   - turnCoverage: Defines which input is included in the user's turn, relative to the starting and ending of the activity.
+  ///   - turnCoverage: Defines which input is included in the user's turn, relative to the starting
+  ///     and ending of the activity.
   public init(automaticActivityDetection: ActivityDetectionConfig? = nil,
               activityHandling: ActivityHandling? = nil,
               turnCoverage: TurnCoverage? = nil) {

--- a/FirebaseAI/Sources/Types/Public/Live/RealtimeInputConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/RealtimeInputConfig.swift
@@ -1,0 +1,88 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Configures model input behavior when generating content in the Live API via the realtime supported methods
+public struct RealtimeInputConfig: Sendable {
+  let bidiRealtimeInputConfig: BidiRealtimeInputConfig
+
+  /// How a model handles user input activity.
+  public enum ActivityHandling: Sendable {
+    /// When the user sends input marking the start of activity, the model's current response will be cut-off immediately.
+    ///
+    /// The start of activity could be manually specified in the call, or the model could interpret it
+    /// automatically (depending on the value of `automaticActivityDetectionConfig`).
+    ///
+    /// An example of activity starting implicitly could be the user speaking over the model.
+    case interrupt
+
+    /// When the user sends input marking the start of activity, the model will process it, but won't cut-off its current response.
+    ///
+    /// This is the inverse of `interrupt`.
+    case noInterrupt
+  }
+
+  /// How the model considers which input is included in the user's turn.
+  public enum TurnCoverage: Sendable {
+    /// The model will exclude inactivity (e.g, silence on the audio stream) from the user's input.
+    case onlyActivity
+
+    /// The model will include all input (including inactivity) since the last turn as the user's input.
+    case allInput
+
+    /// Includes audio activity and all video since the last turn. With automatic
+    /// activity detection, audio activity means speech and excludes silence.
+    case audioActivityAndAllVideo
+  }
+
+  init(_ bidiRealtimeInputConfig: BidiRealtimeInputConfig) {
+    self.bidiRealtimeInputConfig = bidiRealtimeInputConfig
+  }
+
+  /// Creates a new ``RealtimeInputConfig`` value.
+  ///
+  /// - Parameters:
+  ///   - automaticActivityDetection:Configures automatic activity detection on the model.
+  ///
+  ///     When not set, automatic activity detection is enabled by default. If set, the user must send activity signals.
+  ///   - activityHandling: Defines how the model treats user input activity.
+  ///   - turnCoverage: Defines which input is included in the user's turn, relative to the starting and ending of the activity.
+  public init(automaticActivityDetection: ActivityDetectionConfig? = nil,
+              activityHandling: ActivityHandling? = nil,
+              turnCoverage: TurnCoverage? = nil) {
+    self.init(BidiRealtimeInputConfig(
+      automaticActivityDetection: automaticActivityDetection?.bidiActivitiyDetectionConfig,
+      activityHandling: activityHandling.flatMap(BidiRealtimeInputConfig.ActivityHandling.init),
+      turnCoverage: turnCoverage.flatMap(BidiRealtimeInputConfig.TurnCoverage.init)
+    ))
+  }
+}
+
+private extension BidiRealtimeInputConfig.ActivityHandling {
+  init(_ activityHandling: RealtimeInputConfig.ActivityHandling) {
+    switch activityHandling {
+    case .noInterrupt: self = .noInterruption
+    case .interrupt: self = .startOfInterrupts
+    }
+  }
+}
+
+private extension BidiRealtimeInputConfig.TurnCoverage {
+  init(_ turnCoverage: RealtimeInputConfig.TurnCoverage) {
+    switch turnCoverage {
+    case .onlyActivity: self = .onlyActivity
+    case .allInput: self = .allInput
+    case .audioActivityAndAllVideo: self = .audioActivityAndAllVideo
+    }
+  }
+}

--- a/FirebaseAI/Sources/Types/Public/Live/RealtimeInputConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/Live/RealtimeInputConfig.swift
@@ -62,7 +62,7 @@ public struct RealtimeInputConfig: Sendable {
   /// Creates a new ``RealtimeInputConfig`` value.
   ///
   /// - Parameters:
-  ///   - automaticActivityDetection:Configures automatic activity detection on the model.
+  ///   - automaticActivityDetection: Configures automatic activity detection on the model.
   ///
   ///     When not set, automatic activity detection is enabled by default. If set, the user must
   ///     send activity signals.
@@ -73,7 +73,7 @@ public struct RealtimeInputConfig: Sendable {
               activityHandling: ActivityHandling? = nil,
               turnCoverage: TurnCoverage? = nil) {
     self.init(BidiRealtimeInputConfig(
-      automaticActivityDetection: automaticActivityDetection?.bidiActivitiyDetectionConfig,
+      automaticActivityDetection: automaticActivityDetection?.bidiActivityDetectionConfig,
       activityHandling: activityHandling.flatMap(BidiRealtimeInputConfig.ActivityHandling.init),
       turnCoverage: turnCoverage.flatMap(BidiRealtimeInputConfig.TurnCoverage.init)
     ))

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
@@ -602,13 +602,15 @@ struct LiveSessionTests {
 }
 
 private extension LiveSession {
-  /// Collects the next non empty audio output transcript that the model sends, returning nil if it takes longer than the timeout.
+  /// Collects the next non empty audio output transcript that the model sends, returning nil if it
+  /// takes longer than the timeout.
   ///
-  /// Basically the same as ``collectNextAudioOutputTranscript``, but this method will timeout if it takes too long, and
+  /// Basically the same as ``collectNextAudioOutputTranscript``, but this method will timeout if it
+  /// takes too long, and
   /// will make sure you don't get an empty intermediary response back.
   func tryCollectNextValidAudioOutputTranscript(timeout: TimeInterval = 5.0) async throws
     -> String? {
-      let response = try await TestHelpers.withTimeout(seconds: timeout) {
+    let response = try await TestHelpers.withTimeout(seconds: timeout) {
       var text = ""
       for try await content in self.responsesOf(LiveServerContent.self) {
         text += content.outputAudioText()

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
@@ -137,7 +137,10 @@ struct LiveSessionTests {
     // The model can't infer that we're done speaking until we send null bytes
     await session.sendAudioRealtime(Data(repeating: 0, count: audioFile.data.count))
 
-    let text = try await session.collectNextAudioOutputTranscript()
+    let text = try #require(
+      try await session.tryCollectNextValidAudioOutputTranscript(),
+      "Model did not respond in time with a non empty response"
+    )
 
     await session.close()
     let modelResponse = text
@@ -178,7 +181,10 @@ struct LiveSessionTests {
     await session.sendAudioRealtime(audioFile.data)
     await session.sendAudioRealtime(Data(repeating: 0, count: audioFile.data.count))
 
-    let text = try await session.collectNextAudioOutputTranscript()
+    let text = try #require(
+      try await session.tryCollectNextValidAudioOutputTranscript(),
+      "Model did not respond in time with a non empty response"
+    )
 
     await session.close()
     let modelResponse = text
@@ -222,10 +228,10 @@ struct LiveSessionTests {
         functionId: functionCall.functionId
       ),
     ])
-    var text = try await session.collectNextAudioOutputTranscript()
-    if text.isEmpty {
-      text = try await session.collectNextAudioOutputTranscript()
-    }
+    let text = try #require(
+      try await session.tryCollectNextValidAudioOutputTranscript(),
+      "Model did not respond in time with a non empty response"
+    )
 
     await session.close()
     let modelResponse = text
@@ -260,10 +266,10 @@ struct LiveSessionTests {
 
     await session.sendTextRealtime("What is my name?")
 
-    var text = try await session.collectNextAudioOutputTranscript()
-    if text.isEmpty {
-      text = try await session.collectNextAudioOutputTranscript()
-    }
+    let text = try #require(
+      try await session.tryCollectNextValidAudioOutputTranscript(),
+      "Model did not respond in time with a non empty response"
+    )
 
     await session.close()
     let modelResponse = text
@@ -298,10 +304,10 @@ struct LiveSessionTests {
 
     await session.sendTextRealtime("What is my name?")
 
-    var text = try await session.collectNextAudioOutputTranscript()
-    if text.isEmpty {
-      text = try await session.collectNextAudioOutputTranscript()
-    }
+    let text = try #require(
+      try await session.tryCollectNextValidAudioOutputTranscript(),
+      "Model did not respond in time with a non empty response"
+    )
 
     await session.close()
     let modelResponse = text
@@ -336,10 +342,10 @@ struct LiveSessionTests {
 
     await session.sendTextRealtime("What is my name?")
 
-    var text = try await session.collectNextAudioOutputTranscript()
-    if text.isEmpty {
-      text = try await session.collectNextAudioOutputTranscript()
-    }
+    let text = try #require(
+      try await session.tryCollectNextValidAudioOutputTranscript(),
+      "Model did not respond in time with a non empty response"
+    )
 
     await session.close()
     let modelResponse = text
@@ -439,11 +445,10 @@ struct LiveSessionTests {
     await session.sendContent("Does five plus")
     await session.sendContent(" five equal ten?", turnComplete: true)
 
-    var text = try await session.collectNextAudioOutputTranscript()
-    if text.isEmpty {
-      // The model sometimes sends an empty text response first
-      text = try await session.collectNextAudioOutputTranscript()
-    }
+    let text = try #require(
+      try await session.tryCollectNextValidAudioOutputTranscript(),
+      "Model did not respond in time with a non empty response"
+    )
 
     await session.close()
     let modelResponse = text
@@ -470,7 +475,10 @@ struct LiveSessionTests {
 
     await session.sendTextRealtime("does five plus five equal ten?")
 
-    let text = try await session.collectNextAudioOutputTranscript()
+    let text = try #require(
+      try await session.tryCollectNextValidAudioOutputTranscript(),
+      "Model did not respond in time with a non empty response"
+    )
 
     await session.close()
     let modelResponse = text

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
@@ -17,6 +17,7 @@ import FirebaseAITestApp
 import SwiftUI
 import Testing
 
+import AVFoundation
 @testable import struct FirebaseAILogic.APIConfig
 
 @Suite(.serialized)
@@ -89,6 +90,14 @@ struct LiveSessionTests {
       parts: """
       When you hear "Hello" say "Goodbye". If you hear anything else, say "The audio file is \
       broken".
+      """.trimmingCharacters(in: .whitespacesAndNewlines)
+    )
+
+    static let helloCount = ModelContent(
+      role: "system",
+      parts: """
+      Tell me how many times you hear "Hello" (not including these instructions). Only respond with \
+      the number, nothing else. If you hear anything else, say "The audio file is broken".
       """.trimmingCharacters(in: .whitespacesAndNewlines)
     )
 
@@ -486,9 +495,132 @@ struct LiveSessionTests {
       return nil
     }
   }
+
+  @Test(arguments: arguments)
+  func realtime_automaticActivityDetection_disabled(_ config: InstanceConfig,
+                                                    modelName: String) async throws {
+    let model = FirebaseAI.componentInstance(config).liveModel(
+      modelName: modelName,
+      generationConfig: LiveGenerationConfig(
+        responseModalities: [.audio],
+        outputAudioTranscription: AudioTranscriptionConfig(),
+        realtimeInputConfig: RealtimeInputConfig(
+          automaticActivityDetection: ActivityDetectionConfig.disabled()
+        )
+      ),
+      systemInstruction: SystemInstructions.helloCount
+    )
+
+    let session = try await model.connect()
+
+    let audioFile = try #require(
+      NSDataAsset(name: "hello"), "Missing audio file 'hello.wav' in Assets"
+    )
+    let silentData = generateRawPCMSilence(duration: 1)
+
+    await session.sendStartActivityRealtime()
+
+    await session.sendAudioRealtime(audioFile.data)
+    await session.sendAudioRealtime(silentData)
+
+    try await Task.sleep(nanoseconds: oneSecondInNanoseconds)
+
+    await session.sendAudioRealtime(audioFile.data)
+    await session.sendAudioRealtime(silentData)
+
+    await session.sendStopActivityRealtime()
+
+    let text = try #require(
+      try await session.tryCollectNextValidAudioOutputTranscript(),
+      "Model did not respond in time with a non empty response"
+    )
+
+    await session.close()
+    let modelResponse = text
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .trimmingCharacters(in: .punctuationCharacters)
+      .lowercased()
+
+    #expect(modelResponse == "2")
+  }
+
+  @Test(arguments: arguments)
+  func realtime_automaticActivityDetection_enabled(_ config: InstanceConfig,
+                                                   modelName: String) async throws {
+    let model = FirebaseAI.componentInstance(config).liveModel(
+      modelName: modelName,
+      generationConfig: LiveGenerationConfig(
+        responseModalities: [.audio],
+        outputAudioTranscription: AudioTranscriptionConfig(),
+        realtimeInputConfig: RealtimeInputConfig(
+          automaticActivityDetection: ActivityDetectionConfig(
+            silenceDuration: 0.1,
+          ),
+          activityHandling: .noInterrupt
+        )
+      ),
+      systemInstruction: SystemInstructions.helloCount
+    )
+
+    let session = try await model.connect()
+
+    let audioFile = try #require(
+      NSDataAsset(name: "hello"), "Missing audio file 'hello.wav' in Assets"
+    )
+
+    let silentData = generateRawPCMSilence(duration: 1)
+
+    await session.sendAudioRealtime(audioFile.data)
+    await session.sendAudioRealtime(silentData)
+
+    try await Task.sleep(nanoseconds: oneSecondInNanoseconds)
+
+    await session.sendAudioRealtime(audioFile.data)
+    await session.sendAudioRealtime(silentData)
+
+    let text = try #require(
+      try await session.tryCollectNextValidAudioOutputTranscript(),
+      "Model did not respond in time with a non empty response"
+    )
+
+    await session.close()
+    let modelResponse = text
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .trimmingCharacters(in: .punctuationCharacters)
+      .lowercased()
+
+    #expect(modelResponse == "1")
+  }
 }
 
 private extension LiveSession {
+  /// Collects the next non empty audio output transcript that the model sends, returning nil if it takes longer than the timeout.
+  ///
+  /// Basically the same as ``collectNextAudioOutputTranscript``, but this method will timeout if it takes too long, and
+  /// will make sure you don't get an empty intermediary response back.
+  func tryCollectNextValidAudioOutputTranscript(timeout: TimeInterval = 5.0) async throws
+    -> String? {
+      let response = try await TestHelpers.withTimeout(seconds: timeout) {
+      var text = ""
+      for try await content in self.responsesOf(LiveServerContent.self) {
+        text += content.outputAudioText()
+        if content.isTurnComplete {
+          if !text.isEmpty {
+            break
+          }
+        }
+      }
+      return text
+    }
+
+    // if the model terminated early, we could get an empty string back
+    guard let response, !response.isEmpty else {
+      return nil
+    }
+
+    return response
+  }
+
   /// Collects the audio output transcripts that the model sends for the next turn.
   ///
   /// Will listen for `LiveServerContent` messages from the model,
@@ -614,4 +746,16 @@ extension LiveServerContent {
   func outputAudioText() -> String {
     outputAudioTranscription?.text ?? ""
   }
+}
+
+/// Generate silent audio data that has a specific duration.
+func generateRawPCMSilence(duration: TimeInterval) -> Data {
+  // gemini uses 16khz mono
+  let sampleRate = 16000
+  // gemini uses 16-bit
+  let bytesPerSample = 2
+
+  let totalSamples = Int(duration * Double(sampleRate))
+  let totalBytes = totalSamples * bytesPerSample
+  return Data(repeating: 0, count: totalBytes)
 }

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/LiveSessionTests.swift
@@ -610,7 +610,7 @@ private extension LiveSession {
   /// will make sure you don't get an empty intermediary response back.
   func tryCollectNextValidAudioOutputTranscript(timeout: TimeInterval = 5.0) async throws
     -> String? {
-    let response = try await TestHelpers.withTimeout(seconds: timeout) {
+    let response = try await withTimeout(seconds: timeout) {
       var text = ""
       for try await content in self.responsesOf(LiveServerContent.self) {
         text += content.outputAudioText()

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/TestHelpers.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/TestHelpers.swift
@@ -27,4 +27,27 @@ enum TestHelpers {
       return authResult.user.uid
     }
   }
+
+  /// Run a callback, returning nil if it takes longer than the specified amount of seconds.
+  static func withTimeout<T>(seconds: Double,
+                      operation: @escaping @Sendable () async throws -> T) async throws -> T? {
+    try await withThrowingTaskGroup(of: T?.self) { group in
+      group.addTask {
+        try await operation()
+      }
+      group.addTask {
+        try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+        return nil
+      }
+
+      guard let firstResult = try await group.next() else {
+        group.cancelAll()
+        return nil
+      }
+
+      group.cancelAll()
+
+      return firstResult
+    }
+  }
 }

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/TestHelpers.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/TestHelpers.swift
@@ -30,7 +30,8 @@ enum TestHelpers {
 
   /// Run a callback, returning nil if it takes longer than the specified amount of seconds.
   static func withTimeout<T>(seconds: Double,
-                      operation: @escaping @Sendable () async throws -> T) async throws -> T? {
+                             operation: @escaping @Sendable () async throws -> T) async throws
+    -> T? {
     try await withThrowingTaskGroup(of: T?.self) { group in
       group.addTask {
         try await operation()

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/TestHelpers.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/TestHelpers.swift
@@ -27,28 +27,4 @@ enum TestHelpers {
       return authResult.user.uid
     }
   }
-
-  /// Run a callback, returning nil if it takes longer than the specified amount of seconds.
-  static func withTimeout<T>(seconds: Double,
-                             operation: @escaping @Sendable () async throws -> T) async throws
-    -> T? {
-    try await withThrowingTaskGroup(of: T?.self) { group in
-      group.addTask {
-        try await operation()
-      }
-      group.addTask {
-        try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-        return nil
-      }
-
-      guard let firstResult = try await group.next() else {
-        group.cancelAll()
-        return nil
-      }
-
-      group.cancelAll()
-
-      return firstResult
-    }
-  }
 }

--- a/FirebaseAI/Tests/TestApp/Tests/Utilities/IntegrationTestUtils.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Utilities/IntegrationTestUtils.swift
@@ -91,13 +91,12 @@ let nanosecondsPerSecond: Double = 1_000_000_000
 ///   you won't get proper timeout support.
 ///
 /// - Parameters:
-///   - seconds: The amount of seconds to wait before cancelling the callback and considering it a timeout. Must be
-///   **positive**, and at **max one hour**.
+///   - seconds: The amount of seconds to wait before cancelling the callback and considering it a
+///     timeout. Must be **positive**, and at **max one hour**.
 ///   - operation: The callback to execute. **Must** be cancellation-aware.
-func withTimeout<T: Sendable>(
-  seconds: TimeInterval,
-  operation: @escaping @Sendable () async throws -> T
-) async throws -> T? {
+func withTimeout<T: Sendable>(seconds: TimeInterval,
+                              operation: @escaping @Sendable () async throws -> T) async throws
+  -> T? {
   guard seconds > 0 else {
     fatalError("seconds must be a postive number, but we got \(seconds) instead")
   }
@@ -106,7 +105,7 @@ func withTimeout<T: Sendable>(
     fatalError("the maximum amount of seconds you can pass is 1 hour, but you passed \(seconds)")
   }
 
-  let nanoseconds = UInt64(seconds  * nanosecondsPerSecond)
+  let nanoseconds = UInt64(seconds * nanosecondsPerSecond)
 
   return try await withThrowingTaskGroup(of: TimeoutResult<T>.self) { group in
     group.addTask {

--- a/FirebaseAI/Tests/TestApp/Tests/Utilities/IntegrationTestUtils.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Utilities/IntegrationTestUtils.swift
@@ -76,3 +76,60 @@ func retry<T>(times: Int,
   Issue.record("Flaky test failed after \(times) attempt(s): \(String(describing: lastError))")
   throw lastError
 }
+
+enum TimeoutResult<T: Sendable>: Sendable {
+  case completed(T)
+  case timedOut
+}
+
+/// The amount of nano seconds in a second.
+let nanosecondsPerSecond: Double = 1_000_000_000
+
+/// Run a callback, returning nil if it takes longer than the specified amount of seconds.
+///
+/// - Warning: The callback passed to this function **must** be cancellation-aware, otherwise,
+///   you won't get proper timeout support.
+///
+/// - Parameters:
+///   - seconds: The amount of seconds to wait before cancelling the callback and considering it a timeout. Must be
+///   **positive**, and at **max one hour**.
+///   - operation: The callback to execute. **Must** be cancellation-aware.
+func withTimeout<T: Sendable>(
+  seconds: TimeInterval,
+  operation: @escaping @Sendable () async throws -> T
+) async throws -> T? {
+  guard seconds > 0 else {
+    fatalError("seconds must be a postive number, but we got \(seconds) instead")
+  }
+  // constrain to one hour, just in case someone accidentally passed too large of a value
+  guard seconds <= 3600 else {
+    fatalError("the maximum amount of seconds you can pass is 1 hour, but you passed \(seconds)")
+  }
+
+  let nanoseconds = UInt64(seconds  * nanosecondsPerSecond)
+
+  return try await withThrowingTaskGroup(of: TimeoutResult<T>.self) { group in
+    group.addTask {
+      let result = try await operation()
+      return .completed(result)
+    }
+
+    group.addTask {
+      try await Task.sleep(nanoseconds: nanoseconds)
+      return .timedOut
+    }
+
+    defer { group.cancelAll() }
+
+    while let result = try await group.next() {
+      switch result {
+      case let .completed(value):
+        return value
+      case .timedOut:
+        return nil
+      }
+    }
+
+    return nil
+  }
+}


### PR DESCRIPTION
Per [b/538190669](https://b.corp.google.com/issues/538190669),

This adds support for the `RealtimeInputConfig` type (within `LiveGenerationConfig`), as well as the `sendStartActivityRealtime()` and `sendStartActivityRealtime()` methods to `LiveSession`.

Tests have also been added for these new features.

Additionally, the existing tests have been modified slightly to take advantage of a util method that will timeout after waiting some predefined seconds for an audio output transcript, as well as handle the case of the model sending randomly sending intermediate empty responses. This should hopefully help prevent our tests from stalling for excessive amounts of time when the server is having issues. Although, the default timeout duration may need to be adjusted. It can be set on a test-by-test basis, but the default is currently set at 5 seconds; which may or may not be sufficient in a CI environment.