### PR TITLE
docs: fix typos throughout the docs and comments

### DIFF
--- a/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSNonFatalError.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
     NS_DESIGNATED_INITIALIZER;
 
 /**
- * Records the error to disk. No-op if intialization failed.
+ * Records the error to disk. No-op if initialization failed.
  * The action to record to disk is executed on the thread this method is called on.
  */
 - (void)recordError;

--- a/FirebaseAI/Tests/TestApp/Tests/Utilities/IntegrationTestUtils.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Utilities/IntegrationTestUtils.swift
@@ -98,7 +98,7 @@ func withTimeout<T: Sendable>(seconds: TimeInterval,
                               operation: @escaping @Sendable () async throws -> T) async throws
   -> T? {
   guard seconds > 0 else {
-    fatalError("seconds must be a postive number, but we got \(seconds) instead")
+    fatalError("seconds must be a positive number, but we got \(seconds) instead")
   }
   // constrain to one hour, just in case someone accidentally passed too large of a value
   guard seconds <= 3600 else {

--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -81,7 +81,7 @@
   when used in `queryOrderedByKey` queries (#7403).
 
 # 7.5.0
-- [added] Implmement `queryStartingAfterValue` and `queryEndingBeforeValue` for FirebaseDatabase query pagination.
+- [added] Implement `queryStartingAfterValue` and `queryEndingBeforeValue` for FirebaseDatabase query pagination.
 - [added] Added `DatabaseQuery#getData` which returns data from the server when cache is stale (#7110).
 
 # 7.2.0

--- a/FirebaseInAppMessaging/Sources/DefaultUI/Banner/FIRIAMBannerViewController.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/Banner/FIRIAMBannerViewController.m
@@ -35,7 +35,7 @@
 
 // Banner view will be rendered and dismissed with animation. Within viewDidLayoutSubviews function,
 // we would position the view so that it's out of UIWindow range on the top so that later on it can
-// slide in with animation. However, viewDidLayoutSubviews is also triggred in other scenarios
+// slide in with animation. However, viewDidLayoutSubviews is also triggered in other scenarios
 // like split view on iPad or device orientation changes where we don't want to hide the banner for
 // animations. So to have different logic, we use this property to tell the two different
 // cases apart and apply different positioning logic accordingly in viewDidLayoutSubviews.

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMActionURLFollower.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMActionURLFollower.m
@@ -169,7 +169,7 @@ NS_EXTENSION_UNAVAILABLE("Firebase In App Messaging is not supported for iOS ext
 // Try to handle the url as a universal link by triggering
 // application:continueUserActivity:restorationHandler: on App's delegate object directly.
 // @return YES if that delegate method is defined and seeing a YES being returned from
-// trigging it
+// triggering it
 - (BOOL)followURLWithContinueUserActivity:(NSURL *)url {
   if (self.isContinueUserActivityMethodDefined) {
     FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM240004",

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchFlowTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchFlowTests.m
@@ -244,7 +244,7 @@ CGFloat FETCH_MIN_INTERVALS = 1;
   OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(200);
   OCMStub([self.mockBookkeeper lastFetchTime]).andReturn(0);
 
-  // We don't expect fetchMessages: for self.mockMessageFetcher to be triggred
+  // We don't expect fetchMessages: for self.mockMessageFetcher to be triggered
   OCMReject([self.mockMessageFetcher fetchMessagesWithImpressionList:[OCMArg any]
                                                       withCompletion:[OCMArg any]]);
   [self.flow checkAndFetchForInitialAppLaunch:NO];

--- a/FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h
+++ b/FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
                   configContent:(RCNConfigContent *)configContent
                       analytics:(nullable id<FIRAnalyticsInterop>)analytics;
 
-/// Register RolloutsStateSubcriber to FIRRemoteConfig instance
+/// Register RolloutsStateSubscriber to FIRRemoteConfig instance
 - (void)addRemoteConfigInteropSubscriber:(id<FIRRolloutsStateSubscriber> _Nonnull)subscriber;
 
 @end

--- a/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
@@ -72,7 +72,7 @@
   FIRRemoteConfig *config = [provider remoteConfigForNamespace:sharedNamespace];
   XCTAssertNotNil(config);
 
-  // Use a new app and new povider, ensure the instances with the same namespace are different.
+  // Use a new app and new provider, ensure the instances with the same namespace are different.
   NSString *secondAppName = [provider.app.name stringByAppendingString:@"2"];
   FIRApp *secondApp = [[FIRApp alloc] initInstanceWithName:secondAppName
                                                    options:[self fakeOptions]];

--- a/Firestore/Source/Public/FirebaseFirestore/FIRVectorValue.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRVectorValue.h
@@ -32,7 +32,7 @@ NS_SWIFT_NAME(VectorValue)
 - (instancetype)init NS_UNAVAILABLE;
 
 /**
- * Creates a `VectorValue` constructed with a copy of the given array of NSNumbrers.
+ * Creates a `VectorValue` constructed with a copy of the given array of NSNumbers.
  * @param array An array of NSNumbers that represents a vector.
  */
 - (instancetype)initWithArray:(NSArray<NSNumber *> *)array NS_REFINED_FOR_SWIFT;

--- a/Firestore/third_party/re2/re2/re2.h
+++ b/Firestore/third_party/re2/re2/re2.h
@@ -585,7 +585,7 @@ class RE2 {
   // to string "out".
   // Returns true on success.  This method can fail because of a malformed
   // rewrite string.  CheckRewriteString guarantees that the rewrite will
-  // be sucessful.
+  // be successful.
   bool Rewrite(std::string* out,
                const StringPiece& rewrite,
                const StringPiece* vec,

--- a/Firestore/third_party/re2/re2/re2.h
+++ b/Firestore/third_party/re2/re2/re2.h
@@ -581,7 +581,7 @@ class RE2 {
   // Replace(). E.g. if rewrite == "foo \\2,\\1", returns 2.
   static int MaxSubmatch(const StringPiece& rewrite);
 
-  // Append the "rewrite" string, with backslash subsitutions from "vec",
+  // Append the "rewrite" string, with backslash substitutions from "vec",
   // to string "out".
   // Returns true on success.  This method can fail because of a malformed
   // rewrite string.  CheckRewriteString guarantees that the rewrite will


### PR DESCRIPTION
Changes scope kept in comments and docs (except for one `fatalError` message).
All changes are backward compatible.