### PR TITLE
type-check fcm_options before building image URL in extension helper

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessagingExtensionHelper.m
+++ b/FirebaseMessaging/Sources/FIRMessagingExtensionHelper.m
@@ -112,8 +112,15 @@ pb_bytes_array_t *FIRMessagingEncodeString(NSString *string) {
 
   // The `userInfo` property isn't available on newer versions of tvOS.
 #if !TARGET_OS_TV
-  NSObject *currentImageURL = content.userInfo[kPayloadOptionsName][kPayloadOptionsImageURLName];
-  if (!currentImageURL || currentImageURL == [NSNull null]) {
+  // `userInfo` is the raw remote push payload, so `fcm_options` and its `image`
+  // entry can be any JSON type. Reach the URL only when both are the expected
+  // types, otherwise subscripting a non-dictionary or handing a non-string to
+  // URLWithString: raises an exception in the notification service extension.
+  NSObject *fcmOptions = content.userInfo[kPayloadOptionsName];
+  NSObject *currentImageURL = [fcmOptions isKindOfClass:[NSDictionary class]]
+                                  ? ((NSDictionary *)fcmOptions)[kPayloadOptionsImageURLName]
+                                  : nil;
+  if (![currentImageURL isKindOfClass:[NSString class]]) {
     [self deliverNotification];
     return;
   }

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
@@ -112,6 +112,38 @@ static NSString *const kValidImageURL =
   [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
+- (void)testModifyNotificationWithNonDictionaryOptions {
+  XCTestExpectation *handlerCalledExpectation =
+      [self expectationWithDescription:@"Content handler was called."];
+  UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+  // A sender can set `fcm_options` to any JSON type; a non-dictionary must not
+  // be subscripted for the image key.
+  content.userInfo = @{kFCMPayloadOptionsName : @"not a dictionary"};
+  FIRMessagingContentHandler handler = ^(UNNotificationContent *content) {
+    [handlerCalledExpectation fulfill];
+  };
+  [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
+  OCMReject([_mockExtensionHelper loadAttachmentForURL:[OCMArg any]
+                                     completionHandler:[OCMArg any]]);
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testModifyNotificationWithNonStringImageURL {
+  XCTestExpectation *handlerCalledExpectation =
+      [self expectationWithDescription:@"Content handler was called."];
+  UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+  // The `image` entry is likewise untrusted; a non-string must not be handed to
+  // URLWithString:.
+  content.userInfo = @{kFCMPayloadOptionsName : @{kFCMPayloadOptionsImageURLName : @42}};
+  FIRMessagingContentHandler handler = ^(UNNotificationContent *content) {
+    [handlerCalledExpectation fulfill];
+  };
+  [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
+  OCMReject([_mockExtensionHelper loadAttachmentForURL:[OCMArg any]
+                                     completionHandler:[OCMArg any]]);
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
 - (void)testModifyNotificationWithValidPayloadDataNoMimeType {
   NSString *const kValidTestURL = @"test.jpg";
   NSString *const kValidTestExtension = @".jpg";

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
@@ -122,9 +122,9 @@ static NSString *const kValidImageURL =
   FIRMessagingContentHandler handler = ^(UNNotificationContent *content) {
     [handlerCalledExpectation fulfill];
   };
-  [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
   OCMReject([_mockExtensionHelper loadAttachmentForURL:[OCMArg any]
                                      completionHandler:[OCMArg any]]);
+  [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
   [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
@@ -138,9 +138,9 @@ static NSString *const kValidImageURL =
   FIRMessagingContentHandler handler = ^(UNNotificationContent *content) {
     [handlerCalledExpectation fulfill];
   };
-  [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
   OCMReject([_mockExtensionHelper loadAttachmentForURL:[OCMArg any]
                                      completionHandler:[OCMArg any]]);
+  [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
   [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 


### PR DESCRIPTION
populateNotificationContent reads the image URL from the remote push payload with a chained subscript content.userInfo[@"fcm_options"][@"image"], but a sender can set fcm_options to any JSON type, so a non-dictionary value (string, number, array) reaches objectForKeyedSubscript: on a class that does not implement it and the notification service extension aborts with NSInvalidArgumentException; a dictionary whose image entry is not a string hits the same problem one line later at URLWithString:. The rest of the module already guards untrusted payload dictionaries with isKindOfClass before subscripting (FIRMessaging.m, FIRMessagingAnalytics.m), so I read image only when fcm_options is a dictionary and proceed only when image is a string. Added two tests covering a non-dictionary fcm_options and a non-string image.