### PR TITLE
Fix FirebaseAuth random logouts on iOS 15+ during prewarming

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fixed an issue on iOS 15+ where users were randomly logged out during
+  prewarming while the device was locked. (#16498)
+
 # 12.18.0
 - [fixed] Fixed a bug in `PhoneAuthProvider` where the test mode logic would
   fail if multi-factor authentication was enabled. (#16438)

--- a/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
+++ b/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
@@ -57,7 +57,14 @@ final class AuthKeychainServices: Sendable {
       return items[0][kSecValueData as String] as? Data
     }
     if status == errSecItemNotFound {
-      return nil
+      if isKeychainAccessible() {
+        return nil
+      } else {
+        throw AuthErrorUtils.keychainError(
+          function: "SecItemCopyMatching",
+          status: errSecInteractionNotAllowed
+        )
+      }
     } else {
       throw AuthErrorUtils.keychainError(function: "SecItemCopyMatching", status: status)
     }
@@ -179,7 +186,14 @@ final class AuthKeychainServices: Sendable {
     }
 
     if status == errSecItemNotFound {
-      return nil
+      if isKeychainAccessible() {
+        return nil
+      } else {
+        throw AuthErrorUtils.keychainError(
+          function: "SecItemCopyMatching",
+          status: errSecInteractionNotAllowed
+        )
+      }
     } else {
       throw AuthErrorUtils.keychainError(function: "SecItemCopyMatching", status: status)
     }
@@ -242,5 +256,30 @@ final class AuthKeychainServices: Sendable {
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrAccount as String: key,
     ]
+  }
+
+  /// Determines if the keychain is currently accessible.
+  /// This is used to work around a known iOS bug where `SecItemCopyMatching` spuriously returns
+  /// `errSecItemNotFound` instead of `errSecInteractionNotAllowed` when the device is locked (e.g.
+  /// during prewarming).
+  private func isKeychainAccessible() -> Bool {
+    let dummyKey = "firebase_auth_keychain_accessibility_check"
+    var query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: dummyKey,
+      kSecAttrService as String: service,
+      kSecValueData as String: Data([0]),
+      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+    ]
+    query[kSecUseDataProtectionKeychain as String] = true
+
+    let status = keychainStorage.add(query: query)
+    if status == errSecInteractionNotAllowed {
+      return false
+    }
+    if status == errSecSuccess || status == errSecDuplicateItem {
+      keychainStorage.delete(query: query)
+    }
+    return true
   }
 }

--- a/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
+++ b/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
@@ -110,8 +110,6 @@ final class AuthKeychainServices: Sendable {
   /// This dictionary is to avoid unnecessary keychain operations against legacy items.
   private let legacyEntryDeletedForKey = UnfairLock<Set<String>>([])
 
-  private let isKeychainAccessibleCached = UnfairLock<Bool>(false)
-
   func data(forKey key: String) throws -> Data? {
     if let data = try getItemLegacy(query: genericPasswordQuery(key: key)) {
       return data
@@ -265,17 +263,13 @@ final class AuthKeychainServices: Sendable {
   /// `errSecItemNotFound` instead of `errSecInteractionNotAllowed` when the device is locked (e.g.
   /// during prewarming).
   private func isKeychainAccessible() -> Bool {
-    if isKeychainAccessibleCached.value() {
-      return true
-    }
-
     let dummyKey = "firebase_auth_keychain_accessibility_check"
     var query: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrAccount as String: dummyKey,
       kSecAttrService as String: service,
       kSecValueData as String: Data([0]),
-      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
     ]
     query[kSecUseDataProtectionKeychain as String] = true
 
@@ -284,7 +278,6 @@ final class AuthKeychainServices: Sendable {
       return false
     }
 
-    isKeychainAccessibleCached.withLock { $0 = true }
     return true
   }
 }

--- a/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
+++ b/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
@@ -269,7 +269,7 @@ final class AuthKeychainServices: Sendable {
       kSecAttrAccount as String: dummyKey,
       kSecAttrService as String: service,
       kSecValueData as String: Data([0]),
-      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
+      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
     ]
     query[kSecUseDataProtectionKeychain as String] = true
 

--- a/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
+++ b/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
@@ -110,6 +110,8 @@ final class AuthKeychainServices: Sendable {
   /// This dictionary is to avoid unnecessary keychain operations against legacy items.
   private let legacyEntryDeletedForKey = UnfairLock<Set<String>>([])
 
+  private let isKeychainAccessibleCached = UnfairLock<Bool>(false)
+
   func data(forKey key: String) throws -> Data? {
     if let data = try getItemLegacy(query: genericPasswordQuery(key: key)) {
       return data
@@ -263,13 +265,17 @@ final class AuthKeychainServices: Sendable {
   /// `errSecItemNotFound` instead of `errSecInteractionNotAllowed` when the device is locked (e.g.
   /// during prewarming).
   private func isKeychainAccessible() -> Bool {
+    if isKeychainAccessibleCached.value() {
+      return true
+    }
+
     let dummyKey = "firebase_auth_keychain_accessibility_check"
     var query: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrAccount as String: dummyKey,
       kSecAttrService as String: service,
       kSecValueData as String: Data([0]),
-      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
+      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
     ]
     query[kSecUseDataProtectionKeychain as String] = true
 
@@ -278,6 +284,7 @@ final class AuthKeychainServices: Sendable {
       return false
     }
 
+    isKeychainAccessibleCached.withLock { $0 = true }
     return true
   }
 }

--- a/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
+++ b/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
@@ -110,6 +110,9 @@ final class AuthKeychainServices: Sendable {
   /// This dictionary is to avoid unnecessary keychain operations against legacy items.
   private let legacyEntryDeletedForKey = UnfairLock<Set<String>>([])
 
+  /// Caches whether the keychain is currently accessible to avoid redundant dummy operations.
+  private let isKeychainAccessibleCache = UnfairLock<Bool>(false)
+
   func data(forKey key: String) throws -> Data? {
     if let data = try getItemLegacy(query: genericPasswordQuery(key: key)) {
       return data
@@ -263,6 +266,10 @@ final class AuthKeychainServices: Sendable {
   /// `errSecItemNotFound` instead of `errSecInteractionNotAllowed` when the device is locked (e.g.
   /// during prewarming).
   private func isKeychainAccessible() -> Bool {
+    if isKeychainAccessibleCache.value() {
+      return true
+    }
+
     let dummyKey = "firebase_auth_keychain_accessibility_check"
     var query: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
@@ -280,6 +287,8 @@ final class AuthKeychainServices: Sendable {
     if status == errSecSuccess || status == errSecDuplicateItem {
       keychainStorage.delete(query: query)
     }
+
+    isKeychainAccessibleCache.withLock { $0 = true }
     return true
   }
 }

--- a/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
+++ b/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
@@ -285,7 +285,13 @@ final class AuthKeychainServices: Sendable {
       return false
     }
     if status == errSecSuccess || status == errSecDuplicateItem {
-      keychainStorage.delete(query: query)
+      var deleteQuery: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrAccount as String: dummyKey,
+        kSecAttrService as String: service,
+      ]
+      deleteQuery[kSecUseDataProtectionKeychain as String] = true
+      keychainStorage.delete(query: deleteQuery)
     }
 
     isKeychainAccessibleCache.withLock { $0 = true }

--- a/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
+++ b/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
@@ -269,22 +269,13 @@ final class AuthKeychainServices: Sendable {
       kSecAttrAccount as String: dummyKey,
       kSecAttrService as String: service,
       kSecValueData as String: Data([0]),
-      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
     ]
     query[kSecUseDataProtectionKeychain as String] = true
 
     let status = keychainStorage.add(query: query)
     if status == errSecInteractionNotAllowed {
       return false
-    }
-    if status == errSecSuccess || status == errSecDuplicateItem {
-      var deleteQuery: [String: Any] = [
-        kSecClass as String: kSecClassGenericPassword,
-        kSecAttrAccount as String: dummyKey,
-        kSecAttrService as String: service,
-      ]
-      deleteQuery[kSecUseDataProtectionKeychain as String] = true
-      keychainStorage.delete(query: deleteQuery)
     }
 
     return true

--- a/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
+++ b/FirebaseAuth/Sources/Swift/Storage/AuthKeychainServices.swift
@@ -110,9 +110,6 @@ final class AuthKeychainServices: Sendable {
   /// This dictionary is to avoid unnecessary keychain operations against legacy items.
   private let legacyEntryDeletedForKey = UnfairLock<Set<String>>([])
 
-  /// Caches whether the keychain is currently accessible to avoid redundant dummy operations.
-  private let isKeychainAccessibleCache = UnfairLock<Bool>(false)
-
   func data(forKey key: String) throws -> Data? {
     if let data = try getItemLegacy(query: genericPasswordQuery(key: key)) {
       return data
@@ -266,10 +263,6 @@ final class AuthKeychainServices: Sendable {
   /// `errSecItemNotFound` instead of `errSecInteractionNotAllowed` when the device is locked (e.g.
   /// during prewarming).
   private func isKeychainAccessible() -> Bool {
-    if isKeychainAccessibleCache.value() {
-      return true
-    }
-
     let dummyKey = "firebase_auth_keychain_accessibility_check"
     var query: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
@@ -294,7 +287,6 @@ final class AuthKeychainServices: Sendable {
       keychainStorage.delete(query: deleteQuery)
     }
 
-    isKeychainAccessibleCache.withLock { $0 = true }
     return true
   }
 }

--- a/FirebaseAuth/Tests/Unit/AuthKeychainServicesTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthKeychainServicesTests.swift
@@ -196,7 +196,7 @@ class AuthKeychainServicesTests: XCTestCase {
   }
 }
 
-private class LockedKeychainStorage: AuthKeychainStorage {
+private final class LockedKeychainStorage: AuthKeychainStorage {
   func get(query: [String: Any], result: inout AnyObject?) -> OSStatus {
     return errSecItemNotFound
   }

--- a/FirebaseAuth/Tests/Unit/AuthKeychainServicesTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthKeychainServicesTests.swift
@@ -202,7 +202,11 @@ private final class LockedKeychainStorage: AuthKeychainStorage {
   }
 
   func add(query: [String: Any]) -> OSStatus {
-    return errSecInteractionNotAllowed
+    if let accessible = query[kSecAttrAccessible as String] as? String,
+       accessible == kSecAttrAccessibleWhenUnlocked as String {
+      return errSecInteractionNotAllowed
+    }
+    return errSecSuccess
   }
 
   func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {

--- a/FirebaseAuth/Tests/Unit/AuthKeychainServicesTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthKeychainServicesTests.swift
@@ -203,7 +203,7 @@ private final class LockedKeychainStorage: AuthKeychainStorage {
 
   func add(query: [String: Any]) -> OSStatus {
     if let accessible = query[kSecAttrAccessible as String] as? String,
-       accessible == kSecAttrAccessibleWhenUnlocked as String {
+       accessible == kSecAttrAccessibleWhenUnlockedThisDeviceOnly as String {
       return errSecInteractionNotAllowed
     }
     return errSecSuccess

--- a/FirebaseAuth/Tests/Unit/AuthKeychainServicesTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthKeychainServicesTests.swift
@@ -203,7 +203,7 @@ private final class LockedKeychainStorage: AuthKeychainStorage {
 
   func add(query: [String: Any]) -> OSStatus {
     if let accessible = query[kSecAttrAccessible as String] as? String,
-       accessible == kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String {
+       accessible == kSecAttrAccessibleWhenUnlocked as String {
       return errSecInteractionNotAllowed
     }
     return errSecSuccess

--- a/FirebaseAuth/Tests/Unit/AuthKeychainServicesTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthKeychainServicesTests.swift
@@ -203,7 +203,7 @@ private final class LockedKeychainStorage: AuthKeychainStorage {
 
   func add(query: [String: Any]) -> OSStatus {
     if let accessible = query[kSecAttrAccessible as String] as? String,
-       accessible == kSecAttrAccessibleWhenUnlocked as String {
+       accessible == kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String {
       return errSecInteractionNotAllowed
     }
     return errSecSuccess

--- a/FirebaseAuth/Tests/Unit/AuthKeychainServicesTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthKeychainServicesTests.swift
@@ -195,3 +195,38 @@ class AuthKeychainServicesTests: XCTestCase {
     XCTAssertEqual(storage.delete(query: query as [String: Any]), errSecSuccess)
   }
 }
+
+private class LockedKeychainStorage: AuthKeychainStorage {
+  func get(query: [String: Any], result: inout AnyObject?) -> OSStatus {
+    return errSecItemNotFound
+  }
+
+  func add(query: [String: Any]) -> OSStatus {
+    return errSecInteractionNotAllowed
+  }
+
+  func update(query: [String: Any], attributes: [String: Any]) -> OSStatus {
+    return errSecInteractionNotAllowed
+  }
+
+  func delete(query: [String: Any]) -> OSStatus {
+    return errSecInteractionNotAllowed
+  }
+}
+
+extension AuthKeychainServicesTests {
+  func testDeviceLockedReturnsError() {
+    let lockedStorage = LockedKeychainStorage()
+    let lockedKeychain = AuthKeychainServices(service: Self.service, storage: lockedStorage)
+
+    do {
+      _ = try lockedKeychain.data(forKey: Self.key)
+      XCTFail("Should have thrown error")
+    } catch let error as NSError {
+      XCTAssertEqual(error.domain, AuthErrorDomain)
+      XCTAssertEqual(error.code, AuthErrorCode.keychainError.rawValue)
+      let reason = error.userInfo[NSLocalizedFailureReasonErrorKey] as? String
+      XCTAssertTrue(reason?.contains("\(errSecInteractionNotAllowed)") ?? false)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #16498

This PR addresses an issue where users were randomly logged out during iOS prewarming. The root cause is a known iOS 15+ bug where `SecItemCopyMatching` spuriously returns `errSecItemNotFound` instead of `errSecInteractionNotAllowed` when the device is locked.

Because `FirebaseAuth` trusted this error code, it assumed the user was genuinely signed out, wiping the in-memory user state and causing a silent logout.

**Changes:**
- Added `isKeychainAccessible()` to `AuthKeychainServices.swift` which attempts to write a dummy keychain item with the `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` protection class to reliably detect if the keychain is locked.
- Updated error handling in `getItem` and `getItemLegacy` to verify keychain accessibility when `errSecItemNotFound` is returned. If the keychain is not accessible, it now appropriately throws `errSecInteractionNotAllowed`.
- Added unit tests to `AuthKeychainServicesTests.swift` to verify this behavior using a mocked keychain storage.