### PR TITLE
Fix infinite recursion in Swift concurrency verifyPhoneNumber (#16416)

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixed a bug where `verifyPhoneNumber` could hit an infinite recursion and crash due to a Swift concurrency compiler bug in some toolchains. (#16416)
+
 # 12.17.0
 - [fixed] Fixed an array out-of-bounds access in `ActionCodeURL` query parsing.
   (#16382)

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-- [fixed] Fixed a bug where `verifyPhoneNumber` could hit an infinite recursion and crash due to a Swift concurrency compiler bug in some toolchains. (#16416)
+- [fixed] Fixed a bug where `verifyPhoneNumber` could hit an infinite recursion
+  and crash due to a Swift concurrency compiler bug in some toolchains. (#16416)
 
 # 12.17.0
 - [fixed] Fixed an array out-of-bounds access in `ActionCodeURL` query parsing.

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
@@ -79,7 +79,7 @@ import Foundation
                                 completion: (@MainActor (String?, Error?) -> Void)?) {
       Task {
         do {
-          let verificationID = try await verifyPhoneNumber(
+          let verificationID: String = try await verifyPhoneNumber(
             phoneNumber,
             uiDelegate: uiDelegate,
             multiFactorSession: multiFactorSession
@@ -135,7 +135,7 @@ import Foundation
                                 completion: ((String?, Error?) -> Void)?) {
       Task {
         do {
-          let verificationID = try await verifyPhoneNumber(
+          let verificationID: String = try await verifyPhoneNumber(
             with: multiFactorInfo,
             uiDelegate: uiDelegate,
             multiFactorSession: multiFactorSession

--- a/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
@@ -62,6 +62,47 @@
       }
     }
 
+    /**
+     @fn testIssue16416_NoInfiniteRecursionInCompletionHandler
+     @brief Tests that calling verifyPhoneNumber with a completion handler does not cause an infinite recursion (issue 16416).
+     */
+    func testIssue16416_NoInfiniteRecursionInCompletionHandler() {
+      initApp(#function)
+      guard let auth = PhoneAuthProviderTests.auth else {
+        XCTFail("Auth not initialized")
+        return
+      }
+
+      // Provide a fake credential so it doesn't wait for reCAPTCHA/push
+      auth.appCredentialManager?.credential = AuthAppCredential(
+        receipt: "receipt",
+        secret: "secret"
+      )
+
+      rpcIssuer.verifyRequester = { request in
+        do {
+          return try self.rpcIssuer.respond(withJSON: ["sessionInfo": "fakeVerificationID"])
+        } catch {
+          XCTFail("Failure sending response: \(error)")
+          return (nil, nil)
+        }
+      }
+
+      let provider = PhoneAuthProvider.provider(auth: auth)
+      let expectation = self
+        .expectation(description: "Completion should be called without crashing")
+
+      provider
+        .verifyPhoneNumber("123456", uiDelegate: nil,
+                           multiFactorSession: nil) { verificationID, error in
+          // If there is no infinite recursion, this block will be executed.
+          XCTAssertNil(error, "Expected error to be nil but got \(String(describing: error))")
+          XCTAssertEqual(verificationID, "fakeVerificationID")
+          expectation.fulfill()
+        }
+      waitForExpectations(timeout: 2.0)
+    }
+
     /** @fn testVerifyEmptyPhoneNumber
      @brief Tests a failed invocation verifyPhoneNumber because an empty phone
      number was provided.


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-ios-sdk/issues/16416

Under some compiler configurations and toolchains (especially when built in Release mode or as part of a Flutter build), the synthesized optional-argument version of `verifyPhoneNumber` gets resolved as the target of the async thunk instead of the explicitly defined method. This leads to the async method infinitely calling itself, exhausting the Swift task local allocator and crashing the application with an `assertionFailure`.

This PR forcibly disambiguates the call by specifying the return type as `let verificationID: String`. This explicitly eliminates the ambiguity, forcing the compiler to correctly target the `String` returning function instead of the synthesized `String?` version, regardless of the toolchain or build configuration.

A unit test was also added to lock down the completion handler behavior and verify it successfully routes the callback without recursion.