### PR TITLE
docs(FirebaseAI): rename Vertex AI to Agent Platform Gemini API in comments

### DIFF
--- a/FirebaseAI/AGENTS.md
+++ b/FirebaseAI/AGENTS.md
@@ -64,7 +64,7 @@ Data types used in the FirebaseAI library.
 
 ### Public Types
 
-- **`Backend.swift`**: Used to configure the backend API (Gemini Enterprise Agent Platform or Google AI).
+- **`Backend.swift`**: Used to configure the backend API (Agent Platform Gemini API or Gemini Developer API).
 - **`ImageConfig.swift`**: Defines the `ImageConfig` struct, used for configuring generated image properties like aspect ratio and size.
 - **`Part.swift`**: Defines the `Part` protocol and conforming structs (Text, InlineData, FunctionCall, etc.).
 - **`ResponseModality.swift`**: Represents types of data a model can produce (text, image, audio).

--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -2,7 +2,7 @@
 - [fixed] Fixed a stream leak in the Live API where the WebSocket connection
   would remain open indefinitely if the consumer cancelled the stream. (#16393)
 - [changed] Deprecated `Backend.vertexAI` in favor of `Backend.agentPlatform` to
-  reflect the renaming of Vertex AI to Gemini Enterprise Agent Platform.
+  reflect the renaming of Vertex AI to the Agent Platform Gemini API.
   (#16372)
   Note: The default location is now `global` instead of `us-central1` (no other
   functionality has changed). To continue using `us-central1`, specify

--- a/FirebaseAI/Sources/FirebaseAI.swift
+++ b/FirebaseAI/Sources/FirebaseAI.swift
@@ -411,7 +411,7 @@ public final class FirebaseAI: Sendable {
         return "projects/\(firebaseInfo.projectID)/models/\(modelName)"
       case .agentPlatformStagingBypassProxy:
         fatalError(
-          "The Agent Platform Gemini API staging endpoint does not support the Gemini Developer API (Google AI)."
+          "The Agent Platform Gemini API staging endpoint does not support the Gemini Developer API."
         )
     #endif // DEBUG
     }

--- a/FirebaseAI/Sources/FirebaseAI.swift
+++ b/FirebaseAI/Sources/FirebaseAI.swift
@@ -411,7 +411,7 @@ public final class FirebaseAI: Sendable {
         return "projects/\(firebaseInfo.projectID)/models/\(modelName)"
       case .agentPlatformStagingBypassProxy:
         fatalError(
-          "The Gemini Enterprise Agent Platform staging endpoint does not support the Gemini Developer API (Google AI)."
+          "The Agent Platform Gemini API staging endpoint does not support the Gemini Developer API (Google AI)."
         )
     #endif // DEBUG
     }

--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -431,7 +431,7 @@ public struct PromptFeedback: Sendable {
 /// > Important: If using Grounding with Google Search, you are required to comply with the
 /// "Grounding with Google Search" usage requirements for your chosen API provider:
 /// [Gemini Developer API](https://ai.google.dev/gemini-api/terms#grounding-with-google-search)
-/// or Agent Platform Gemini API (see
+/// or the Agent Platform Gemini API (see
 /// [Service Terms](https://cloud.google.com/terms/service-terms)
 /// section within the Service Specific Terms).
 public struct GroundingMetadata: Sendable, Equatable, Hashable {

--- a/FirebaseAI/Sources/GenerateContentResponse.swift
+++ b/FirebaseAI/Sources/GenerateContentResponse.swift
@@ -431,7 +431,7 @@ public struct PromptFeedback: Sendable {
 /// > Important: If using Grounding with Google Search, you are required to comply with the
 /// "Grounding with Google Search" usage requirements for your chosen API provider:
 /// [Gemini Developer API](https://ai.google.dev/gemini-api/terms#grounding-with-google-search)
-/// or Gemini Enterprise Agent Platform Gemini API (see
+/// or Agent Platform Gemini API (see
 /// [Service Terms](https://cloud.google.com/terms/service-terms)
 /// section within the Service Specific Terms).
 public struct GroundingMetadata: Sendable, Equatable, Hashable {
@@ -474,7 +474,7 @@ public struct GroundingMetadata: Sendable, Equatable, Hashable {
     public let title: String?
     /// The domain of the original URI from which the content was retrieved.
     ///
-    /// This field is only populated when using the Gemini Enterprise Agent Platform Gemini API.
+    /// This field is only populated when using the Agent Platform Gemini API.
     public let domain: String?
   }
 
@@ -678,8 +678,8 @@ extension Candidate: Decodable {
 
 extension CitationMetadata: Decodable {
   enum CodingKeys: CodingKey {
-    case citations // Gemini Enterprise Agent Platform
-    case citationSources // Google AI
+    case citations // Agent Platform Gemini API
+    case citationSources // Gemini Developer API
   }
 
   public init(from decoder: any Decoder) throws {

--- a/FirebaseAI/Sources/GenerativeModel.swift
+++ b/FirebaseAI/Sources/GenerativeModel.swift
@@ -61,7 +61,7 @@ public final class GenerativeModel: Sendable {
   ///   - modelName: The name of the model.
   ///   - modelResourceName: The model resource name corresponding with `modelName` in the backend.
   ///     The form depends on the backend and will be one of:
-  ///       - Gemini Enterprise Agent Platform via Firebase AI SDK:
+  ///       - Agent Platform Gemini API via Firebase AI SDK:
   ///       `"projects/{projectID}/locations/{locationID}/publishers/google/models/{modelName}"`
   ///       - Developer API via Firebase AI SDK: `"projects/{projectID}/models/{modelName}"`
   ///       - Developer API via Generative Language: `"models/{modelName}"`
@@ -233,7 +233,7 @@ public final class GenerativeModel: Sendable {
         modelResourceName
       case .googleAI(endpoint: .agentPlatformStagingBypassProxy):
         fatalError(
-          "The Gemini Enterprise Agent Platform staging endpoint does not support the Gemini Developer API (Google AI)."
+          "The Agent Platform Gemini API staging endpoint does not support the Gemini Developer API (Google AI)."
         )
     #endif // DEBUG
     }

--- a/FirebaseAI/Sources/GenerativeModel.swift
+++ b/FirebaseAI/Sources/GenerativeModel.swift
@@ -233,7 +233,7 @@ public final class GenerativeModel: Sendable {
         modelResourceName
       case .googleAI(endpoint: .agentPlatformStagingBypassProxy):
         fatalError(
-          "The Agent Platform Gemini API staging endpoint does not support the Gemini Developer API (Google AI)."
+          "The Agent Platform Gemini API staging endpoint does not support the Gemini Developer API."
         )
     #endif // DEBUG
     }

--- a/FirebaseAI/Sources/Safety.swift
+++ b/FirebaseAI/Sources/Safety.swift
@@ -291,8 +291,8 @@ extension SafetyRating: Decodable {
       HarmProbability.self, forKey: .probability
     ) ?? .unspecified
 
-    // The following 3 fields are only provided when using the Gemini Enterprise Agent Platform
-    // backend (not Google AI).
+    // The following 3 fields are only provided when using the Agent Platform Gemini API
+    // backend (not the Gemini Developer API).
     probabilityScore = try container.decodeIfPresent(Float.self, forKey: .probabilityScore) ?? 0.0
     severity = try container.decodeIfPresent(HarmSeverity.self, forKey: .severity) ?? .unspecified
     severityScore = try container.decodeIfPresent(Float.self, forKey: .severityScore) ?? 0.0

--- a/FirebaseAI/Sources/Tool.swift
+++ b/FirebaseAI/Sources/Tool.swift
@@ -98,7 +98,7 @@ public struct FunctionDeclaration: Sendable {
 /// > Important: When using this feature, you are required to comply with the
 /// "Grounding with Google Search" usage requirements for your chosen API provider:
 /// [Gemini Developer API](https://ai.google.dev/gemini-api/terms#grounding-with-google-search)
-/// or Gemini Enterprise Agent Platform Gemini API (see
+/// or Agent Platform Gemini API (see
 /// [Service Terms](https://cloud.google.com/terms/service-terms)
 /// section within the Service Specific Terms).
 public struct GoogleSearch: Sendable {
@@ -285,7 +285,7 @@ public extension ToolRepresentable where Self == FirebaseAILogic.Tool {
   /// > Important: When using this feature, you are required to comply with the
   /// "Grounding with Google Search" usage requirements for your chosen API provider:
   /// [Gemini Developer API](https://ai.google.dev/gemini-api/terms#grounding-with-google-search)
-  /// or Gemini Enterprise Agent Platform Gemini API (see
+  /// or Agent Platform Gemini API (see
   /// [Service Terms](https://cloud.google.com/terms/service-terms)
   /// section within the Service Specific Terms).
   ///

--- a/FirebaseAI/Sources/Tool.swift
+++ b/FirebaseAI/Sources/Tool.swift
@@ -98,7 +98,7 @@ public struct FunctionDeclaration: Sendable {
 /// > Important: When using this feature, you are required to comply with the
 /// "Grounding with Google Search" usage requirements for your chosen API provider:
 /// [Gemini Developer API](https://ai.google.dev/gemini-api/terms#grounding-with-google-search)
-/// or Agent Platform Gemini API (see
+/// or the Agent Platform Gemini API (see
 /// [Service Terms](https://cloud.google.com/terms/service-terms)
 /// section within the Service Specific Terms).
 public struct GoogleSearch: Sendable {
@@ -285,7 +285,7 @@ public extension ToolRepresentable where Self == FirebaseAILogic.Tool {
   /// > Important: When using this feature, you are required to comply with the
   /// "Grounding with Google Search" usage requirements for your chosen API provider:
   /// [Gemini Developer API](https://ai.google.dev/gemini-api/terms#grounding-with-google-search)
-  /// or Agent Platform Gemini API (see
+  /// or the Agent Platform Gemini API (see
   /// [Service Terms](https://cloud.google.com/terms/service-terms)
   /// section within the Service Specific Terms).
   ///

--- a/FirebaseAI/Sources/Types/Internal/APIConfig.swift
+++ b/FirebaseAI/Sources/Types/Internal/APIConfig.swift
@@ -43,8 +43,8 @@ extension APIConfig {
     /// Agent Platform Gemini API.
     ///
     /// See the [Cloud
-    /// docs](https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/models/inference) for
-    /// more details.
+    /// docs](https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/models/inference)
+    /// for more details.
     case agentPlatform(endpoint: Endpoint, location: String)
 
     /// The Gemini Developer API provided by Google AI.

--- a/FirebaseAI/Sources/Types/Internal/APIConfig.swift
+++ b/FirebaseAI/Sources/Types/Internal/APIConfig.swift
@@ -37,13 +37,13 @@ extension APIConfig {
   /// API services providing generative AI functionality.
   ///
   /// See [Agent Platform Gemini API and Gemini Developer API
-  /// differences](https://cloud.google.com/vertex-ai/generative-ai/docs/overview#how-gemini-vertex-different-gemini-aistudio)
+  /// differences](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/migrate/migrate-google-ai#google-ai)
   /// for a comparison of the two [API services](https://google.aip.dev/9#api-service).
   enum Service: Hashable, Encodable {
     /// Agent Platform Gemini API.
     ///
     /// See the [Cloud
-    /// docs](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) for
+    /// docs](https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/models/inference) for
     /// more details.
     case agentPlatform(endpoint: Endpoint, location: String)
 

--- a/FirebaseAI/Sources/Types/Internal/APIConfig.swift
+++ b/FirebaseAI/Sources/Types/Internal/APIConfig.swift
@@ -36,11 +36,11 @@ struct APIConfig: Sendable, Hashable, Encodable {
 extension APIConfig {
   /// API services providing generative AI functionality.
   ///
-  /// See [Gemini Enterprise Agent Platform and Google AI
+  /// See [Agent Platform Gemini API and Gemini Developer API
   /// differences](https://cloud.google.com/vertex-ai/generative-ai/docs/overview#how-gemini-vertex-different-gemini-aistudio)
   /// for a comparison of the two [API services](https://google.aip.dev/9#api-service).
   enum Service: Hashable, Encodable {
-    /// Gemini Enterprise Agent Platform Gemini API.
+    /// Agent Platform Gemini API.
     ///
     /// See the [Cloud
     /// docs](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference) for
@@ -72,31 +72,29 @@ extension APIConfig.Service {
   enum Endpoint: String, Encodable {
     /// The Firebase proxy production endpoint.
     ///
-    /// This endpoint supports both Google AI and Gemini Enterprise Agent Platform.
+    /// This endpoint supports both the Gemini Developer API and the Agent Platform Gemini API.
     case firebaseProxyProd = "https://firebasevertexai.googleapis.com"
 
     #if DEBUG
       /// The Firebase proxy staging endpoint; for SDK development and testing only.
       ///
       /// This endpoint supports both the Gemini Developer API (commonly referred to as Google AI)
-      /// and the Gemini API in Gemini Enterprise Agent Platform (commonly referred to simply as
-      /// Gemini Enterprise Agent Platform).
+      /// and the Agent Platform Gemini API.
       case firebaseProxyStaging = "https://staging-firebasevertexai.sandbox.googleapis.com"
 
       /// The Gemini Developer API (Google AI) direct production endpoint; for SDK development and
       /// testing only.
       ///
       /// This bypasses the Firebase proxy and directly connects to the Gemini Developer API
-      /// (Google AI) backend. This endpoint only supports the Gemini Developer API, not Gemini
-      /// Enterprise Agent Platform.
+      /// (Google AI) backend. This endpoint only supports the Gemini Developer API, not the
+      /// Agent Platform Gemini API.
       case googleAIBypassProxy = "https://generativelanguage.googleapis.com"
 
-      /// The Gemini Enterprise Agent Platform direct staging endpoint; for SDK development and
+      /// The Agent Platform Gemini API direct staging endpoint; for SDK development and
       /// testing only.
       ///
-      /// This bypasses the Firebase proxy and directly connects to the Gemini Enterprise Agent
-      /// Platform backend. This
-      /// endpoint only supports the Gemini API in Gemini Enterprise Agent Platform, not the Gemini
+      /// This bypasses the Firebase proxy and directly connects to the Agent Platform Gemini API
+      /// backend. This endpoint only supports the Agent Platform Gemini API, not the Gemini
       /// Developer API.
       case agentPlatformStagingBypassProxy = "https://staging-aiplatform.sandbox.googleapis.com"
     #endif // DEBUG
@@ -114,9 +112,8 @@ extension APIConfig {
       /// only.
       case v1
 
-      /// The beta channel for version 1 of the direct Gemini Enterprise Agent Platform API, when
-      /// bypassing the Firebase
-      /// proxy; for SDK development and testing only.
+      /// The beta channel for version 1 of the direct Agent Platform Gemini API, when
+      /// bypassing the Firebase proxy; for SDK development and testing only.
       case v1beta1
     #endif // DEBUG
   }

--- a/FirebaseAI/Sources/Types/Public/Backend.swift
+++ b/FirebaseAI/Sources/Types/Public/Backend.swift
@@ -40,7 +40,7 @@ public struct Backend {
   ///     [Vertex AI locations](https://firebase.google.com/docs/vertex-ai/locations?platform=ios#available-locations)
   ///     for a list of supported locations.
   @available(*, deprecated, renamed: "agentPlatform(location:)", message: """
-  Vertex AI has been renamed to the Gemini Enterprise Agent Platform.
+  Vertex AI has been renamed to the Agent Platform Gemini API.
   """)
   public static func vertexAI(location: String) -> Backend {
     return Backend(
@@ -51,9 +51,9 @@ public struct Backend {
     )
   }
 
-  /// Initializes a `Backend` configured for the Gemini Enterprise Agent Platform.
+  /// Initializes a `Backend` configured for the Agent Platform Gemini API.
   ///
-  /// > Note: The Gemini Enterprise Agent Platform was formerly known as the Vertex AI.
+  /// > Note: The Agent Platform Gemini API was formerly known as Vertex AI.
   ///
   /// - Parameters:
   ///   - location: The region identifier, defaulting to `global`; see
@@ -68,7 +68,7 @@ public struct Backend {
     )
   }
 
-  /// Initializes a `Backend` configured for the Google Developer API.
+  /// Initializes a `Backend` configured for the Gemini Developer API.
   public static func googleAI() -> Backend {
     return Backend(
       apiConfig: APIConfig(

--- a/FirebaseAI/Sources/Types/Public/GeminiModel.swift
+++ b/FirebaseAI/Sources/Types/Public/GeminiModel.swift
@@ -15,8 +15,7 @@
 import Foundation
 
 #if compiler(>=6.2.3)
-  /// A Gemini model accessed via the Gemini Developer API or the Gemini Enterprise Agent Platform
-  /// API.
+  /// A Gemini model accessed via the Gemini Developer API or the Agent Platform Gemini API.
   ///
   /// **Public Preview**: This API is a public preview and may be subject to change.
   ///

--- a/FirebaseAI/Sources/Types/Public/SpeakerVoiceConfig.swift
+++ b/FirebaseAI/Sources/Types/Public/SpeakerVoiceConfig.swift
@@ -32,8 +32,7 @@ public struct SpeakerVoiceConfig: Sendable {
   ///
   /// Find the list of supported voices for:
   /// - [Gemini Developer API](https://ai.google.dev/gemini-api/docs/speech-generation)
-  /// - [Gemini Enterprise Agent Platform Gemini
-  /// API](https://docs.cloud.google.com/text-to-speech/docs/gemini-tts)
+  /// - [Agent Platform Gemini API](https://docs.cloud.google.com/text-to-speech/docs/gemini-tts)
   // TODO(b/522397979): Update links to point to Firebase when they're live
   public init(speaker: String, voiceName: String) {
     self.init(

--- a/FirebaseAI/Tests/Unit/Snippets/LiveSnippets.swift
+++ b/FirebaseAI/Tests/Unit/Snippets/LiveSnippets.swift
@@ -30,7 +30,7 @@ final class LiveSnippets: XCTestCase {
   }
 
   func sendAudioReceiveAudio() async throws {
-    // Initialize the Gemini Enterprise Agent Platform backend service
+    // Initialize the Agent Platform Gemini API backend service
     // Set the location to `us-central1` (the flash-live model is only supported in that location)
     // Create a `LiveGenerativeModel` instance with the flash-live model (only model that supports
     // the Live API)

--- a/FirebaseAI/Tests/Unit/Types/CitationMetadataTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/CitationMetadataTests.swift
@@ -55,7 +55,7 @@ final class CitationMetadataTests: XCTestCase {
     XCTAssertEqual(citation, expectedCitation)
   }
 
-  // MARK: - Gemini Enterprise Agent Platform Format Decoding
+  // MARK: - Agent Platform Gemini API Format Decoding
 
   func testDecodeCitationMetadata_agentPlatformFormat() throws {
     let json = """


### PR DESCRIPTION
## Description

This PR addresses review feedback to align documentation comments and fatal error strings with the standard naming convention used in the Firebase AI Logic ecosystem:
- **Gemini Developer API** (instead of Google AI / Google Developer API)
- **Agent Platform Gemini API** (instead of Gemini Enterprise Agent Platform)

This brings the iOS SDK's reference documentation in line with the JS SDK changes (https://github.com/firebase/firebase-js-sdk/pull/10184).

---

## Changes

* Updated documentation markup and comments in `Backend.swift`, `FirebaseAI.swift`, `GenerativeModel.swift`, `GenerateContentResponse.swift`, `Safety.swift`, `Tool.swift`, `GeminiModel.swift`, and `SpeakerVoiceConfig.swift`.
* Updated descriptions in `CHANGELOG.md` and `AGENTS.md`.
* Updated test references and snippets in `LiveSnippets.swift` and `CitationMetadataTests.swift`.