### PR TITLE
Fix integer overflow warning in nanopb pretty_printing

### DIFF
--- a/Firestore/core/src/nanopb/pretty_printing.cc
+++ b/Firestore/core/src/nanopb/pretty_printing.cc
@@ -16,6 +16,7 @@
 
 #include "Firestore/core/src/nanopb/pretty_printing.h"
 
+#include <algorithm>
 #include <sstream>
 
 #include "Firestore/core/src/nanopb/byte_string.h"
@@ -26,7 +27,9 @@ namespace nanopb {
 namespace internal {
 
 std::string Indent(int level, int indent_width) {
-  return std::string(level * indent_width, ' ');
+  size_t safe_level = static_cast<size_t>(std::max(0, level));
+  size_t safe_width = static_cast<size_t>(std::max(0, indent_width));
+  return std::string(safe_level * safe_width, ' ');
 }
 
 std::string ToString(pb_bytes_array_t* value) {

--- a/Firestore/core/src/nanopb/pretty_printing.cc
+++ b/Firestore/core/src/nanopb/pretty_printing.cc
@@ -27,8 +27,9 @@ namespace nanopb {
 namespace internal {
 
 std::string Indent(int level, int indent_width) {
-  size_t safe_level = static_cast<size_t>(std::max(0, level));
-  size_t safe_width = static_cast<size_t>(std::max(0, indent_width));
+  size_t safe_level = static_cast<size_t>(std::max(0, std::min(1000, level)));
+  size_t safe_width =
+      static_cast<size_t>(std::max(0, std::min(100, indent_width)));
   return std::string(safe_level * safe_width, ' ');
 }
 

--- a/Firestore/core/src/nanopb/pretty_printing.cc
+++ b/Firestore/core/src/nanopb/pretty_printing.cc
@@ -27,8 +27,9 @@ namespace nanopb {
 namespace internal {
 
 std::string Indent(int level, int indent_width) {
-  size_t safe_level = static_cast<size_t>(std::max(0, std::min(1000, level)));
-  size_t safe_width =
+  const size_t safe_level =
+      static_cast<size_t>(std::max(0, std::min(1000, level)));
+  const size_t safe_width =
       static_cast<size_t>(std::max(0, std::min(100, indent_width)));
   return std::string(safe_level * safe_width, ' ');
 }


### PR DESCRIPTION
This addresses a CodeQL warning where an integer multiplication result was converted to a larger type after the multiplication, potentially allowing an integer overflow. The inputs are now safely clamped to 0 and cast to `size_t` prior to multiplication.