### PR TITLE
release: update unreleased CHANGELOG entries

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.18.0
 - [removed] Removes unused integration with the now deprecated ObjC MetricKit API.
 
 # 12.17.0

--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.18.0
 - [removed] Removed deprecated Imagen APIs. Note that the Imagen service turned down on August 17, 2026.
 - [feature] Added support for `RealtimeInputConfig` in `LiveGenerationConfig`. (#16441)
 - [feature] Added support for `sendStartActivityRealtime` and `sendStopActivityRealtime`

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.18.0
 - [fixed] Safely disable the reCAPTCHA provider when its Swift dependencies
   cannot be resolved to prevent `unknown receiver` build failures that
   occur in unsupported `use_modular_headers!` use cases. (#16477)

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.18.0
 - [fixed] Fixed a bug in `PhoneAuthProvider` where the test mode logic would
   fail if multi-factor authentication was enabled. (#16438)
 - [fixed] Fixed a bug where `verifyPhoneNumber` could hit an infinite recursion

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 12.18.0
 - [fixed] Fix an issue where new FCM registration processing was not invoked
   when `FirebaseMessagingInstallationIdEnabled` was set to `YES` and a legacy token
   existed in cache. (#16429)


### PR DESCRIPTION
Updated `Unreleased` `CHANGELOG` entries in preparation for M185 / `12.18.0`.
