### PR TITLE
ci: replace downloadPlatform with simctl create

### DIFF
--- a/.github/actions/setup_simulator/action.yml
+++ b/.github/actions/setup_simulator/action.yml
@@ -1,0 +1,12 @@
+name: Setup Simulator
+description: Creates a simulator for the specified platform using the latest installed runtime.
+inputs:
+  platform:
+    description: 'Platform (iOS, tvOS, watchOS, visionOS, all)'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Simulator
+      shell: bash
+      run: scripts/setup_simulator.sh "${{ inputs.platform }}"

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -136,22 +136,11 @@ jobs:
       env:
         XCODE_VERSION: ${{ inputs.xcode }}
       run: sudo xcode-select -s /Applications/"$XCODE_VERSION".app/Contents/Developer
-    - name: Install simulators
+    - name: Setup simulator
       if: inputs.platform != 'macOS' && inputs.platform != 'catalyst'
-      env:
-        PLATFORM_INPUT: ${{ inputs.platform }}
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: |
-          if [[ "$PLATFORM_INPUT" == "all" ]]; then
-            xcodebuild -downloadAllPlatforms
-          else
-            xcodebuild -downloadPlatform "$PLATFORM_INPUT"
-          fi
+        platform: ${{ inputs.platform }}
     - name: Run setup command
       if: inputs.setup_command != ''
       # This file is used as a template for other workflows, so

--- a/.github/workflows/_cocoapods.cron.yml
+++ b/.github/workflows/_cocoapods.cron.yml
@@ -78,15 +78,11 @@ jobs:
       env:
         XCODE_VERSION: ${{ inputs.xcode }}
       run: sudo xcode-select -s /Applications/"$XCODE_VERSION".app/Contents/Developer
-    - name: Install simulators in case they are missing.
+    - name: Setup simulator
       if: matrix.platform != 'macos'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: xcodebuild -downloadPlatform ${{ matrix.platform }}
+        platform: ${{ matrix.platform }}
     - name: Set FIREBASE_CI, if needed.
       if: inputs.ignore_deprecation_warnings == true
       run: echo "FIREBASE_CI=true" >> "$GITHUB_ENV"

--- a/.github/workflows/_cocoapods.yml
+++ b/.github/workflows/_cocoapods.yml
@@ -150,15 +150,11 @@ jobs:
         command: scripts/setup_bundler.sh
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Install simulators in case they are missing.
+    - name: Setup simulator
       if: matrix.platform != 'macOS'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: xcodebuild -downloadPlatform ${{ matrix.platform }}
+        platform: ${{ matrix.platform }}
     - name: Set conditional environment variable, if needed.
       if: inputs.product == 'FirebaseAuth'
       run: echo "FIREBASE_CI=true" >> "$GITHUB_ENV"

--- a/.github/workflows/_quickstart.framework.yml
+++ b/.github/workflows/_quickstart.framework.yml
@@ -75,15 +75,10 @@ jobs:
       env:
         XCODE_VERSION: ${{ inputs.xcode }}
       run: sudo xcode-select -s /Applications/"$XCODE_VERSION".app/Contents/Developer
-    - name: Install simulators
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    - name: Setup simulator
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: |
-          xcodebuild -downloadPlatform iOS
+        platform: iOS
     - name: Setup Bundler
       run: ./scripts/setup_bundler.sh
     - name: Move frameworks

--- a/.github/workflows/_quickstart.yml
+++ b/.github/workflows/_quickstart.yml
@@ -79,14 +79,10 @@ jobs:
       run: gem install xcpretty
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
-    - name: Install simulators
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    - name: Setup simulator
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: xcodebuild -downloadPlatform iOS
+        platform: iOS
     - name: Run setup command.
       run: ${{ inputs.setup_command }} # zizmor: ignore[template-injection]
     - name: Install Secret GoogleService-Info.plist

--- a/.github/workflows/_spm.yml
+++ b/.github/workflows/_spm.yml
@@ -163,15 +163,11 @@ jobs:
         key: ${{needs.spm-package-resolved.outputs.cache_key}}
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Install simulators in case they are missing.
+    - name: Setup simulator
       if: matrix.platform != 'macOS' && matrix.platform != 'catalyst'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: xcodebuild -downloadPlatform ${{ matrix.platform }}
+        platform: ${{ matrix.platform }}
     - name: Run setup command, if needed.
       if: inputs.setup_command != ''
       # hacky workaround for zizmor

--- a/.github/workflows/infra.archiving.yml
+++ b/.github/workflows/infra.archiving.yml
@@ -33,14 +33,10 @@ jobs:
         persist-credentials: false
     - name: Set Xcode version
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
-    - name: Install iOS SDK
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    - name: Setup simulator
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: xcodebuild -downloadPlatform iOS
+        platform: iOS
     - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
@@ -69,20 +65,11 @@ jobs:
         persist-credentials: false
     - name: Set Xcode version
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
-    - name: Install SDK
+    - name: Setup simulator
       if: matrix.target != 'macos'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: |
-          if [[ "${{ matrix.target }}" == "ios" ]]; then
-            xcodebuild -downloadPlatform iOS
-          elif [[ "${{ matrix.target }}" == "tvos" ]]; then
-            xcodebuild -downloadPlatform tvOS
-          fi
+        platform: ${{ matrix.target }}
     - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
     - name: Setup Bundler
       run: scripts/setup_bundler.sh

--- a/.github/workflows/infra.spm_global.yml
+++ b/.github/workflows/infra.spm_global.yml
@@ -81,14 +81,10 @@ jobs:
       run: scripts/update_vertexai_responses.sh
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Install simulators in case they are missing.
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    - name: Setup simulator
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: xcodebuild -downloadPlatform iOS
+        platform: iOS
     - name: Initialize xcodebuild
       run: scripts/setup_spm_tests.sh
     - name: Functions Integration Test Server
@@ -129,14 +125,10 @@ jobs:
       run: scripts/update_vertexai_responses.sh
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Install simulators in case they are missing.
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    - name: Setup simulator
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: xcodebuild -downloadPlatform iOS
+        platform: iOS
     - name: Initialize xcodebuild
       run: scripts/setup_spm_tests.sh
     - name: iOS Device and Test Build
@@ -172,15 +164,11 @@ jobs:
         key: ${{needs.spm-package-resolved.outputs.cache_key}}
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Install simulators in case they are missing.
+    - name: Setup simulator
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: xcodebuild -downloadPlatform ${{ matrix.target }}
+        platform: ${{ matrix.target }}
     - name: Initialize xcodebuild
       run: scripts/setup_spm_tests.sh
     - name: Objc Import Tests
@@ -225,14 +213,10 @@ jobs:
         key: ${{needs.spm-package-resolved.outputs.cache_key}}
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
-    - name: Install simulators in case they are missing.
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    - name: Setup simulator
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: xcodebuild -downloadPlatform iOS
+        platform: iOS
     - name: Initialize xcodebuild
       run: scripts/setup_spm_tests.sh
     - name: Build for CodeQL

--- a/.github/workflows/release.zip.yml
+++ b/.github/workflows/release.zip.yml
@@ -267,7 +267,7 @@ jobs:
             plist_src: "scripts/gha-encrypted/qs-crashlytics.plist.gpg"
             plist_dst: "quickstart-ios/crashlytics/GoogleService-Info.plist"
             command: |
-              xcodebuild -downloadPlatform watchOS
+              scripts/setup_simulator.sh watchOS
               rm -rf "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseAnalytics*
               rm -rf "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleAppMeasurement*
               rm -rf "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleAds*

--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -119,13 +119,9 @@ jobs:
         persist-credentials: false
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Install simulators in case they are missing.
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    - name: Setup simulator
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: xcodebuild -downloadPlatform iOS
+        platform: iOS
     - name: Build Quickstart
       run: scripts/quickstart_build_spm.sh FirebaseAI

--- a/.github/workflows/sdk.analytics.yml
+++ b/.github/workflows/sdk.analytics.yml
@@ -44,15 +44,11 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Install simulators in case they are missing.
+    - name: Setup simulator
       if: matrix.target != 'macos'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        continue_on_error: true
-        command: xcodebuild -downloadPlatform ${{ matrix.target }}
+        platform: ${{ matrix.target }}
     - name: GoogleAppMeasurement
       run: scripts/third_party/travis/retry.sh pod spec lint GoogleAppMeasurement.podspec --platforms=${{ matrix.target }} --sources=https://github.com/firebase/SpecsDev.git,https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/
     - name: FirebaseAnalytics

--- a/.github/workflows/sdk.auth.yml
+++ b/.github/workflows/sdk.auth.yml
@@ -88,13 +88,10 @@ jobs:
           FirebaseAuth/Tests/SampleSwift/SwiftApiTests/Credentials.swift "$plist_secret"
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
-    - name: Install simulators in case they are missing.
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    - name: Setup simulator
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        command: xcodebuild -downloadPlatform iOS
+        platform: iOS
     - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15

--- a/.github/workflows/sdk.crashlytics.yml
+++ b/.github/workflows/sdk.crashlytics.yml
@@ -49,7 +49,7 @@ jobs:
     uses: ./.github/workflows/_quickstart.yml
     with:
       product: Crashlytics
-      setup_command: scripts/setup_quickstart.sh crashlytics && xcodebuild -downloadPlatform watchOS
+      setup_command: scripts/setup_quickstart.sh crashlytics && scripts/setup_simulator.sh watchOS
       plist_src_path: scripts/gha-encrypted/qs-crashlytics.plist.gpg
       plist_dst_path: quickstart-ios/crashlytics/GoogleService-Info.plist
     secrets:

--- a/.github/workflows/sdk.firestore.yml
+++ b/.github/workflows/sdk.firestore.yml
@@ -304,14 +304,11 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
 
-      - name: Install simulators in case they are missing.
+      - name: Setup simulator
         if: matrix.target != 'macOS'
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: ./.github/actions/setup_simulator
         with:
-          timeout_minutes: 15
-          max_attempts: 5
-          retry_wait_seconds: 120
-          command: sudo xcodebuild -downloadPlatform ${{ matrix.target }}
+          platform: ${{ matrix.target }}
 
       - name: Cache Pods
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
@@ -371,14 +368,11 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
 
-      - name: Install simulators in case they are missing.
+      - name: Setup simulator
         if: matrix.target != 'macOS'
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: ./.github/actions/setup_simulator
         with:
-          timeout_minutes: 15
-          max_attempts: 5
-          retry_wait_seconds: 120
-          command: sudo xcodebuild -downloadPlatform ${{ matrix.target }}
+          platform: ${{ matrix.target }}
 
       - name: Cache Pods
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
@@ -445,14 +439,11 @@ jobs:
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
 
-    - name: Install simulators in case they are missing.
+    - name: Setup simulator
       if: matrix.target != 'macOS'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        command: sudo xcodebuild -downloadPlatform ${{ matrix.target }}
+        platform: ${{ matrix.target }}
 
     - name: Cache Pods
       uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
@@ -537,14 +528,11 @@ jobs:
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
 
-    - name: Install simulators in case they are missing.
+    - name: Setup simulator
       if: matrix.platforms != 'macos'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        command: sudo xcodebuild -downloadPlatform ${{ matrix.platforms }}
+        platform: ${{ matrix.platforms }}
 
     - name: Pod lib lint
       # TODO(#9565, b/227461966): Remove --no-analyze when absl is fixed.
@@ -619,14 +607,11 @@ jobs:
         persist-credentials: false
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    - name: Install simulators in case they are missing.
+    - name: Setup simulator
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        command: sudo xcodebuild -downloadPlatform ${{ matrix.target }}
+        platform: ${{ matrix.target }}
     - name: Initialize xcodebuild
       run: scripts/setup_spm_tests.sh
     - name: iOS Build Test
@@ -654,14 +639,11 @@ jobs:
         persist-credentials: false
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
-    - name: Install simulators in case they are missing.
+    - name: Setup simulator
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        command: sudo xcodebuild -downloadPlatform ${{ matrix.target }}
+        platform: ${{ matrix.target }}
     - name: Initialize xcodebuild
       run: scripts/setup_spm_tests.sh
     - name: Build Test - Binary
@@ -680,14 +662,11 @@ jobs:
         persist-credentials: false
     - name: Xcode
       run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
-    - name: Install simulators in case they are missing.
+    - name: Setup simulator
       if: matrix.target != 'macOS' && matrix.target != 'catalyst'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/setup_simulator
       with:
-        timeout_minutes: 15
-        max_attempts: 5
-        retry_wait_seconds: 120
-        command: sudo xcodebuild -downloadPlatform ${{ matrix.target }}
+        platform: ${{ matrix.target }}
     - name: Initialize xcodebuild
       run: scripts/setup_spm_tests.sh
     - name: Build Test - Binary

--- a/Package.swift
+++ b/Package.swift
@@ -707,7 +707,6 @@ func packageTargets() -> [Target] {
 
       // MARK: - Firebase Functions
 
-      // TODO: Remove this comment before merging. Using it to trigger tests on CI.
       .target(
         name: "FirebaseFunctions",
         dependencies: [

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -189,7 +189,7 @@ ios_device_flags=(
 )
 
 ipad_flags=(
-  -destination 'platform=iOS Simulator,name=Firebase-iPhone-15-Pro'
+  -destination 'platform=iOS Simulator,name=Firebase-iPad-Pro-11-inch'
 )
 
 macos_flags=(
@@ -221,7 +221,8 @@ case "$platform" in
 
   iPad)
     xcb_flags=("${ipad_flags[@]}")
-  ;;
+    gen_platform=ios
+    ;;
 
   macOS)
     xcb_flags=("${macos_flags[@]}")

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -170,19 +170,17 @@ function CheckUnexpectedFailures() {
   fi
 }
 
+"${scripts_dir}/setup_simulator.sh" "$platform"
+
 if [[ "$xcode_major" -lt 16 && "$method" != "cmake" ]]; then
   echo "Unsupported Xcode major version being used: $xcode_major"
   exit 1
 else
-  iphone_simulator_name="iPhone 16"
-  if [[ "$xcode_major" -gt 16 ]]; then
-    iphone_simulator_name="iPhone 17"
-  fi
   ios_flags=(
-    -destination "platform=iOS Simulator,name=${iphone_simulator_name}"
+    -destination 'platform=iOS Simulator,name=Firebase-iPhone-15-Pro'
   )
   watchos_flags=(
-    -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (42mm)'
+    -destination 'platform=watchOS Simulator,name=Firebase-Apple-Watch-Ultra-2'
   )
 fi
 
@@ -191,28 +189,18 @@ ios_device_flags=(
 )
 
 ipad_flags=(
-  -destination 'platform=iOS Simulator,name=iPad Pro (9.7-inch)'
+  -destination 'platform=iOS Simulator,name=Firebase-iPhone-15-Pro'
 )
 
 macos_flags=(
   -destination 'platform=OS X,arch=x86_64'
 )
 tvos_flags=(
-  -destination 'platform=tvOS Simulator,name=Apple TV'
+  -destination 'platform=tvOS Simulator,name=Firebase-Apple-TV-4K-Gen-2'
 )
-if [[ "$xcode_major" -ge 26 ]]; then
-  visionos_flags=(
-    -destination "platform=visionOS Simulator,OS=${xcode_version},name=Apple Vision Pro"
-  )
-else
-  # TODO(ncooke3): Remove this else case when we no longer need to test against macOS 15.
-  visionos_flags=(
-    # As of Aug 15, 2025, the default OS "latest" was failing as it matched both
-    # the visionOS 26 beta and visionOS 2.5 (from Xcode 16.4) simulators;
-    # explicitly specifying OS=2.5 in destination as a workaround.
-    -destination 'platform=visionOS Simulator,OS=2.5,name=Apple Vision Pro'
-  )
-fi
+visionos_flags=(
+  -destination 'platform=visionOS Simulator,name=Firebase-Apple-Vision-Pro'
+)
 catalyst_flags=(
   ARCHS=x86_64 VALID_ARCHS=x86_64 SUPPORTS_MACCATALYST=YES
   -destination platform="macOS,variant=Mac Catalyst,arch=x86_64" TARGETED_DEVICE_FAMILY=2

--- a/scripts/setup_simulator.sh
+++ b/scripts/setup_simulator.sh
@@ -24,16 +24,16 @@ create_sim() {
   local device_type="$3"
 
   local runtime
-  runtime=$(xcrun simctl list runtimes | grep -i -E "$platform_search" | grep -v 'unavailable' | tail -1 | awk '{print $NF}')
+  runtime=$(xcrun simctl list runtimes | grep -i -E "$platform_search" | grep -v 'unavailable' | tail -1 | awk '{print $NF}' || true)
 
   if [[ -z "$runtime" ]]; then
-    echo "Warning: Could not find available runtime for platform search '$platform_search'." >&2
-    return 0
+    echo "Error: Could not find available runtime for platform search '$platform_search'." >&2
+    exit 1
   fi
 
   if ! xcrun simctl list devices | grep -q "$sim_name"; then
     echo "Creating simulator '$sim_name' ($device_type) with runtime '$runtime'..."
-    xcrun simctl create "$sim_name" "$device_type" "$runtime" > /dev/null 2>&1 || true
+    xcrun simctl create "$sim_name" "$device_type" "$runtime" > /dev/null
   else
     echo "Simulator '$sim_name' already exists."
   fi
@@ -58,7 +58,7 @@ case "$platform" in
     create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-2nd-generation-1080p"
     create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro"
     ;;
-  macOS|catalyst|Linux)
+  macOS|catalyst|Linux|iOS-device)
     # No simulator creation needed
     ;;
   *)

--- a/scripts/setup_simulator.sh
+++ b/scripts/setup_simulator.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+platform="${1:-iOS}"
+
+create_sim() {
+  local platform_search="$1"
+  local sim_name="$2"
+  local device_type="$3"
+
+  local runtime
+  runtime=$(xcrun simctl list runtimes | grep -i -E "$platform_search" | grep -v 'unavailable' | tail -1 | awk '{print $NF}')
+
+  if [[ -z "$runtime" ]]; then
+    echo "Warning: Could not find available runtime for platform search '$platform_search'." >&2
+    return 0
+  fi
+
+  if ! xcrun simctl list devices | grep -q "$sim_name"; then
+    echo "Creating simulator '$sim_name' ($device_type) with runtime '$runtime'..."
+    xcrun simctl create "$sim_name" "$device_type" "$runtime" > /dev/null 2>&1 || true
+  else
+    echo "Simulator '$sim_name' already exists."
+  fi
+}
+
+case "$platform" in
+  iOS|iPad)
+    create_sim "iOS" "Firebase-iPhone-15-Pro" "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro"
+    ;;
+  watchOS)
+    create_sim "watchOS" "Firebase-Apple-Watch-Ultra-2" "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Ultra-2-49mm"
+    ;;
+  tvOS)
+    create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-2nd-generation-1080p"
+    ;;
+  visionOS)
+    create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro"
+    ;;
+  all)
+    create_sim "iOS" "Firebase-iPhone-15-Pro" "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro"
+    create_sim "watchOS" "Firebase-Apple-Watch-Ultra-2" "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Ultra-2-49mm"
+    create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-2nd-generation-1080p"
+    create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro"
+    ;;
+  macOS|catalyst|Linux)
+    # No simulator creation needed
+    ;;
+  *)
+    create_sim "$platform" "Firebase-iPhone-15-Pro" "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro"
+    ;;
+esac

--- a/scripts/setup_simulator.sh
+++ b/scripts/setup_simulator.sh
@@ -54,23 +54,28 @@ create_sim() {
 main() {
   local platform="${1:-iOS}"
 
+  local platform_clean
+  platform_clean=$(
+    echo "$platform" | awk '{print $1}' | tr '[:upper:]' '[:lower:]'
+  )
+
   local dev_prefix="com.apple.CoreSimulator.SimDeviceType"
   local ios_dev="${dev_prefix}.iPhone-15-Pro"
   local watch_dev="${dev_prefix}.Apple-Watch-Ultra-2-49mm"
   local tv_dev="${dev_prefix}.Apple-TV-4K-2nd-generation-1080p"
   local vision_dev="${dev_prefix}.Apple-Vision-Pro"
 
-  case "$platform" in
-    iOS|iPad)
+  case "$platform_clean" in
+    ios|ipad)
       create_sim "iOS" "Firebase-iPhone-15-Pro" "$ios_dev"
       ;;
-    watchOS)
+    watchos)
       create_sim "watchOS" "Firebase-Apple-Watch-Ultra-2" "$watch_dev"
       ;;
-    tvOS)
+    tvos)
       create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "$tv_dev"
       ;;
-    visionOS)
+    visionos|xros)
       create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "$vision_dev"
       ;;
     all)
@@ -79,11 +84,11 @@ main() {
       create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "$tv_dev"
       create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "$vision_dev"
       ;;
-    macOS|catalyst|Linux|iOS-device)
+    macos|catalyst|linux|ios-device)
       # No simulator creation needed
       ;;
     *)
-      create_sim "$platform" "Firebase-iPhone-15-Pro" "$ios_dev"
+      create_sim "iOS" "Firebase-iPhone-15-Pro" "$ios_dev"
       ;;
   esac
 }

--- a/scripts/setup_simulator.sh
+++ b/scripts/setup_simulator.sh
@@ -59,11 +59,12 @@ main() {
     echo "$platform" | awk '{print $1}' | tr '[:upper:]' '[:lower:]'
   )
 
-  local dev_prefix="com.apple.CoreSimulator.SimDeviceType"
-  local ios_dev="${dev_prefix}.iPhone-15-Pro"
-  local watch_dev="${dev_prefix}.Apple-Watch-Ultra-2-49mm"
-  local tv_dev="${dev_prefix}.Apple-TV-4K-2nd-generation-1080p"
-  local vision_dev="${dev_prefix}.Apple-Vision-Pro"
+  local device_prefix="com.apple.CoreSimulator.SimDeviceType"
+  local ios_device="${device_prefix}.iPhone-15-Pro"
+  local ipad_device="${device_prefix}.iPad-Pro--11-inch---2nd-generation-"
+  local watch_device="${device_prefix}.Apple-Watch-Ultra-2-49mm"
+  local tv_device="${device_prefix}.Apple-TV-4K-2nd-generation-1080p"
+  local vision_device="${device_prefix}.Apple-Vision-Pro"
   local vision_runtime
   vision_runtime=$(
     xcrun simctl list runtimes |
@@ -73,33 +74,37 @@ main() {
       awk '{print $NF}' || true
   )
   if [[ "$vision_runtime" =~ xrOS-26|visionOS-26 ]]; then
-    vision_dev="${dev_prefix}.Apple-Vision-Pro-4K"
+    vision_device="${device_prefix}.Apple-Vision-Pro-4K"
   fi
 
   case "$platform_clean" in
-    ios|ipad)
-      create_sim "iOS" "Firebase-iPhone-15-Pro" "$ios_dev"
+    ios)
+      create_sim "iOS" "Firebase-iPhone-15-Pro" "$ios_device"
+      ;;
+    ipad)
+      create_sim "iOS" "Firebase-iPad-Pro-11-inch" "$ipad_device"
       ;;
     watchos)
-      create_sim "watchOS" "Firebase-Apple-Watch-Ultra-2" "$watch_dev"
+      create_sim "watchOS" "Firebase-Apple-Watch-Ultra-2" "$watch_device"
       ;;
     tvos)
-      create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "$tv_dev"
+      create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "$tv_device"
       ;;
     visionos|xros)
-      create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "$vision_dev"
+      create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "$vision_device"
       ;;
     all)
-      create_sim "iOS" "Firebase-iPhone-15-Pro" "$ios_dev"
-      create_sim "watchOS" "Firebase-Apple-Watch-Ultra-2" "$watch_dev"
-      create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "$tv_dev"
-      create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "$vision_dev"
+      create_sim "iOS" "Firebase-iPhone-15-Pro" "$ios_device"
+      create_sim "iOS" "Firebase-iPad-Pro-11-inch" "$ipad_device"
+      create_sim "watchOS" "Firebase-Apple-Watch-Ultra-2" "$watch_device"
+      create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "$tv_device"
+      create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "$vision_device"
       ;;
     macos|catalyst|linux|ios-device)
       # No simulator creation needed
       ;;
     *)
-      create_sim "iOS" "Firebase-iPhone-15-Pro" "$ios_dev"
+      create_sim "iOS" "Firebase-iPhone-15-Pro" "$ios_device"
       ;;
   esac
 }

--- a/scripts/setup_simulator.sh
+++ b/scripts/setup_simulator.sh
@@ -14,54 +14,78 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Dynamically creates Apple simulator devices using installed runtimes.
+
 set -euo pipefail
 
-platform="${1:-iOS}"
-
+# Creates a simulator with the latest installed runtime for a given platform.
+# Arguments:
+#   $1 - Platform search string for simctl (e.g. "iOS", "watchOS")
+#   $2 - Desired simulator device name (e.g. "Firebase-iPhone-15-Pro")
+#   $3 - Simulator device type ID
+#        (e.g. "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro")
 create_sim() {
   local platform_search="$1"
   local sim_name="$2"
   local device_type="$3"
 
   local runtime
-  runtime=$(xcrun simctl list runtimes | grep -i -E "$platform_search" | grep -v 'unavailable' | tail -1 | awk '{print $NF}' || true)
+  runtime=$(
+    xcrun simctl list runtimes |
+      grep -i -E "$platform_search" |
+      grep -v 'unavailable' |
+      tail -1 |
+      awk '{print $NF}' || true
+  )
 
   if [[ -z "$runtime" ]]; then
-    echo "Error: Could not find available runtime for platform search '$platform_search'." >&2
+    echo "Error: Could not find runtime for platform '$platform_search'." >&2
     exit 1
   fi
 
   if ! xcrun simctl list devices | grep -q "$sim_name"; then
-    echo "Creating simulator '$sim_name' ($device_type) with runtime '$runtime'..."
+    echo "Creating simulator '$sim_name' ($device_type)..."
     xcrun simctl create "$sim_name" "$device_type" "$runtime" > /dev/null
   else
     echo "Simulator '$sim_name' already exists."
   fi
 }
 
-case "$platform" in
-  iOS|iPad)
-    create_sim "iOS" "Firebase-iPhone-15-Pro" "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro"
-    ;;
-  watchOS)
-    create_sim "watchOS" "Firebase-Apple-Watch-Ultra-2" "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Ultra-2-49mm"
-    ;;
-  tvOS)
-    create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-2nd-generation-1080p"
-    ;;
-  visionOS)
-    create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro"
-    ;;
-  all)
-    create_sim "iOS" "Firebase-iPhone-15-Pro" "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro"
-    create_sim "watchOS" "Firebase-Apple-Watch-Ultra-2" "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Ultra-2-49mm"
-    create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-2nd-generation-1080p"
-    create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro"
-    ;;
-  macOS|catalyst|Linux|iOS-device)
-    # No simulator creation needed
-    ;;
-  *)
-    create_sim "$platform" "Firebase-iPhone-15-Pro" "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro"
-    ;;
-esac
+main() {
+  local platform="${1:-iOS}"
+
+  local dev_prefix="com.apple.CoreSimulator.SimDeviceType"
+  local ios_dev="${dev_prefix}.iPhone-15-Pro"
+  local watch_dev="${dev_prefix}.Apple-Watch-Ultra-2-49mm"
+  local tv_dev="${dev_prefix}.Apple-TV-4K-2nd-generation-1080p"
+  local vision_dev="${dev_prefix}.Apple-Vision-Pro"
+
+  case "$platform" in
+    iOS|iPad)
+      create_sim "iOS" "Firebase-iPhone-15-Pro" "$ios_dev"
+      ;;
+    watchOS)
+      create_sim "watchOS" "Firebase-Apple-Watch-Ultra-2" "$watch_dev"
+      ;;
+    tvOS)
+      create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "$tv_dev"
+      ;;
+    visionOS)
+      create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "$vision_dev"
+      ;;
+    all)
+      create_sim "iOS" "Firebase-iPhone-15-Pro" "$ios_dev"
+      create_sim "watchOS" "Firebase-Apple-Watch-Ultra-2" "$watch_dev"
+      create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "$tv_dev"
+      create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "$vision_dev"
+      ;;
+    macOS|catalyst|Linux|iOS-device)
+      # No simulator creation needed
+      ;;
+    *)
+      create_sim "$platform" "Firebase-iPhone-15-Pro" "$ios_dev"
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/setup_simulator.sh
+++ b/scripts/setup_simulator.sh
@@ -34,8 +34,8 @@ create_sim() {
     xcrun simctl list runtimes |
       grep -i -E "$platform_search" |
       grep -v 'unavailable' |
-      tail -1 |
-      awk '{print $NF}' || true
+      grep -o -E 'com\.apple\.CoreSimulator\.SimRuntime\.[a-zA-Z0-9.-]+' |
+      tail -1 || true
   )
 
   if [[ -z "$runtime" ]]; then
@@ -48,6 +48,26 @@ create_sim() {
     xcrun simctl create "$sim_name" "$device_type" "$runtime" > /dev/null
   else
     echo "Simulator '$sim_name' already exists."
+  fi
+}
+
+# Returns Vision Pro device type for the installed visionOS runtime.
+# Arguments:
+#   $1 - Device type prefix string
+get_vision_device() {
+  local device_prefix="$1"
+  local vision_runtime
+  vision_runtime=$(
+    xcrun simctl list runtimes |
+      grep -i -E "visionOS|xrOS" |
+      grep -v 'unavailable' |
+      grep -o -E 'com\.apple\.CoreSimulator\.SimRuntime\.[a-zA-Z0-9.-]+' |
+      tail -1 || true
+  )
+  if [[ "$vision_runtime" =~ xrOS-26|visionOS-26 ]]; then
+    echo "${device_prefix}.Apple-Vision-Pro-4K"
+  else
+    echo "${device_prefix}.Apple-Vision-Pro"
   fi
 }
 
@@ -64,18 +84,7 @@ main() {
   local ipad_device="${device_prefix}.iPad-Pro--11-inch---2nd-generation-"
   local watch_device="${device_prefix}.Apple-Watch-Ultra-2-49mm"
   local tv_device="${device_prefix}.Apple-TV-4K-2nd-generation-1080p"
-  local vision_device="${device_prefix}.Apple-Vision-Pro"
-  local vision_runtime
-  vision_runtime=$(
-    xcrun simctl list runtimes |
-      grep -i -E "visionOS|xrOS" |
-      grep -v 'unavailable' |
-      tail -1 |
-      awk '{print $NF}' || true
-  )
-  if [[ "$vision_runtime" =~ xrOS-26|visionOS-26 ]]; then
-    vision_device="${device_prefix}.Apple-Vision-Pro-4K"
-  fi
+  local vision_device
 
   case "$platform_clean" in
     ios)
@@ -91,9 +100,11 @@ main() {
       create_sim "tvOS" "Firebase-Apple-TV-4K-Gen-2" "$tv_device"
       ;;
     visionos|xros)
+      vision_device=$(get_vision_device "$device_prefix")
       create_sim "visionOS|xrOS" "Firebase-Apple-Vision-Pro" "$vision_device"
       ;;
     all)
+      vision_device=$(get_vision_device "$device_prefix")
       create_sim "iOS" "Firebase-iPhone-15-Pro" "$ios_device"
       create_sim "iOS" "Firebase-iPad-Pro-11-inch" "$ipad_device"
       create_sim "watchOS" "Firebase-Apple-Watch-Ultra-2" "$watch_device"

--- a/scripts/setup_simulator.sh
+++ b/scripts/setup_simulator.sh
@@ -64,6 +64,17 @@ main() {
   local watch_dev="${dev_prefix}.Apple-Watch-Ultra-2-49mm"
   local tv_dev="${dev_prefix}.Apple-TV-4K-2nd-generation-1080p"
   local vision_dev="${dev_prefix}.Apple-Vision-Pro"
+  local vision_runtime
+  vision_runtime=$(
+    xcrun simctl list runtimes |
+      grep -i -E "visionOS|xrOS" |
+      grep -v 'unavailable' |
+      tail -1 |
+      awk '{print $NF}' || true
+  )
+  if [[ "$vision_runtime" =~ xrOS-26|visionOS-26 ]]; then
+    vision_dev="${dev_prefix}.Apple-Vision-Pro-4K"
+  fi
 
   case "$platform_clean" in
     ios|ipad)


### PR DESCRIPTION
Replaced the slow `xcodebuild -downloadPlatform` calls in GitHub Actions workflows with `xcrun simctl create` using installed runtimes.

- Added `scripts/setup_simulator.sh` to dynamically create custom simulators using the latest available installed runtime in the runner image.
- Added a reusable `.github/actions/setup_simulator` composite action.
- Updated `scripts/build.sh` to automatically set up and target the new `Firebase-` prefixed simulator devices.
- Replaced `xcodebuild -downloadPlatform` calls in workflow files.

#no-changelog