### PR TITLE
guard fcm_options and image URL types in populateNotificationContent

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessagingExtensionHelper.m
+++ b/FirebaseMessaging/Sources/FIRMessagingExtensionHelper.m
@@ -112,8 +112,18 @@ pb_bytes_array_t *FIRMessagingEncodeString(NSString *string) {
 
   // The `userInfo` property isn't available on newer versions of tvOS.
 #if !TARGET_OS_TV
-  NSObject *currentImageURL = content.userInfo[kPayloadOptionsName][kPayloadOptionsImageURLName];
-  if (!currentImageURL || currentImageURL == [NSNull null]) {
+  // `userInfo` is the untrusted push payload, so a sender controls the type of
+  // every value in it. `fcm_options` and its `image` entry are read below and
+  // must be a dictionary and a string; otherwise the keyed subscript or the
+  // NSString cast would raise on an unexpected class.
+  NSObject *fcmOptions = content.userInfo[kPayloadOptionsName];
+  if (![fcmOptions isKindOfClass:[NSDictionary class]]) {
+    [self deliverNotification];
+    return;
+  }
+  NSObject *currentImageURL = ((NSDictionary *)fcmOptions)[kPayloadOptionsImageURLName];
+  if (!currentImageURL || currentImageURL == [NSNull null] ||
+      ![currentImageURL isKindOfClass:[NSString class]]) {
     [self deliverNotification];
     return;
   }

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingExtensionHelperTest.m
@@ -112,6 +112,36 @@ static NSString *const kValidImageURL =
   [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
+- (void)testModifyNotificationWithNonDictionaryFCMOptions {
+  XCTestExpectation *handlerCalledExpectation =
+      [self expectationWithDescription:@"Content handler was called."];
+  UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+  // A sender can set `fcm_options` to a non-dictionary value in the payload.
+  content.userInfo = @{kFCMPayloadOptionsName : @"not a dictionary"};
+  FIRMessagingContentHandler handler = ^(UNNotificationContent *content) {
+    [handlerCalledExpectation fulfill];
+  };
+  [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
+  OCMReject([_mockExtensionHelper loadAttachmentForURL:[OCMArg any]
+                                     completionHandler:[OCMArg any]]);
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
+- (void)testModifyNotificationWithNonStringImageURL {
+  XCTestExpectation *handlerCalledExpectation =
+      [self expectationWithDescription:@"Content handler was called."];
+  UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+  // A sender can set the `image` entry to a non-string value in the payload.
+  content.userInfo = @{kFCMPayloadOptionsName : @{kFCMPayloadOptionsImageURLName : @123}};
+  FIRMessagingContentHandler handler = ^(UNNotificationContent *content) {
+    [handlerCalledExpectation fulfill];
+  };
+  [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
+  OCMReject([_mockExtensionHelper loadAttachmentForURL:[OCMArg any]
+                                     completionHandler:[OCMArg any]]);
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+
 - (void)testModifyNotificationWithValidPayloadDataNoMimeType {
   NSString *const kValidTestURL = @"test.jpg";
   NSString *const kValidTestExtension = @".jpg";


### PR DESCRIPTION
populateNotificationContent reads the image URL out of the untrusted push payload with content.userInfo[fcm_options][image] and force-casts it to NSString before handing it to +[NSURL URLWithString:], so a sender who sets fcm_options to a non-dictionary or image to a non-string crashes the notification service extension with an unrecognized selector instead of delivering the notification. Validate that fcm_options is a dictionary and image is a string before use, matching the isKindOfClass checks the rest of the module already applies to payload values, and fall back to delivering the unmodified notification otherwise. Added two regression tests covering a non-dictionary fcm_options and a non-string image URL.