### PR TITLE
Revert to using kFPRSlowFrameThreshold for slow frames on iOS

### DIFF
--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Revert to using `kFPRSlowFrameThreshold` for slow frames on iOS to prevent falsely classifying 60 FPS frames as slow on ProMotion displays,
+while preserving dynamic frame rate support for tvOS.
+
 # 12.16.0
 - [fixed] Fixed a crash in `FPRMemoryGaugeCollector` by collecting memory usage
   with `task_info(TASK_VM_INFO)` instead of `malloc_zone_statistics()`, which

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
-- [fixed] Revert to using `kFPRSlowFrameThreshold` for slow frames on iOS to prevent falsely classifying 60 FPS frames as slow on ProMotion displays,
-while preserving dynamic frame rate support for tvOS.
+- [fixed] Revert to using `kFPRSlowFrameThreshold` for slow frames on iOS to prevent
+  falsely classifying 60 FPS frames as slow on ProMotion devices,
+  while preserving dynamic frame rate support for tvOS.
 
 # 12.16.0
 - [fixed] Fixed a crash in `FPRMemoryGaugeCollector` by collecting memory usage

--- a/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker+Private.h
+++ b/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker+Private.h
@@ -129,7 +129,8 @@ FOUNDATION_EXTERN CFTimeInterval const kFPRFrozenFrameThreshold;
 - (void)screenModeDidChangeNotification:(NSNotification *)notification;
 #endif
 
-/** Updates the cached maxFPS and slowBudget from UIScreen.maximumFramesPerSecond.
+/** Updates the cached slow budget. On tvOS, recomputes from UIScreen.maximumFramesPerSecond.
+ *  On iOS, this method is only for test verification and maintains kFPRSlowFrameThreshold.
  *  This method must be called on the main thread.
  */
 - (void)updateCachedSlowBudget;

--- a/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
@@ -26,19 +26,20 @@ NSString *const kFPRSlowFrameCounterName = @"_fr_slo";
 NSString *const kFPRTotalFramesCounterName = @"_fr_tot";
 
 // Note: This was previously 60 FPS, but that resulted in 90% +  of all frames collected to be
-// flagged as slow frames, and so the threshold for iOS is being changed to 59 FPS.
-// TODO(b/73498642): Make these configurable.
-// This constant is kept for backward compatibility but is no longer used directly.
-// The actual threshold is computed dynamically from UIScreen.maximumFramesPerSecond.
+// flagged as slow frames, and so the threshold for iOS is 59 FPS.
+// b/545164487 tracks any changes / next steps for ProMotion devices - where the frame rate can be
+// as high as 120 FPS.
 CFTimeInterval const kFPRSlowFrameThreshold = 1.0 / 59.0;  // Anything less than 59 FPS is slow.
 CFTimeInterval const kFPRFrozenFrameThreshold = 700.0 / 1000.0;
 
+#if TARGET_OS_TV
 /** Default/fallback FPS value used when UIScreen.maximumFramesPerSecond is unavailable or invalid.
  */
 static const NSInteger kFPRDefaultFPS = 60;
 
-/** Epsilon value to avoid floating point comparison issues (e.g., 59.94 vs 60). */
+/** Epsilon value to avoid floating point comparison issues (e.g., 59.94 vs 60) on tvOS. */
 static const CFTimeInterval kFPRSlowFrameEpsilon = 0.001;
+#endif
 
 /** Constant that indicates an invalid time. */
 CFAbsoluteTime const kFPRInvalidTime = -1.0;
@@ -93,11 +94,13 @@ static NSString *FPRScreenTraceNameForViewController(UIViewController *viewContr
   /** Instance variable storing the frozen frames observed so far. */
   atomic_int_fast64_t _frozenFramesCount;
 
-  /** Cached maximum frames per second from UIScreen. */
+#if TARGET_OS_TV
+  /** Cached maximum frames per second from UIScreen on tvOS. */
   NSInteger _cachedMaxFPS;
+#endif
 
-  /** Cached slow frame budget computed from maxFPS. Initialized to the old constant value
-   *  for backward compatibility until updateCachedSlowBudget is called.
+  /** Cached slow frame budget. On iOS, uses kFPRSlowFrameThreshold (59 FPS).
+   *  On tvOS, computed dynamically from UIScreen.maximumFramesPerSecond.
    */
   CFTimeInterval _cachedSlowBudget;
 }
@@ -130,15 +133,12 @@ static NSString *FPRScreenTraceNameForViewController(UIViewController *viewContr
     atomic_store_explicit(&_frozenFramesCount, 0, memory_order_relaxed);
     atomic_store_explicit(&_slowFramesCount, 0, memory_order_relaxed);
 
-    // Initialize cached values with defaults. These will be updated by updateCachedSlowBudget,
-    // but having defaults ensures reasonable behavior if initialization is delayed or fails.
+#if TARGET_OS_TV
+    // Initialize slow budget and maxFPS values with defaults for tvOS.
+    // On tvOS, refresh rate depends on the connected display mode (e.g. 50 Hz vs 60 Hz).
     _cachedMaxFPS = kFPRDefaultFPS;
-    _cachedSlowBudget = 1.0 / kFPRDefaultFPS;
+    _cachedSlowBudget = 1.0 / (CFTimeInterval)kFPRDefaultFPS;
 
-    // Initialize cached maxFPS and slowBudget on main thread.
-    // UIScreen.maximumFramesPerSecond reflects device capability and can be up to 120 on ProMotion.
-    // TODO: Support ProMotion devices that dynamically adjust refresh rate based on content.
-    // Use synchronous dispatch to ensure values are set before first frame is recorded.
     if ([NSThread isMainThread]) {
       [self updateCachedSlowBudget];
     } else {
@@ -146,6 +146,9 @@ static NSString *FPRScreenTraceNameForViewController(UIViewController *viewContr
         [self updateCachedSlowBudget];
       });
     }
+#else
+    _cachedSlowBudget = kFPRSlowFrameThreshold;
+#endif
 
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(displayLinkStep)];
     [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
@@ -249,11 +252,13 @@ static NSString *FPRScreenTraceNameForViewController(UIViewController *viewContr
 }
 #endif
 
-/** Updates the cached maxFPS and slowBudget from UIScreen.maximumFramesPerSecond.
- *  This method must be called on the main thread.
+/** Updates the cached slow budget. On tvOS, recomputes from UIScreen.maximumFramesPerSecond.
+ *  On iOS, maintains kFPRSlowFrameThreshold.
+ *  This method must be called on the main thread - and is available on iOS only for verification.
  */
 - (void)updateCachedSlowBudget {
   NSAssert([NSThread isMainThread], @"updateCachedSlowBudget must be called on main thread");
+#if TARGET_OS_TV
   UIScreen *mainScreen = [UIScreen mainScreen];
   NSInteger maxFPS = 0;
   if (mainScreen) {
@@ -261,12 +266,17 @@ static NSString *FPRScreenTraceNameForViewController(UIViewController *viewContr
   }
   if (maxFPS > 0) {
     _cachedMaxFPS = maxFPS;
-    _cachedSlowBudget = 1.0 / maxFPS;
+    _cachedSlowBudget = 1.0 / (CFTimeInterval)maxFPS;
   } else {
     // Fallback to default FPS if maximumFramesPerSecond is unavailable or invalid.
     _cachedMaxFPS = kFPRDefaultFPS;
-    _cachedSlowBudget = 1.0 / kFPRDefaultFPS;
+    _cachedSlowBudget = 1.0 / (CFTimeInterval)kFPRDefaultFPS;
   }
+#else
+  // TODO(b/545164487): Updating this is likely the first step for ProMotion devices.
+  // https://github.com/firebase/firebase-ios-sdk/issues/10220#issuecomment-1248632304
+  _cachedSlowBudget = kFPRSlowFrameThreshold;
+#endif
 }
 
 #pragma mark - Frozen, slow and good frames
@@ -274,7 +284,7 @@ static NSString *FPRScreenTraceNameForViewController(UIViewController *viewContr
 - (void)displayLinkStep {
   static CFAbsoluteTime previousTimestamp = kFPRInvalidTime;
   CFAbsoluteTime currentTimestamp = self.displayLink.timestamp;
-  // Use the cached slow budget computed from UIScreen.maximumFramesPerSecond.
+  // Use the cached slow budget.
   RecordFrameType(currentTimestamp, previousTimestamp, &_slowFramesCount, &_frozenFramesCount,
                   &_totalFramesCount, _cachedSlowBudget);
   previousTimestamp = currentTimestamp;
@@ -288,6 +298,7 @@ static NSString *FPRScreenTraceNameForViewController(UIViewController *viewContr
  *  @param slowFramesCounter The value of the slowFramesCount before this function was called.
  *  @param frozenFramesCounter The value of the frozenFramesCount before this function was called.
  *  @param totalFramesCounter The value of the totalFramesCount before this function was called.
+ *  @param slowBudget The frame duration threshold above which a frame is considered slow.
  */
 FOUNDATION_STATIC_INLINE
 void RecordFrameType(CFAbsoluteTime currentTimestamp,
@@ -300,11 +311,17 @@ void RecordFrameType(CFAbsoluteTime currentTimestamp,
   if (previousTimestamp == kFPRInvalidTime) {
     return;
   }
-  // Use cached slowBudget with epsilon to avoid floating point comparison issues
+#if TARGET_OS_TV
+  // On tvOS, use cached slowBudget with epsilon to avoid floating point comparison issues
   // (e.g., 59.94 vs 60 Hz displays).
   if (frameDuration > slowBudget + kFPRSlowFrameEpsilon) {
     atomic_fetch_add_explicit(slowFramesCounter, 1, memory_order_relaxed);
   }
+#else
+  if (frameDuration > kFPRSlowFrameThreshold) {
+    atomic_fetch_add_explicit(slowFramesCounter, 1, memory_order_relaxed);
+  }
+#endif
   if (frameDuration > kFPRFrozenFrameThreshold) {
     atomic_fetch_add_explicit(frozenFramesCounter, 1, memory_order_relaxed);
   }

--- a/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
+++ b/FirebasePerformance/Sources/AppActivity/FPRScreenTraceTracker.m
@@ -284,7 +284,7 @@ static NSString *FPRScreenTraceNameForViewController(UIViewController *viewContr
 - (void)displayLinkStep {
   static CFAbsoluteTime previousTimestamp = kFPRInvalidTime;
   CFAbsoluteTime currentTimestamp = self.displayLink.timestamp;
-  // Use the cached slow budget.
+  // Use the cached slow budget where needed - currently only on tvOS.
   RecordFrameType(currentTimestamp, previousTimestamp, &_slowFramesCount, &_frozenFramesCount,
                   &_totalFramesCount, _cachedSlowBudget);
   previousTimestamp = currentTimestamp;

--- a/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
@@ -998,35 +998,43 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
 
 #pragma mark - Dynamic FPS Tests
 
-/** Helper method to swizzle UIScreen.maximumFramesPerSecond for testing.
- *
- *  @param fps The FPS value to stub.
- *  @param block The block to execute with the stubbed FPS.
+/** Tests that ProMotion displays with maximumFramesPerSecond = 120 do not cause standard 60 FPS
+ *  frames to be falsely marked as slow frames on iOS.
  */
-- (void)withStubbedMaxFPS:(NSInteger)fps performBlock:(void (^)(void))block {
-  Method originalMethod =
-      class_getInstanceMethod([UIScreen class], @selector(maximumFramesPerSecond));
-  IMP originalIMP = method_getImplementation(originalMethod);
+- (void)testProMotion120FPSDisplayDoesNotMake60FPSFramesSlowOnIOS {
+  [self withStubbedMaxFPS:120
+             performBlock:^{
+               [self.tracker updateCachedSlowBudget];
 
-  NSInteger (^stubBlock)(id) = ^NSInteger(id self) {
-    return fps;
-  };
-  IMP stubIMP = imp_implementationWithBlock(stubBlock);
-  method_setImplementation(originalMethod, stubIMP);
+               id displayLinkMock = OCMClassMock([CADisplayLink class]);
+               [self.tracker.displayLink invalidate];
+               self.tracker.displayLink = displayLinkMock;
 
-  @try {
-    block();
-  } @finally {
-    method_setImplementation(originalMethod, originalIMP);
-  }
+               CFAbsoluteTime firstFrameTimestamp = 1.0;
+               // Standard 60 FPS frame duration is ~16.67ms (1.0 / 60.0)
+               CFAbsoluteTime secondFrameTimestamp = firstFrameTimestamp + (1.0 / 60.0);
+
+               OCMExpect([displayLinkMock timestamp]).andReturn(firstFrameTimestamp);
+               [self.tracker displayLinkStep];
+               int64_t initialSlowFramesCount = self.tracker.slowFramesCount;
+
+               OCMExpect([displayLinkMock timestamp]).andReturn(secondFrameTimestamp);
+               [self.tracker displayLinkStep];
+
+               int64_t slowFramesCount = self.tracker.slowFramesCount;
+               XCTAssertEqual(slowFramesCount, initialSlowFramesCount,
+                              @"Standard 60 FPS frames should NOT be marked as slow on ProMotion "
+                              @"(120 FPS) devices on iOS");
+             }];
 }
 
-/** Helper method to create a test tracker with stubbed FPS and updated cached budget.
+#if TARGET_OS_TV
+
+/** Helper method to create a test tracker updated cached budget.
  *
- *  @param fps The FPS value to stub.
  *  @return A configured FPRScreenTraceTracker instance.
  */
-- (FPRScreenTraceTracker *)createTestTrackerWithStubbedFPS:(NSInteger)fps {
+- (FPRScreenTraceTracker *)createTestTrackerWithUpdatedFPS {
   FPRScreenTraceTracker *testTracker = [[FPRScreenTraceTracker alloc] init];
   testTracker.displayLink.paused = YES;
   // Tests run on main thread, so call updateCachedSlowBudget directly.
@@ -1034,10 +1042,9 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   return testTracker;
 }
 
-#if TARGET_OS_TV
 /** Tests that slow frames are correctly detected with a custom maxFPS value on tvOS.
  *  This test stubs UIScreen.maximumFramesPerSecond to 50 FPS and verifies that frames
- *  at ~21ms (slow) and ~19ms (not slow) are correctly classified.
+ *  at ~25ms (slow) and ~19ms (not slow) are correctly classified.
  */
 - (void)testSlowFrameIsRecordedWithCustomMaxFPSOnTvOS {
   // At 50 FPS, slow budget = 1.0/50 = 0.02 seconds = 20ms.
@@ -1047,7 +1054,7 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
                UIScreen *mainScreen = [UIScreen mainScreen];
                XCTAssertEqual(mainScreen.maximumFramesPerSecond, 50, @"Stub should return 50 FPS");
 
-               FPRScreenTraceTracker *testTracker = [self createTestTrackerWithStubbedFPS:50];
+               FPRScreenTraceTracker *testTracker = [self createTestTrackerWithUpdatedFPS];
 
                // Verify the stub is still working after tracker creation.
                XCTAssertEqual([UIScreen mainScreen].maximumFramesPerSecond, 50,
@@ -1090,15 +1097,14 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
                    @"Frame at 19ms should NOT be marked as slow at 50 FPS (20ms threshold)");
              }];
 }
-#endif
 
-/** Tests that the epsilon value correctly handles edge cases around 59.94 vs 60 Hz displays.
- *  Frames right at the threshold should not be miscounted due to floating point precision.
+/** Tests that the epsilon value correctly handles edge cases around 59.94 vs 60 Hz displays on
+ * tvOS. Frames right at the threshold should not be miscounted due to floating point precision.
  */
 - (void)testSlowFrameRate_isHandled_inEdgeCases {
   [self withStubbedMaxFPS:60
              performBlock:^{
-               FPRScreenTraceTracker *testTracker = [self createTestTrackerWithStubbedFPS:60];
+               FPRScreenTraceTracker *testTracker = [self createTestTrackerWithUpdatedFPS];
 
                // Verify the stub is working - UIScreen should return 60 FPS.
                UIScreen *mainScreen = [UIScreen mainScreen];
@@ -1145,7 +1151,6 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
              }];
 }
 
-#if TARGET_OS_TV
 /** Tests that the slow budget is recomputed when UIScreenModeDidChangeNotification is posted on
  * tvOS. This verifies that the tracker adapts to display mode changes that affect refresh rate.
  */
@@ -1163,7 +1168,7 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
   method_setImplementation(originalMethod, stubIMP);
 
   @try {
-    FPRScreenTraceTracker *testTracker = [self createTestTrackerWithStubbedFPS:60];
+    FPRScreenTraceTracker *testTracker = [self createTestTrackerWithUpdatedFPS];
 
     // Verify initial behavior: at 60 FPS, slow budget = ~16.67ms.
     // An 18ms frame should be slow at 60 FPS.
@@ -1237,6 +1242,29 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
 #endif
 
 #pragma mark - Helper methods
+
+/** Helper method to swizzle UIScreen.maximumFramesPerSecond for testing.
+ *
+ *  @param fps The FPS value to stub.
+ *  @param block The block to execute with the stubbed FPS.
+ */
+- (void)withStubbedMaxFPS:(NSInteger)fps performBlock:(void (^)(void))block {
+  Method originalMethod =
+      class_getInstanceMethod([UIScreen class], @selector(maximumFramesPerSecond));
+  IMP originalIMP = method_getImplementation(originalMethod);
+
+  NSInteger (^stubBlock)(id) = ^NSInteger(id self) {
+    return fps;
+  };
+  IMP stubIMP = imp_implementationWithBlock(stubBlock);
+  method_setImplementation(originalMethod, stubIMP);
+
+  @try {
+    block();
+  } @finally {
+    method_setImplementation(originalMethod, originalIMP);
+  }
+}
 
 + (NSString *)expectedTraceNameForViewController:(UIViewController *)viewController {
   return [@"_st_" stringByAppendingString:NSStringFromClass([viewController class])];

--- a/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
@@ -1000,7 +1000,7 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
 
 #if TARGET_OS_TV
 
-/** Helper method to create a test tracker updated cached budget.
+/** Helper method to create a test tracker with updated cached budget.
  *
  *  @return A configured FPRScreenTraceTracker instance.
  */

--- a/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
+++ b/FirebasePerformance/Tests/Unit/FPRScreenTraceTrackerTest.m
@@ -998,36 +998,6 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
 
 #pragma mark - Dynamic FPS Tests
 
-/** Tests that ProMotion displays with maximumFramesPerSecond = 120 do not cause standard 60 FPS
- *  frames to be falsely marked as slow frames on iOS.
- */
-- (void)testProMotion120FPSDisplayDoesNotMake60FPSFramesSlowOnIOS {
-  [self withStubbedMaxFPS:120
-             performBlock:^{
-               [self.tracker updateCachedSlowBudget];
-
-               id displayLinkMock = OCMClassMock([CADisplayLink class]);
-               [self.tracker.displayLink invalidate];
-               self.tracker.displayLink = displayLinkMock;
-
-               CFAbsoluteTime firstFrameTimestamp = 1.0;
-               // Standard 60 FPS frame duration is ~16.67ms (1.0 / 60.0)
-               CFAbsoluteTime secondFrameTimestamp = firstFrameTimestamp + (1.0 / 60.0);
-
-               OCMExpect([displayLinkMock timestamp]).andReturn(firstFrameTimestamp);
-               [self.tracker displayLinkStep];
-               int64_t initialSlowFramesCount = self.tracker.slowFramesCount;
-
-               OCMExpect([displayLinkMock timestamp]).andReturn(secondFrameTimestamp);
-               [self.tracker displayLinkStep];
-
-               int64_t slowFramesCount = self.tracker.slowFramesCount;
-               XCTAssertEqual(slowFramesCount, initialSlowFramesCount,
-                              @"Standard 60 FPS frames should NOT be marked as slow on ProMotion "
-                              @"(120 FPS) devices on iOS");
-             }];
-}
-
 #if TARGET_OS_TV
 
 /** Helper method to create a test tracker updated cached budget.
@@ -1239,6 +1209,38 @@ static UIViewController *FPRCustomViewController(NSString *className, BOOL isVie
     method_setImplementation(originalMethod, originalIMP);
   }
 }
+
+#else
+
+/** Tests that non tvOS devices (including ProMotion devices) displays do not use the dynamic frame
+ * rate. */
+- (void)testNonTVOSDevicesDontUseMaximumFramesPerSecond {
+  [self withStubbedMaxFPS:120
+             performBlock:^{
+               [self.tracker updateCachedSlowBudget];
+
+               id displayLinkMock = OCMClassMock([CADisplayLink class]);
+               [self.tracker.displayLink invalidate];
+               self.tracker.displayLink = displayLinkMock;
+
+               CFAbsoluteTime firstFrameTimestamp = 1.0;
+               // Standard 60 FPS frame duration is ~16.67ms (1.0 / 60.0)
+               CFAbsoluteTime secondFrameTimestamp = firstFrameTimestamp + (1.0 / 60.0);
+
+               OCMExpect([displayLinkMock timestamp]).andReturn(firstFrameTimestamp);
+               [self.tracker displayLinkStep];
+               int64_t initialSlowFramesCount = self.tracker.slowFramesCount;
+
+               OCMExpect([displayLinkMock timestamp]).andReturn(secondFrameTimestamp);
+               [self.tracker displayLinkStep];
+
+               int64_t slowFramesCount = self.tracker.slowFramesCount;
+               XCTAssertEqual(slowFramesCount, initialSlowFramesCount,
+                              @"Standard 60 FPS frames should NOT be marked as slow on ProMotion "
+                              @"(120 FPS) devices on iOS");
+             }];
+}
+
 #endif
 
 #pragma mark - Helper methods


### PR DESCRIPTION
This is a follow up for https://github.com/firebase/firebase-ios-sdk/issues/10220.

Customers reported that the count of slow frames on ProMotion devices was non-trivially higher. This PR reverts the definition of slow frames on iOS prior to https://github.com/firebase/firebase-ios-sdk/pull/15516 - but retains the variable frame rate for tvOS to support different frame rates in different regions.



