### PR TITLE
rollback(spm): conditional min. OS versions for Xcode 27

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Firebase 12.17.0
 - [fixed] Updated Swift Package Manager minimum deployment targets when building
   with Xcode 27 betas (Swift 6.4+) to watchOS 9.0 and macOS 12.0. (#16408)
+- [changed] Removed the  (never activated) `recaptchaSiteKey` property from `FirebaseOptions`.
+  This feature is part of the public preview reCAPTCHA provider.
 
 # Firebase 12.15.0
 - [changed] Firebase now requires Swift tools version 6.1 for the Swift Package.
   The package will no longer resolve in Xcode versions older than 16.3. Note that
   the minimum officially supported version for the SDK remains Xcode 26.2+.
-- [changed] Removed the  (never activated) `recaptchaSiteKey` property from `FirebaseOptions`.
-  This feature is part of the public preview reCAPTCHA provider.
 
 # Firebase 12.14.0
 - [fixed] Remove extra comma in Package.swift that caused SPM resolution

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Firebase 12.17.0
 - [fixed] Updated Swift Package Manager minimum deployment targets when building
   with Xcode 27 betas (Swift 6.4+) to watchOS 9.0 and macOS 12.0. (#16408)
-- [changed] Removed the  (never activated) `recaptchaSiteKey` property from `FirebaseOptions`.
-  This feature is part of the public preview reCAPTCHA provider.
 
 # Firebase 12.15.0
 - [changed] Firebase now requires Swift tools version 6.1 for the Swift Package.
   The package will no longer resolve in Xcode versions older than 16.3. Note that
   the minimum officially supported version for the SDK remains Xcode 26.2+.
+- [changed] Removed the  (never activated) `recaptchaSiteKey` property from `FirebaseOptions`.
+  This feature is part of the public preview reCAPTCHA provider.
 
 # Firebase 12.14.0
 - [fixed] Remove extra comma in Package.swift that caused SPM resolution

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,4 @@
 # Firebase 12.17.0
-- [fixed] Updated Swift Package Manager minimum deployment targets when building
-  with Xcode 27 betas (Swift 6.4+) to watchOS 9.0 and macOS 12.0. (#16408)
 - [changed] Removed the  (never activated) `recaptchaSiteKey` property from `FirebaseOptions`.
   This feature is part of the public preview reCAPTCHA provider.
 

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let shouldUseSourceFirestore = Context.environment["FIREBASE_SOURCE_FIRESTORE"] 
 
 let package = Package(
   name: "Firebase",
-  platforms: supportedPlatforms(),
+  platforms: [.iOS(.v15), .macCatalyst(.v15), .macOS(.v10_15), .tvOS(.v15), .watchOS(.v7)],
   products: [
     .library(
       name: "FirebaseAI",
@@ -1366,20 +1366,6 @@ let package = Package(
 )
 
 // MARK: - Helper Functions
-
-/// Returns the list of platforms supported by the package.
-///
-/// Under Xcode 27 (Swift 6.4+), watchOS 9 and macOS 12 are now the minimum deployment targets. For
-/// Xcode 26.x and earlier, the deployment targets are watchOS 7 and macOS 10.15. The iOS, tvOS and
-/// Mac Catalyst minimums remain the same for both.
-func supportedPlatforms() -> [SupportedPlatform] {
-  // TODO: Remove the `compiler(>=6.4)` check when Xcode 27.x is the minimum supported version.
-  #if compiler(>=6.4)
-    return [.iOS(.v15), .macCatalyst(.v15), .macOS(.v12), .tvOS(.v15), .watchOS(.v9)]
-  #else
-    return [.iOS(.v15), .macCatalyst(.v15), .macOS(.v10_15), .tvOS(.v15), .watchOS(.v7)]
-  #endif
-}
 
 func firebaseCrashlyticsTarget() -> Target {
   var cSettings: [CSetting] = [


### PR DESCRIPTION
Xcode 27 betas have enforced Xcode's minimum deployment targets. We were able to reproduce this on CI, and responded by updating the Package.swift to conditionally compile a higher min. deployment target when Xcode 27 was being used. However, investigating further revealed that the issue isn't our Package.swift's min. OS versions, but how our CI is injecting older deployment versions that Xcode now flags as an error. 

**Passes (Letting Xcode auto-upgrade the deployment target):**
```bash
xcodebuild -scheme FirebaseAILogicUnit -destination platform=OS\ X\,arch=x86_64 \
  ONLY_ACTIVE_ARCH=YES CODE_SIGNING_REQUIRED=NO \
  CODE_SIGNING_ALLOWED=YES COMPILER_INDEX_STORE_ENABLE=NO build
```

**Fails (Forcing the compiler to build for an unsupported macOS version):**
```bash
xcodebuild -scheme FirebaseAILogicUnit -destination platform=OS\ X\,arch=x86_64 \
  ONLY_ACTIVE_ARCH=YES CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES \
  COMPILER_INDEX_STORE_ENABLE=NO IPHONEOS_DEPLOYMENT_TARGET=15.0 \
  MACOSX_DEPLOYMENT_TARGET=10.15 TVOS_DEPLOYMENT_TARGET=15.0 \
  WATCHOS_DEPLOYMENT_TARGET=7.0 build
```

**Apple Documentation:**
This auto-upgrade behavior is defined in the Swift Package Manager documentation for `SupportedPlatform` ([Apple Developer Docs](https://developer.apple.com/documentation/packagedescription/supportedplatform)):
> *"This predefined deployment version is the oldest deployment target version that the installed SDK supports for a given platform."*

Note: There is a "hidden" build setting to turn off the enforcement checks: `__DIAGNOSE_INVALID_DEPLOYMENT_TARGET_AS_ERROR=NO`.

---

The "fix" for this issue on our CI will be in the Xcode 27 PR, #16424, adjusting the `scripts/build.sh` to not pass specific OS versions or pass OS versions that Xcode is happy with (TBD).

#no-changelog