### PR TITLE
spm: enable Mac Catalyst for FirebasePerformance and FirebaseInAppMessaging (discussion)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -747,7 +747,8 @@ let package = Package(
     .target(
       name: "FirebaseInAppMessagingTarget",
       dependencies: [
-        .target(name: "FirebaseInAppMessaging", condition: .when(platforms: [.iOS, .tvOS])),
+        .target(name: "FirebaseInAppMessaging",
+                condition: .when(platforms: [.iOS, .tvOS, .macCatalyst])),
       ],
       path: "SwiftPM-PlatformExclude/FirebaseInAppMessagingWrap"
     ),
@@ -883,7 +884,7 @@ let package = Package(
     .target(
       name: "FirebasePerformanceTarget",
       dependencies: [.target(name: "FirebasePerformance",
-                             condition: .when(platforms: [.iOS, .tvOS, .visionOS]))],
+                             condition: .when(platforms: [.iOS, .tvOS, .visionOS, .macCatalyst]))],
       path: "SwiftPM-PlatformExclude/FirebasePerformanceWrap"
     ),
     .target(


### PR DESCRIPTION
> Speculative / discussion **draft** PR. Opening this to ask maintainers whether the current SPM-under-Catalyst behavior for Firebase Performance and Firebase In-App Messaging is intentional and permanent, and — if not — whether a change like this (with any additional source or CI work that Google requires) is worth polishing into a real proposal.

## Summary

Under SPM on Mac Catalyst, the umbrella `.target` entries `FirebasePerformanceTarget` and `FirebaseInAppMessagingTarget` gate their real product dependencies with `.when(platforms: [.iOS, ...])` that omits `.macCatalyst`. The consequence is that a Mac Catalyst app that lists `FirebasePerformance` / `FirebaseInAppMessaging` as SPM products only links the empty `SwiftPM-PlatformExclude/*Wrap` dummies (`FirebasePerformanceTarget.o` / `FirebaseInAppMessagingTarget.o`) and never compiles the real modules.

This draft adds `.macCatalyst` to the platform conditions for **Performance** and **In-App Messaging** wrap-target dependencies. Firebase **App Distribution** is intentionally left iOS-only in this draft (App Distribution's model is genuinely iOS-tester-only).

Concretely:

```diff
     .target(
       name: \"FirebaseInAppMessagingTarget\",
       dependencies: [
-        .target(name: \"FirebaseInAppMessaging\", condition: .when(platforms: [.iOS, .tvOS])),
+        .target(name: \"FirebaseInAppMessaging\",
+                condition: .when(platforms: [.iOS, .tvOS, .macCatalyst])),
       ],
       path: \"SwiftPM-PlatformExclude/FirebaseInAppMessagingWrap\"
     ),
...
     .target(
       name: \"FirebasePerformanceTarget\",
       dependencies: [.target(name: \"FirebasePerformance\",
-                             condition: .when(platforms: [.iOS, .tvOS, .visionOS]))],
+                             condition: .when(platforms: [.iOS, .tvOS, .visionOS, .macCatalyst]))],
       path: \"SwiftPM-PlatformExclude/FirebasePerformanceWrap\"
     ),
```

The Package already declares `.macCatalyst(.v15)` in \`Package.platforms\` and uses `.macCatalyst` alongside `.iOS` / `.tvOS` / `.macOS` for many other targets (Auth, Firestore, Analytics helpers, GoogleAppMeasurementIdentitySupport, etc.), so the style matches existing precedent in the same file.

## Questions for maintainers

1. **Was omitting `.macCatalyst` for `FirebasePerformanceTarget` and `FirebaseInAppMessagingTarget` under SPM intentional and permanent?**
2. If not permanent, **would a real (non-draft) PR along these lines have a chance** once any additional source guards / CI matrix updates you require are in place?
3. Is there context I'm missing about historical Catalyst issues specific to these two products (Performance instrumentation, IAM UI presentation) that motivated the SPM-only exclusion? The CocoaPods podspecs are `s.ios` + `s.tvos`, and Catalyst apps consuming those via CocoaPods historically got the iOS slice through the `Firebase/Firebase.h` umbrella — so this is asking why SPM diverges.

## Compile fitness note (speculative — please treat as discussion)

I have not verified full build-and-link of a Catalyst target against this Package.swift on Google's CI matrix. Notes on source-level fitness:

- **Firebase Performance:** the sources already handle Catalyst explicitly for CoreTelephony, e.g. \`FirebasePerformance/Sources/FPRNanoPbUtils.h\`:
  \`\`\`objc
  #if __has_include(\"CoreTelephony/CTTelephonyNetworkInfo.h\") && !TARGET_OS_MACCATALYST
  \`\`\`
  and `MobileCoreServices` / `QuartzCore` link settings are already `.when(platforms: [.iOS, .tvOS])` (Catalyst has both frameworks available).
- **Firebase In-App Messaging:** many `.m` sources gate on `TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION`. `TARGET_OS_IOS` is 1 under Mac Catalyst (Catalyst is an iOS-derived variant), so these guards should pass on Catalyst. There is a separate `FirebaseInAppMessaging_iOS` sub-target (resources) that is `.when(platforms: [.iOS])` and remains iOS-only; I did not attempt to broaden it here.

If Google CI reveals additional source-level Catalyst issues (availability annotations, missing UIKit-on-macOS APIs, IAM display flows, etc.) I'm happy to iterate on this branch, or to close it and let the team address it in whatever way fits your roadmap. The main ask is the **policy question** above.

## Consumer context (why this came up)

[React Native Firebase](https://github.com/invertase/react-native-firebase) supports Mac Catalyst demos in its release qualification. In `invertase/react-native-firebase#8933` we're qualifying an SPM-first path (SPM as the default resolver). On Catalyst:

- **SPM path (current upstream):** correctly honors these platform conditions and links only the wrap dummies. The RNFB Objective-C++ modules that `@import FirebasePerformance;` / `@import FirebaseInAppMessaging;` therefore fail to compile on Catalyst.
- **CocoaPods path (historical):** Catalyst apps consumed the iOS podspecs and the RNFB modules compiled and linked through the `Firebase/Firebase.h` umbrella. So this worked historically without any RNFB-side change.

We're going to land RNFB-side stubs on Catalyst for those two products regardless (mirroring what App Distribution already does), and cite this PR from those stub comments. But the root question — whether upstream SPM's exclusion is intentional — belongs here.

Related: [invertase/react-native-firebase#8933](https://github.com/invertase/react-native-firebase/pull/8933).

## Not in scope

- No source, header, or CI changes.
- No change to Firebase App Distribution (kept iOS-only — App Distribution's testers-workflow is genuinely iOS-only in practice).
- No podspec changes.