### PR TITLE
[Storage] Fix spm test failure

### DIFF
--- a/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
+++ b/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
@@ -28,7 +28,7 @@ class StoragePOSIXErrorTest: StorageIntegrationCommon {
 
     let data = try XCTUnwrap("Hello".data(using: .utf8))
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-    let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
+    let fileURL = tmpDirURL.appendingPathComponent(UUID().uuidString + ".txt")
     try data.write(to: fileURL, options: .atomicWrite)
     addTeardownBlock {
       try? FileManager.default.removeItem(at: fileURL)

--- a/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
+++ b/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
@@ -29,7 +29,8 @@ class StoragePOSIXErrorTest: StorageIntegrationCommon {
     let data = try XCTUnwrap("Hello".data(using: .utf8))
     let sanitizedTestName = #function.replacingOccurrences(of: "()", with: "")
     let tmpDirURL = FileManager.default.temporaryDirectory
-    // createDirectory is necessary because SPM tests on CI can fail with ENOENT if the temporary directory doesn't exist yet.
+    // createDirectory is necessary because SPM tests on CI can fail with ENOENT if the temporary
+    // directory doesn't exist yet.
     try? FileManager.default.createDirectory(at: tmpDirURL, withIntermediateDirectories: true)
     let fileURL = tmpDirURL.appendingPathComponent("\(sanitizedTestName)-\(UUID().uuidString).txt")
     try data.write(to: fileURL)

--- a/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
+++ b/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
@@ -29,7 +29,6 @@ class StoragePOSIXErrorTest: StorageIntegrationCommon {
     let data = try XCTUnwrap("Hello".data(using: .utf8))
     let sanitizedTestName = #function.replacingOccurrences(of: "()", with: "")
     let tmpDirURL = FileManager.default.temporaryDirectory
-    try? FileManager.default.createDirectory(at: tmpDirURL, withIntermediateDirectories: true)
     let fileURL = tmpDirURL.appendingPathComponent("\(sanitizedTestName)-\(UUID().uuidString).txt")
     try data.write(to: fileURL)
     addTeardownBlock {

--- a/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
+++ b/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
@@ -29,6 +29,8 @@ class StoragePOSIXErrorTest: StorageIntegrationCommon {
     let data = try XCTUnwrap("Hello".data(using: .utf8))
     let sanitizedTestName = #function.replacingOccurrences(of: "()", with: "")
     let tmpDirURL = FileManager.default.temporaryDirectory
+    // createDirectory is necessary because SPM tests on CI can fail with ENOENT if the temporary directory doesn't exist yet.
+    try? FileManager.default.createDirectory(at: tmpDirURL, withIntermediateDirectories: true)
     let fileURL = tmpDirURL.appendingPathComponent("\(sanitizedTestName)-\(UUID().uuidString).txt")
     try data.write(to: fileURL)
     addTeardownBlock {

--- a/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
+++ b/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
@@ -28,7 +28,8 @@ class StoragePOSIXErrorTest: StorageIntegrationCommon {
 
     let data = try XCTUnwrap("Hello".data(using: .utf8))
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-    let fileURL = tmpDirURL.appendingPathComponent(UUID().uuidString + ".txt")
+    let sanitizedTestName = #function.replacingOccurrences(of: "()", with: "")
+    let fileURL = tmpDirURL.appendingPathComponent("\(sanitizedTestName)-\(UUID().uuidString).txt")
     try data.write(to: fileURL, options: .atomicWrite)
     addTeardownBlock {
       try? FileManager.default.removeItem(at: fileURL)

--- a/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
+++ b/FirebaseStorage/Tests/Integration/StoragePOSIXErrorTest.swift
@@ -27,10 +27,11 @@ class StoragePOSIXErrorTest: StorageIntegrationCommon {
     let ref = storage.reference(withPath: "ios/public/testPOSIX40")
 
     let data = try XCTUnwrap("Hello".data(using: .utf8))
-    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let sanitizedTestName = #function.replacingOccurrences(of: "()", with: "")
+    let tmpDirURL = FileManager.default.temporaryDirectory
+    try? FileManager.default.createDirectory(at: tmpDirURL, withIntermediateDirectories: true)
     let fileURL = tmpDirURL.appendingPathComponent("\(sanitizedTestName)-\(UUID().uuidString).txt")
-    try data.write(to: fileURL, options: .atomicWrite)
+    try data.write(to: fileURL)
     addTeardownBlock {
       try? FileManager.default.removeItem(at: fileURL)
     }

--- a/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
@@ -39,7 +39,7 @@ class StoragePutFileTests: StorageTestHelpers {
 
     let data = try XCTUnwrap("Hello".data(using: .utf8))
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-    let fileURL = tmpDirURL.appendingPathComponent(#function + "hello.txt")
+    let fileURL = tmpDirURL.appendingPathComponent(UUID().uuidString + ".txt")
     try data.write(to: fileURL, options: .atomicWrite)
     addTeardownBlock {
       try? FileManager.default.removeItem(at: fileURL)

--- a/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
@@ -40,6 +40,8 @@ class StoragePutFileTests: StorageTestHelpers {
     let data = try XCTUnwrap("Hello".data(using: .utf8))
     let sanitizedTestName = #function.replacingOccurrences(of: "()", with: "")
     let tmpDirURL = FileManager.default.temporaryDirectory
+    // createDirectory is necessary because SPM tests on CI can fail with ENOENT if the temporary directory doesn't exist yet.
+    try? FileManager.default.createDirectory(at: tmpDirURL, withIntermediateDirectories: true)
     let fileURL = tmpDirURL.appendingPathComponent("\(sanitizedTestName)-\(UUID().uuidString).txt")
     try data.write(to: fileURL)
     addTeardownBlock {

--- a/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
@@ -40,7 +40,8 @@ class StoragePutFileTests: StorageTestHelpers {
     let data = try XCTUnwrap("Hello".data(using: .utf8))
     let sanitizedTestName = #function.replacingOccurrences(of: "()", with: "")
     let tmpDirURL = FileManager.default.temporaryDirectory
-    // createDirectory is necessary because SPM tests on CI can fail with ENOENT if the temporary directory doesn't exist yet.
+    // createDirectory is necessary because SPM tests on CI can fail with ENOENT if the temporary
+    // directory doesn't exist yet.
     try? FileManager.default.createDirectory(at: tmpDirURL, withIntermediateDirectories: true)
     let fileURL = tmpDirURL.appendingPathComponent("\(sanitizedTestName)-\(UUID().uuidString).txt")
     try data.write(to: fileURL)

--- a/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
@@ -39,7 +39,8 @@ class StoragePutFileTests: StorageTestHelpers {
 
     let data = try XCTUnwrap("Hello".data(using: .utf8))
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
-    let fileURL = tmpDirURL.appendingPathComponent(UUID().uuidString + ".txt")
+    let sanitizedTestName = #function.replacingOccurrences(of: "()", with: "")
+    let fileURL = tmpDirURL.appendingPathComponent("\(sanitizedTestName)-\(UUID().uuidString).txt")
     try data.write(to: fileURL, options: .atomicWrite)
     addTeardownBlock {
       try? FileManager.default.removeItem(at: fileURL)

--- a/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
@@ -40,7 +40,6 @@ class StoragePutFileTests: StorageTestHelpers {
     let data = try XCTUnwrap("Hello".data(using: .utf8))
     let sanitizedTestName = #function.replacingOccurrences(of: "()", with: "")
     let tmpDirURL = FileManager.default.temporaryDirectory
-    try? FileManager.default.createDirectory(at: tmpDirURL, withIntermediateDirectories: true)
     let fileURL = tmpDirURL.appendingPathComponent("\(sanitizedTestName)-\(UUID().uuidString).txt")
     try data.write(to: fileURL)
     addTeardownBlock {

--- a/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
+++ b/FirebaseStorage/Tests/Unit/StoragePutFileTests.swift
@@ -38,10 +38,11 @@ class StoragePutFileTests: StorageTestHelpers {
     }
 
     let data = try XCTUnwrap("Hello".data(using: .utf8))
-    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let sanitizedTestName = #function.replacingOccurrences(of: "()", with: "")
+    let tmpDirURL = FileManager.default.temporaryDirectory
+    try? FileManager.default.createDirectory(at: tmpDirURL, withIntermediateDirectories: true)
     let fileURL = tmpDirURL.appendingPathComponent("\(sanitizedTestName)-\(UUID().uuidString).txt")
-    try data.write(to: fileURL, options: .atomicWrite)
+    try data.write(to: fileURL)
     addTeardownBlock {
       try? FileManager.default.removeItem(at: fileURL)
     }

--- a/Package.swift
+++ b/Package.swift
@@ -1153,6 +1153,7 @@ let package = Package(
         .swiftLanguageMode(SwiftLanguageMode.v5),
       ]
     ),
+    // Touch to test.
     .testTarget(
       name: "FirebaseStorageUnit",
       dependencies: ["FirebaseStorage",

--- a/Package.swift
+++ b/Package.swift
@@ -1153,7 +1153,6 @@ let package = Package(
         .swiftLanguageMode(SwiftLanguageMode.v5),
       ]
     ),
-    // Touch to test.
     .testTarget(
       name: "FirebaseStorageUnit",
       dependencies: ["FirebaseStorage",


### PR DESCRIPTION
Fix test failure `Creating a temporary file via mktemp failed` in POSIX 40 tests on the `swift-build-run` CI job.

**Context:**
The `testPutFileWithPOSIXError40UpdatesExistingFetcherService` and `testPutFileWithPOSIXError40` tests were intermittently failing with `errno Optional(2)` (ENOENT). 
This occurred because the tests used `data.write(to:options: .atomicWrite)`, which internally relies on the `mktemp` C function to create an auxiliary file. If the SPM sandbox environment does not have a fully materialized temporary directory when the test runs, `mktemp` fails with "No such file or directory".

**Fix:**
- Replaced `NSTemporaryDirectory()` with the more modern `FileManager.default.temporaryDirectory`.
- Explicitly called `FileManager.default.createDirectory` to ensure the temporary directory actually exists in the CI environment before writing to it.
- Removed `options: .atomicWrite` to bypass `mktemp` entirely and write the dummy file directly.
- Sanitized the test `#function` name to remove `()` and appended a UUID for guaranteed concurrent execution safety and test leak traceability.
