### PR TITLE
Ensure legacy V4 FCM tokens are re-registered when FirebaseMessagingInstallationIdEnabled is YES. (#16458)

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [fixed] Fix an issue where new FCM registration processing was not invoked
+  when `FirebaseMessagingInstallationIdEnabled` was set to `YES` and a legacy token
+  existed in cache. (#16429)
+
 # 12.17.0
 - [fixed] Reject path separators in file extensions for downloaded image
   attachments. (#16387)

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -797,15 +797,11 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     }
   };
 
-  NSString *cachedToken = self.tokenManager.defaultFCMToken;
-  if (!cachedToken.length) {
-    FIRMessagingTokenInfo *cachedTokenInfo =
-        [self.tokenManager cachedTokenInfoWithAuthorizedEntity:senderID
-                                                         scope:kFIRMessagingDefaultTokenScope];
-    cachedToken = cachedTokenInfo.token;
-  }
+  FIRMessagingTokenInfo *cachedTokenInfo =
+      [self.tokenManager cachedTokenInfoWithAuthorizedEntity:senderID
+                                                       scope:kFIRMessagingDefaultTokenScope];
 
-  if (cachedToken.length > 0) {
+  if (cachedTokenInfo.token.length > 0 && [cachedTokenInfo.tokenType isEqualToString:@"FID"]) {
     // We always want to notify the delegate of the FID. If the FID is available now we notify
     // immediately.
     [self notifyDelegateOfFCMTokenAvailability];

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -77,13 +77,15 @@
     return _defaultFCMToken;
   }
 
+  BOOL isInstallationIdEnabled = [FIRMessaging messaging].isInstallationIdEnabled;
+  NSString *expectedTokenType = isInstallationIdEnabled ? @"FID" : @"V4";
+
   FIRMessagingTokenInfo *cachedTokenInfo =
       [self cachedTokenInfoWithAuthorizedEntity:self.fcmSenderID
                                           scope:kFIRMessagingDefaultTokenScope];
-  NSString *cachedToken = cachedTokenInfo.token;
-
-  if (cachedToken) {
-    return cachedToken;
+  if ([cachedTokenInfo.tokenType isEqualToString:expectedTokenType]) {
+    _defaultFCMToken = [cachedTokenInfo.token copy];
+    return _defaultFCMToken;
   } else {
     [self tokenWithAuthorizedEntity:self.fcmSenderID
                               scope:kFIRMessagingDefaultTokenScope

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -83,7 +83,8 @@
   FIRMessagingTokenInfo *cachedTokenInfo =
       [self cachedTokenInfoWithAuthorizedEntity:self.fcmSenderID
                                           scope:kFIRMessagingDefaultTokenScope];
-  if ([cachedTokenInfo.tokenType isEqualToString:expectedTokenType]) {
+  if (cachedTokenInfo.token.length > 0 &&
+      [cachedTokenInfo.tokenType isEqualToString:expectedTokenType]) {
     _defaultFCMToken = [cachedTokenInfo.token copy];
     return _defaultFCMToken;
   } else {

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTest.m
@@ -20,6 +20,7 @@
 #import <GoogleUtilities/GULUserDefaults.h>
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 #import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseMessaging/Sources/FIRMessagingConstants.h"
 #import "FirebaseMessaging/Sources/FIRMessagingPubSub.h"
 #import "FirebaseMessaging/Sources/FIRMessagingTopicOperation.h"
 #import "FirebaseMessaging/Sources/FIRMessagingUtilities.h"
@@ -29,7 +30,9 @@
 #import "FirebaseMessaging/Sources/Token/FIRMessagingAPNSInfo.h"
 #import "FirebaseMessaging/Sources/Token/FIRMessagingFIDRegisterOperation.h"
 #import "FirebaseMessaging/Sources/Token/FIRMessagingFIDUnregisterOperation.h"
+#import "FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.h"
 #import "FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.h"
+#import "FirebaseMessaging/Sources/Token/FIRMessagingTokenStore.h"
 #import "FirebaseMessaging/Tests/UnitTests/FIRMessagingTestUtilities.h"
 #import "Interop/Analytics/Public/FIRAnalyticsInterop.h"
 #import "SharedTestUtilities/URLSession/FIRURLSessionOCMockStub.h"
@@ -425,7 +428,18 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
   OCMStub([(FIRApp *)self.mockFirebaseApp options]).andReturn(mockOptions);
 
   [self.messaging.tokenManager setValue:@"123456789123" forKey:@"fcmSenderID"];
-  [self.messaging.tokenManager setValue:@"fake-cached-fid" forKey:@"defaultFCMToken"];
+  FIRMessagingTokenInfo *cachedTokenInfo =
+      [[FIRMessagingTokenInfo alloc] initWithAuthorizedEntity:@"123456789123"
+                                                        scope:kFIRMessagingDefaultTokenScope
+                                                        token:@"fake-cached-fid"
+                                                   appVersion:@"1.0"
+                                                firebaseAppID:@"app-id"
+                                                    tokenType:@"FID"];
+  OCMStub([self.mockTokenManager
+              cachedTokenInfoWithAuthorizedEntity:@"123456789123"
+                                            scope:kFIRMessagingDefaultTokenScope])
+      .andReturn(cachedTokenInfo);
+  OCMStub([self.mockTokenManager defaultFCMToken]).andReturn(@"fake-cached-fid");
 
   // Setup message delegate.
   id mockDelegate = OCMProtocolMock(@protocol(FIRMessagingDelegate));
@@ -446,6 +460,40 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
   [self.messaging registerWithCompletion:^(NSError *error) {
     XCTAssertNil(error);
     [completionExpectation fulfill];
+  }];
+
+  [self waitForExpectationsWithTimeout:30.0 handler:nil];
+}
+
+- (void)testRegisterCallsRetrieveTokenOrFidWhenCachedTokenIsNotFid {
+  OCMStub([self.mockMessaging isInstallationIdEnabled]).andReturn(YES);
+
+  id mockOptions = OCMClassMock([FIROptions class]);
+  OCMStub([mockOptions GCMSenderID]).andReturn(@"123456789123");
+  OCMStub([(FIRApp *)self.mockFirebaseApp options]).andReturn(mockOptions);
+
+  [self.messaging.tokenManager setValue:@"123456789123" forKey:@"fcmSenderID"];
+
+  FIRMessagingTokenInfo *cachedTokenInfo =
+      [[FIRMessagingTokenInfo alloc] initWithAuthorizedEntity:@"123456789123"
+                                                        scope:kFIRMessagingDefaultTokenScope
+                                                        token:@"old-v4-token"
+                                                   appVersion:@"1.0"
+                                                firebaseAppID:@"app-id"
+                                                    tokenType:@"V4"];
+  OCMStub([self.mockTokenManager
+              cachedTokenInfoWithAuthorizedEntity:@"123456789123"
+                                            scope:kFIRMessagingDefaultTokenScope])
+      .andReturn(cachedTokenInfo);
+
+  // retrieveTokenOrFidForSenderID should be called because the cached token is not "FID".
+  XCTestExpectation *retrieveExpectation =
+      [self expectationWithDescription:@"retrieveTokenOrFidForSenderID should be called"];
+  [[[self.mockMessaging expect] andDo:^(NSInvocation *invocation) {
+    [retrieveExpectation fulfill];
+  }] retrieveTokenOrFidForSenderID:@"123456789123" completion:OCMOCK_ANY];
+
+  [self.messaging registerWithCompletion:^(NSError *error){
   }];
 
   [self waitForExpectationsWithTimeout:30.0 handler:nil];

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenManagerTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenManagerTest.m
@@ -17,9 +17,11 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
+#import "FirebaseMessaging/Sources/FIRMessagingConstants.h"
 #import "FirebaseMessaging/Sources/Token/FIRMessagingAuthService.h"
 #import "FirebaseMessaging/Sources/Token/FIRMessagingCheckinPreferences.h"
 #import "FirebaseMessaging/Sources/Token/FIRMessagingCheckinStore.h"
+#import "FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.h"
 #import "FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.h"
 #import "FirebaseMessaging/Tests/UnitTests/FIRMessagingTestUtilities.h"
 
@@ -160,6 +162,62 @@
 
   [_messaging.tokenManager resetCredentialsIfNeeded];
   OCMVerifyAll(_mockCheckinStore);
+}
+
+- (void)testTokenAndRequestIfNotExistCallsTokenWithAuthorizedEntityWhenCachedTokenIsV4 {
+  OCMStub([_mockMessaging isInstallationIdEnabled]).andReturn(YES);
+
+  _messaging.tokenManager.fcmSenderID = @"123456789123";
+
+  FIRMessagingTokenInfo *cachedTokenInfo =
+      [[FIRMessagingTokenInfo alloc] initWithAuthorizedEntity:@"123456789123"
+                                                        scope:kFIRMessagingDefaultTokenScope
+                                                        token:@"old-v4-token"
+                                                   appVersion:@"1.0"
+                                                firebaseAppID:@"app-id"
+                                                    tokenType:@"V4"];
+
+  OCMStub([_mockTokenManager cachedTokenInfoWithAuthorizedEntity:@"123456789123"
+                                                           scope:kFIRMessagingDefaultTokenScope])
+      .andReturn(cachedTokenInfo);
+
+  OCMExpect([_mockTokenManager tokenWithAuthorizedEntity:@"123456789123"
+                                                   scope:kFIRMessagingDefaultTokenScope
+                                                 options:OCMOCK_ANY
+                                                 handler:OCMOCK_ANY]);
+
+  NSString *token = [_messaging.tokenManager tokenAndRequestIfNotExist];
+
+  XCTAssertNil(token);
+  OCMVerifyAll(_mockTokenManager);
+}
+
+- (void)testTokenAndRequestIfNotExistReturnsCachedV4TokenWhenInstallationIdDisabled {
+  OCMStub([_mockMessaging isInstallationIdEnabled]).andReturn(NO);
+
+  _messaging.tokenManager.fcmSenderID = @"123456789123";
+
+  FIRMessagingTokenInfo *cachedTokenInfo =
+      [[FIRMessagingTokenInfo alloc] initWithAuthorizedEntity:@"123456789123"
+                                                        scope:kFIRMessagingDefaultTokenScope
+                                                        token:@"cached-v4-token"
+                                                   appVersion:@"1.0"
+                                                firebaseAppID:@"app-id"
+                                                    tokenType:@"V4"];
+
+  OCMStub([_mockTokenManager cachedTokenInfoWithAuthorizedEntity:@"123456789123"
+                                                           scope:kFIRMessagingDefaultTokenScope])
+      .andReturn(cachedTokenInfo);
+
+  [[_mockTokenManager reject] tokenWithAuthorizedEntity:OCMOCK_ANY
+                                                  scope:OCMOCK_ANY
+                                                options:OCMOCK_ANY
+                                                handler:OCMOCK_ANY];
+
+  NSString *token = [_messaging.tokenManager tokenAndRequestIfNotExist];
+
+  XCTAssertEqualObjects(token, @"cached-v4-token");
+  OCMVerifyAll(_mockTokenManager);
 }
 
 @end


### PR DESCRIPTION
This PR is expected to fix an issue where new FCM registration processing was not invoked when `FirebaseMessagingInstallationIdEnabled` was set to `YES` and a legacy token existed in cache. (#16429)