### PR TITLE
docs: fix typos throughout the tests

### DIFF
--- a/Crashlytics/UnitTests/FIRCrashlyticsReportTests.m
+++ b/Crashlytics/UnitTests/FIRCrashlyticsReportTests.m
@@ -87,7 +87,7 @@
 }
 
 #pragma mark - Public Getter Methods
-- (void)testPropertiesFromMetadatFile {
+- (void)testPropertiesFromMetadataFile {
   FIRCrashlyticsReport *report = [self createTempCopyOfReportWithName:@"metadata_only_report"];
 
   XCTAssertEqualObjects(@"772929a7f21f4ad293bb644668f257cd", report.reportID);

--- a/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithCredentialTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithCredentialTests.swift
@@ -545,14 +545,14 @@ class SignInWithCredentialTests: XCTestCase {
     var cancellables = Set<AnyCancellable>()
     let userSignInExpectation = expectation(description: "User signed in")
 
-    let emailCrendential = EmailAuthProvider.credential(
+    let emailCredential = EmailAuthProvider.credential(
       withEmail: Self.email,
       link: Self.fakeEmailSignInlink
     )
 
     // when
     Auth.auth()
-      .signIn(with: emailCrendential)
+      .signIn(with: emailCredential)
       .sink { completion in
         switch completion {
         case .finished:
@@ -586,14 +586,14 @@ class SignInWithCredentialTests: XCTestCase {
     var cancellables = Set<AnyCancellable>()
     let userSignInExpectation = expectation(description: "User disabled")
 
-    let emailCrendential = EmailAuthProvider.credential(
+    let emailCredential = EmailAuthProvider.credential(
       withEmail: Self.email,
       link: Self.fakeEmailSignInlink
     )
 
     // when
     Auth.auth()
-      .signIn(with: emailCrendential)
+      .signIn(with: emailCredential)
       .sink { completion in
         if case let .failure(error as NSError) = completion {
           XCTAssertNotNil(error.userInfo[NSLocalizedDescriptionKey])

--- a/FirebaseMessaging/Apps/Sample/README.md
+++ b/FirebaseMessaging/Apps/Sample/README.md
@@ -7,7 +7,7 @@ To run this app, you'll need the following steps.
 1. Go to the [Firebase Console](https://console.firebase.google.com/)
 2. Create a Firebase project if you don't have one already.
 3. Create a new iOS App if you don't have one already.
-4. Go to Project Overview -> General -> Your apps, select your iOS app and download the GoogleSerive-Info.plist file.
+4. Go to Project Overview -> General -> Your apps, select your iOS app and download the GoogleService-Info.plist file.
 
 
 #### Push notification provisioning profile

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -1195,7 +1195,7 @@ using firebase::firestore::util::TimerId;
 }
 
 - (void)testCanQueueWritesWhileOffline {
-  XCTestExpectation *writeEpectation = [self expectationWithDescription:@"successful write"];
+  XCTestExpectation *writeExpectation = [self expectationWithDescription:@"successful write"];
   XCTestExpectation *networkExpectation = [self expectationWithDescription:@"enable network"];
 
   FIRDocumentReference *doc = [self documentRef];
@@ -1208,7 +1208,7 @@ using firebase::firestore::util::TimerId;
     [doc setData:data
         completion:^(NSError *error) {
           XCTAssertNil(error);
-          [writeEpectation fulfill];
+          [writeExpectation fulfill];
         }];
 
     [firestore enableNetworkWithCompletion:^(NSError *error) {


### PR DESCRIPTION
Fixed a bunch of typos in test codes.
Changes scoped to tests and seem not to have any effects on the public code and backward compatibility.