### PR TITLE
test(auth): enable SPM unit tests for PhoneAuthProvider and AuthNotificationManager

### DIFF
--- a/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
@@ -18,7 +18,15 @@
 
   /// A class represents a credential that proves the identity of the app.
   @preconcurrency
-  class AuthNotificationManager {
+  // Protocol to help with unit tests.
+  protocol AuthNotificationApplication: Sendable {
+    var delegate: UIApplicationDelegate? { get }
+    var applicationState: UIApplication.State { get }
+  }
+
+  extension UIApplication: AuthNotificationApplication {}
+
+  class AuthNotificationManager: @unchecked Sendable {
     /// The key to locate payload data in the remote notification.
     private let kNotificationDataKey = "com.google.firebase.auth"
 
@@ -35,7 +43,7 @@
     private let kProbingTimeout = 1.0
 
     /// The application.
-    private let application: UIApplication
+    private let application: AuthNotificationApplication
 
     /// The object to handle app credentials delivered via notification.
     private let appCredentialManager: AuthAppCredentialManager
@@ -63,7 +71,7 @@
     /// - Parameter appCredentialManager: The object to handle app credentials delivered via
     /// notification.
     /// - Returns: The initialized instance.
-    init(withApplication application: UIApplication,
+    init(withApplication application: AuthNotificationApplication,
          appCredentialManager: AuthAppCredentialManager) {
       self.application = application
       self.appCredentialManager = appCredentialManager
@@ -97,7 +105,8 @@
              delegate
              .responds(to: #selector(UIApplicationDelegate
                  .application(_:didReceiveRemoteNotification:fetchCompletionHandler:))) {
-            delegate.application?(self.application,
+            let appObj = (self.application as? UIApplication) ?? UIApplication.shared
+            delegate.application?(appObj,
                                   didReceiveRemoteNotification: proberNotification) { _ in
             }
           } else {

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
@@ -54,6 +54,8 @@
     /// Whether or not notification is being forwarded
     private var isNotificationBeingForwarded: Bool = false
 
+    private let lock = NSLock()
+
     /// The timeout for checking for notification forwarding.
     ///
     /// Only tests should access this property.
@@ -62,7 +64,20 @@
     /// Disable callback waiting for tests.
     ///
     /// Only tests should access this property.
-    var immediateCallbackForTestFaking: (() -> Bool)?
+    var immediateCallbackForTestFaking: (() -> Bool)? {
+      get {
+        lock.lock()
+        defer { lock.unlock() }
+        return _immediateCallbackForTestFaking
+      }
+      set {
+        lock.lock()
+        defer { lock.unlock() }
+        _immediateCallbackForTestFaking = newValue
+      }
+    }
+
+    private var _immediateCallbackForTestFaking: (() -> Bool)?
 
     private let condition: AuthCondition
 
@@ -91,11 +106,17 @@
 
     /// Checks whether or not remote notifications are being forwarded to this class.
     func checkNotificationForwarding() async -> Bool {
-      if let getValueFunc = immediateCallbackForTestFaking {
+      lock.lock()
+      let getValueFunc = _immediateCallbackForTestFaking
+      let checked = hasCheckedNotificationForwarding
+      let forwarded = isNotificationBeingForwarded
+      lock.unlock()
+
+      if let getValueFunc = getValueFunc {
         return getValueFunc()
       }
-      if hasCheckedNotificationForwarding {
-        return isNotificationBeingForwarded
+      if checked {
+        return forwarded
       }
       if await pendingCount.increment() == 1 {
         DispatchQueue.main.async {
@@ -122,8 +143,11 @@
         }
       }
       await condition.wait()
+      lock.lock()
       hasCheckedNotificationForwarding = true
-      return isNotificationBeingForwarded
+      let finalForwarded = isNotificationBeingForwarded
+      lock.unlock()
+      return finalForwarded
     }
 
     /// Attempts to handle the remote notification.
@@ -145,11 +169,14 @@
         return false
       }
       if dictionary[kNotificationProberKey] != nil {
+        lock.lock()
         if hasCheckedNotificationForwarding {
+          lock.unlock()
           // The prober notification probably comes from another instance, so pass it along.
           return false
         }
         isNotificationBeingForwarded = true
+        lock.unlock()
         condition.signal()
         return true
       }

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
@@ -106,11 +106,13 @@
 
     /// Checks whether or not remote notifications are being forwarded to this class.
     func checkNotificationForwarding() async -> Bool {
-      lock.lock()
-      let getValueFunc = _immediateCallbackForTestFaking
-      let checked = hasCheckedNotificationForwarding
-      let forwarded = isNotificationBeingForwarded
-      lock.unlock()
+      let (getValueFunc, checked, forwarded) = lock.withLock {
+        (
+          _immediateCallbackForTestFaking,
+          hasCheckedNotificationForwarding,
+          isNotificationBeingForwarded
+        )
+      }
 
       if let getValueFunc = getValueFunc {
         return getValueFunc()
@@ -143,11 +145,10 @@
         }
       }
       await condition.wait()
-      lock.lock()
-      hasCheckedNotificationForwarding = true
-      let finalForwarded = isNotificationBeingForwarded
-      lock.unlock()
-      return finalForwarded
+      return lock.withLock {
+        hasCheckedNotificationForwarding = true
+        return isNotificationBeingForwarded
+      }
     }
 
     /// Attempts to handle the remote notification.
@@ -169,16 +170,19 @@
         return false
       }
       if dictionary[kNotificationProberKey] != nil {
-        lock.lock()
-        if hasCheckedNotificationForwarding {
-          lock.unlock()
-          // The prober notification probably comes from another instance, so pass it along.
+        let shouldForward = lock.withLock {
+          if hasCheckedNotificationForwarding {
+            return false
+          }
+          isNotificationBeingForwarded = true
+          return true
+        }
+        if shouldForward {
+          condition.signal()
+          return true
+        } else {
           return false
         }
-        isNotificationBeingForwarded = true
-        lock.unlock()
-        condition.signal()
-        return true
       }
       guard let receipt = dictionary[kNotificationReceiptKey] as? String,
             let secret = dictionary[kNotificationSecretKey] as? String else {

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
@@ -56,6 +56,12 @@
 
     private let lock = NSLock()
 
+    private func sync<T>(_ block: () throws -> T) rethrows -> T {
+      lock.lock()
+      defer { lock.unlock() }
+      return try block()
+    }
+
     /// The timeout for checking for notification forwarding.
     ///
     /// Only tests should access this property.
@@ -66,14 +72,10 @@
     /// Only tests should access this property.
     var immediateCallbackForTestFaking: (() -> Bool)? {
       get {
-        lock.lock()
-        defer { lock.unlock() }
-        return _immediateCallbackForTestFaking
+        return sync { _immediateCallbackForTestFaking }
       }
       set {
-        lock.lock()
-        defer { lock.unlock() }
-        _immediateCallbackForTestFaking = newValue
+        sync { _immediateCallbackForTestFaking = newValue }
       }
     }
 
@@ -106,7 +108,7 @@
 
     /// Checks whether or not remote notifications are being forwarded to this class.
     func checkNotificationForwarding() async -> Bool {
-      let (getValueFunc, checked, forwarded) = lock.withLock {
+      let (getValueFunc, checked, forwarded) = sync {
         (
           _immediateCallbackForTestFaking,
           hasCheckedNotificationForwarding,
@@ -145,7 +147,7 @@
         }
       }
       await condition.wait()
-      return lock.withLock {
+      return sync {
         hasCheckedNotificationForwarding = true
         return isNotificationBeingForwarded
       }
@@ -170,7 +172,7 @@
         return false
       }
       if dictionary[kNotificationProberKey] != nil {
-        let shouldForward = lock.withLock {
+        let shouldForward = sync {
           if hasCheckedNotificationForwarding {
             return false
           }

--- a/FirebaseAuth/Tests/Unit/AuthNotificationManagerTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthNotificationManagerTests.swift
@@ -50,7 +50,7 @@
         storage: FakeAuthKeychainStorage()
       )
       appCredentialManager = AuthAppCredentialManager(withKeychain: fakeKeychain)
-      let application = UIApplication.shared
+      let application = FakeApplication()
       notificationManager = AuthNotificationManager(withApplication: application,
                                                     appCredentialManager: appCredentialManager!)
       modernDelegate = FakeForwardingDelegate(notificationManager!)
@@ -140,7 +140,10 @@
         .canHandle(notification: ["com.google.firebase.auth": ["error": "asdf"]]))
     }
 
-    private class FakeApplication: UIApplication {}
+    private class FakeApplication: AuthNotificationApplication, @unchecked Sendable {
+      var delegate: UIApplicationDelegate?
+      var applicationState: UIApplication.State = .active
+    }
 
     private class FakeForwardingDelegate: NSObject, UIApplicationDelegate {
       let notificationManager: AuthNotificationManager

--- a/FirebaseAuth/Tests/Unit/AuthNotificationManagerTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthNotificationManagerTests.swift
@@ -141,7 +141,7 @@
     }
 
     private class FakeApplication: AuthNotificationApplication, @unchecked Sendable {
-      var delegate: UIApplicationDelegate?
+      weak var delegate: UIApplicationDelegate?
       var applicationState: UIApplication.State = .active
     }
 

--- a/FirebaseAuth/Tests/Unit/AuthTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthTests.swift
@@ -2325,7 +2325,7 @@ class AuthTests: RPCBaseTests {
     }
 
     func testAppDidReceiveRemoteNotificationWithCompletion_NotificationManagerHandleCanNotification() {
-      class FakeNotificationManager: AuthNotificationManager {
+      class FakeNotificationManager: AuthNotificationManager, @unchecked Sendable {
         var canHandled = false
         override func canHandle(notification: [AnyHashable: Any]) -> Bool {
           canHandled = true

--- a/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
@@ -983,9 +983,25 @@
           settings.appVerificationDisabledForTesting = true
           auth.settings = settings
         }
+        if auth.appCredentialManager == nil {
+          let fakeKeychain = AuthKeychainServices(
+            service: "PhoneAuthProviderTests",
+            storage: FakeAuthKeychainStorage()
+          )
+          auth.appCredentialManager = AuthAppCredentialManager(withKeychain: fakeKeychain)
+        }
+        if auth.notificationManager == nil {
+          auth.notificationManager = AuthNotificationManager(
+            withApplication: FakeApplication(),
+            appCredentialManager: auth.appCredentialManager
+          )
+        }
         auth.notificationManager?.immediateCallbackForTestFaking = { forwardingNotification }
         auth.mainBundleUrlTypes = [["CFBundleURLSchemes": [scheme]]]
 
+        if auth.tokenManager == nil {
+          auth.tokenManager = AuthAPNSTokenManager(withApplication: FakeApplication())
+        }
         if fakeToken {
           guard let data = "!@#$%^".data(using: .utf8) else {
             XCTFail("Failed to encode data for fake token")
@@ -997,6 +1013,13 @@
           auth.tokenManager = FakeTokenManager(withApplication: UIApplication.shared)
         }
       }
+    }
+
+    private class FakeApplication: AuthNotificationApplication, AuthAPNSTokenApplication,
+      @unchecked Sendable {
+      var delegate: UIApplicationDelegate?
+      var applicationState: UIApplication.State = .active
+      @MainActor func registerForRemoteNotifications() {}
     }
 
     class FakeAuthRecaptchaVerifier: AuthRecaptchaVerifier, @unchecked Sendable {

--- a/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
@@ -1010,7 +1010,7 @@
           auth.tokenManager?.tokenStore = AuthAPNSToken(withData: data, type: .prod)
         } else {
           // Skip APNS token fetching.
-          auth.tokenManager = FakeTokenManager(withApplication: UIApplication.shared)
+          auth.tokenManager = FakeTokenManager(withApplication: FakeApplication())
         }
       }
     }

--- a/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
@@ -1017,7 +1017,7 @@
 
     private class FakeApplication: AuthNotificationApplication, AuthAPNSTokenApplication,
       @unchecked Sendable {
-      var delegate: UIApplicationDelegate?
+      weak var delegate: UIApplicationDelegate?
       var applicationState: UIApplication.State = .active
       @MainActor func registerForRemoteNotifications() {}
     }

--- a/Package.swift
+++ b/Package.swift
@@ -529,9 +529,6 @@ let package = Package(
       ],
       path: "FirebaseAuth/Tests/Unit",
       exclude: [
-        // TODO: these tests rely on a non-zero UIApplication.shared. They run from CocoaPods.
-        "PhoneAuthProviderTests.swift",
-        "AuthNotificationManagerTests.swift",
         // TODO: The following tests run in CocoaPods only, until mixed language or separate target.
         "ObjCAPITests.m",
         "ObjCGlobalTests.m",


### PR DESCRIPTION
This PR addresses a TODO in Package.swift by enabling PhoneAuthProviderTests and AuthNotificationManagerTests for Swift Package Manager.

### Changes:
* Removed PhoneAuthProviderTests.swift and AuthNotificationManagerTests.swift from the exclude list in Package.swift.
* Explicitly injects fakes for appCredentialManager, notificationManager, and tokenManager in PhoneAuthProviderTests.initApp() to fix test timeouts and build errors caused by Missing host applications in SPM environments.
* Added missing `@unchecked Sendable` conformance to AuthNotificationManager and FakeNotificationManager to resolve compilation errors.
* Made FakeApplication conform to AuthAPNSTokenApplication and marked its `delegate` property as `weak` to prevent retain cycles in tests.
* Added thread safety to AuthNotificationManager by protecting its mutable state with an `NSLock` and a custom synchronous helper to ensure compatibility across Swift 6 concurrency and older deployment targets (iOS 15 / macOS 10.15).