### PR TITLE
fix(ai): correct FunctionResponsePart role to "user"

### DIFF
--- a/FirebaseAI/Sources/Tool.swift
+++ b/FirebaseAI/Sources/Tool.swift
@@ -260,7 +260,7 @@ public extension ToolRepresentable where Self == FirebaseAILogic.Tool {
   ///   configured by specifying a ``ToolConfig`` when instantiating the model. When a
   ///   ``FunctionCallPart`` is received, the next conversation turn may contain a
   ///   ``FunctionResponsePart`` in ``ModelContent/parts`` with a ``ModelContent/role`` of
-  ///   `"function"`; this response contains the result of executing the function on the client,
+  ///   `"user"`; this response contains the result of executing the function on the client,
   ///   providing generation context for the model's next turn.
   static func functionDeclarations(_ functionDeclarations: [FunctionDeclaration]) -> Tool {
     return self.init(functionDeclarations: functionDeclarations)

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/IntegrationTests.swift
@@ -184,7 +184,7 @@ final class IntegrationTests: XCTestCase {
     let response = try await model.countTokens([
       ModelContent(role: "user", parts: prompt),
       ModelContent(role: "model", parts: sumCall),
-      ModelContent(role: "function", parts: sumResponse),
+      ModelContent(role: "user", parts: sumResponse),
     ])
 
     XCTAssertGreaterThan(response.totalTokens, 0)

--- a/FirebaseAI/Tests/Unit/Snippets/FunctionCallingSnippets.swift
+++ b/FirebaseAI/Tests/Unit/Snippets/FunctionCallingSnippets.swift
@@ -100,7 +100,7 @@ final class FunctionCallingSnippets: XCTestCase {
     // Send the response(s) from the function back to the model so that the model can use it
     // to generate its final response.
     let finalResponse = try await chat.sendMessage(
-      [ModelContent(role: "function", parts: functionResponses)]
+      [ModelContent(role: "user", parts: functionResponses)]
     )
 
     // Log the text response.


### PR DESCRIPTION
Updated the `FunctionResponsePart` role from `"function"` to `"user"` in tests, snippets, and documentation comments.

Previously `"function"` was used and accepted by the backend but the documented role `"user"` is now enforced when using Gemini 3.6 Flash on the Gemini Developer API.

Note: This fix has already been applied for `GeminiLanguageModel` in https://github.com/firebase/firebase-ios-sdk/commit/33c3ccb84f09a96574afeedb6422e415550ae3d4.

#no-changelog