### PR TITLE
feat: add streaming HTTP client target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -27,27 +27,47 @@ let package = Package(
   ],
   targets: [
     .target(
-      name: "GeminiForFoundationModels"
+      name: "GeminiForFoundationModels",
+      swiftSettings: [
+        .enableUpcomingFeature("InternalImportsByDefault"),
+        .enableUpcomingFeature("MemberImportVisibility"),
+      ]
     ),
     .target(
       name: "SharedTestUtilities",
-      path: "Tests/SharedTestUtilities"
+      path: "Tests/SharedTestUtilities",
+      swiftSettings: [
+        .enableUpcomingFeature("InternalImportsByDefault"),
+        .enableUpcomingFeature("MemberImportVisibility"),
+      ]
     ),
     .testTarget(
       name: "GeminiForFoundationModelsTests",
       dependencies: [
         "GeminiForFoundationModels",
         "SharedTestUtilities",
+      ],
+      swiftSettings: [
+        .enableUpcomingFeature("InternalImportsByDefault"),
+        .enableUpcomingFeature("MemberImportVisibility"),
       ]
     ),
     .target(
-      name: "HTTPStreamingClient"
+      name: "HTTPStreamingClient",
+      swiftSettings: [
+        .enableUpcomingFeature("InternalImportsByDefault"),
+        .enableUpcomingFeature("MemberImportVisibility"),
+      ]
     ),
     .testTarget(
       name: "HTTPStreamingClientTests",
       dependencies: [
         "HTTPStreamingClient",
         "SharedTestUtilities",
+      ],
+      swiftSettings: [
+        .enableUpcomingFeature("InternalImportsByDefault"),
+        .enableUpcomingFeature("MemberImportVisibility"),
       ]
     ),
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -27,12 +27,27 @@ let package = Package(
   ],
   targets: [
     .target(
-      name: "GeminiForFoundationModels",
+      name: "GeminiForFoundationModels"
+    ),
+    .target(
+      name: "SharedTestUtilities",
+      path: "Tests/SharedTestUtilities"
     ),
     .testTarget(
       name: "GeminiForFoundationModelsTests",
       dependencies: [
-        "GeminiForFoundationModels"
+        "GeminiForFoundationModels",
+        "SharedTestUtilities"
+      ]
+    ),
+    .target(
+      name: "HTTPStreamingClient"
+    ),
+    .testTarget(
+      name: "HTTPStreamingClientTests",
+      dependencies: [
+        "HTTPStreamingClient",
+        "SharedTestUtilities"
       ]
     ),
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
       name: "GeminiForFoundationModelsTests",
       dependencies: [
         "GeminiForFoundationModels",
-        "SharedTestUtilities"
+        "SharedTestUtilities",
       ]
     ),
     .target(
@@ -47,7 +47,7 @@ let package = Package(
       name: "HTTPStreamingClientTests",
       dependencies: [
         "HTTPStreamingClient",
-        "SharedTestUtilities"
+        "SharedTestUtilities",
       ]
     ),
   ],

--- a/Sources/HTTPStreamingClient/HTTPLineDecoder.swift
+++ b/Sources/HTTPStreamingClient/HTTPLineDecoder.swift
@@ -40,12 +40,17 @@ package struct HTTPLineDecoder: Sendable {
     }
 
     while searchStartIndex < data.endIndex {
-      guard
-        let nextNewlineIndex = data[searchStartIndex...].firstIndex(where: {
-          $0 == 0x0A || $0 == 0x0D
-        })
-      else {
-        buffer.append(data[searchStartIndex...])
+      let slice = data[searchStartIndex...]
+      let lfIndex = slice.firstIndex(of: 0x0A)
+      let crIndex = slice.firstIndex(of: 0x0D)
+
+      let nextNewlineIndex: Data.Index
+      if let lf = lfIndex, let cr = crIndex {
+        nextNewlineIndex = min(lf, cr)
+      } else if let found = lfIndex ?? crIndex {
+        nextNewlineIndex = found
+      } else {
+        buffer.append(slice)
         pendingCR = false
         break
       }

--- a/Sources/HTTPStreamingClient/HTTPLineDecoder.swift
+++ b/Sources/HTTPStreamingClient/HTTPLineDecoder.swift
@@ -30,7 +30,6 @@ package struct HTTPLineDecoder: Sendable {
     guard !data.isEmpty else { return [] }
 
     var lines: [String] = []
-    lines.reserveCapacity(data.count / 32)
     var searchStartIndex = data.startIndex
 
     if pendingCR {

--- a/Sources/HTTPStreamingClient/HTTPLineDecoder.swift
+++ b/Sources/HTTPStreamingClient/HTTPLineDecoder.swift
@@ -1,0 +1,94 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package import Foundation
+
+/// An incremental decoder that extracts UTF-8 lines of text from streaming byte chunks.
+package struct HTTPLineDecoder: Sendable {
+  private var buffer = Data()
+  private var pendingCR = false
+
+  /// Initializes a new line decoder with an empty buffer.
+  package init() {}
+
+  /// Feeds a new chunk of data and returns all complete lines found.
+  ///
+  /// - Parameter data: The incoming data chunk.
+  /// - Returns: An array of decoded lines with trailing line delimiters stripped.
+  package mutating func feed(_ data: Data) -> [String] {
+    guard !data.isEmpty else { return [] }
+
+    var lines: [String] = []
+    lines.reserveCapacity(data.count / 32)
+    var searchStartIndex = data.startIndex
+
+    if pendingCR {
+      pendingCR = false
+      if data[searchStartIndex] == 0x0A {
+        searchStartIndex = data.index(after: searchStartIndex)
+      }
+    }
+
+    while searchStartIndex < data.endIndex {
+      guard
+        let nextNewlineIndex = data[searchStartIndex...].firstIndex(where: {
+          $0 == 0x0A || $0 == 0x0D
+        })
+      else {
+        buffer.append(data[searchStartIndex...])
+        pendingCR = false
+        break
+      }
+
+      let byte = data[nextNewlineIndex]
+
+      if pendingCR {
+        pendingCR = false
+        if byte == 0x0A && nextNewlineIndex == searchStartIndex {
+          searchStartIndex = data.index(after: nextNewlineIndex)
+          continue
+        }
+      }
+
+      if nextNewlineIndex > searchStartIndex {
+        buffer.append(data[searchStartIndex..<nextNewlineIndex])
+      }
+
+      let line = String(decoding: buffer, as: UTF8.self)
+      lines.append(line)
+      buffer.removeAll(keepingCapacity: true)
+
+      if byte == 0x0D {
+        pendingCR = true
+      } else {
+        pendingCR = false
+      }
+
+      searchStartIndex = data.index(after: nextNewlineIndex)
+    }
+
+    return lines
+  }
+
+  /// Flushes any remaining bytes in the buffer as the final line.
+  ///
+  /// - Returns: The final line if the buffer is non-empty, or `nil`.
+  package mutating func flush() -> String? {
+    pendingCR = false
+    guard !buffer.isEmpty else { return nil }
+    let line = String(decoding: buffer, as: UTF8.self)
+    buffer.removeAll(keepingCapacity: false)
+    return line
+  }
+}

--- a/Sources/HTTPStreamingClient/HTTPLineDecoder.swift
+++ b/Sources/HTTPStreamingClient/HTTPLineDecoder.swift
@@ -34,15 +34,15 @@ package struct HTTPLineDecoder: Sendable {
 
     if pendingCR {
       pendingCR = false
-      if data[searchStartIndex] == 0x0A {
+      if data[searchStartIndex] == 0x0A /* LF (\n) */ {
         searchStartIndex = data.index(after: searchStartIndex)
       }
     }
 
     while searchStartIndex < data.endIndex {
       let slice = data[searchStartIndex...]
-      let lfIndex = slice.firstIndex(of: 0x0A)
-      let crIndex = slice.firstIndex(of: 0x0D)
+      let lfIndex = slice.firstIndex(of: 0x0A)  // Line Feed (\n)
+      let crIndex = slice.firstIndex(of: 0x0D)  // Carriage Return (\r)
 
       let nextNewlineIndex: Data.Index
       if let lf = lfIndex, let cr = crIndex {
@@ -59,7 +59,7 @@ package struct HTTPLineDecoder: Sendable {
 
       if pendingCR {
         pendingCR = false
-        if byte == 0x0A && nextNewlineIndex == searchStartIndex {
+        if byte == 0x0A /* LF (\n) */ && nextNewlineIndex == searchStartIndex {
           searchStartIndex = data.index(after: nextNewlineIndex)
           continue
         }
@@ -79,7 +79,7 @@ package struct HTTPLineDecoder: Sendable {
       }
       lines.append(line)
 
-      if byte == 0x0D {
+      if byte == 0x0D /* CR (\r) */ {
         pendingCR = true
       } else {
         pendingCR = false

--- a/Sources/HTTPStreamingClient/HTTPLineDecoder.swift
+++ b/Sources/HTTPStreamingClient/HTTPLineDecoder.swift
@@ -61,13 +61,19 @@ package struct HTTPLineDecoder: Sendable {
         }
       }
 
-      if nextNewlineIndex > searchStartIndex {
-        buffer.append(data[searchStartIndex..<nextNewlineIndex])
-      }
+      let lineSlice = data[searchStartIndex..<nextNewlineIndex]
+      let line: String
 
-      let line = String(decoding: buffer, as: UTF8.self)
+      if buffer.isEmpty {
+        // Fast path: Zero-copy direct slice decoding
+        line = String(decoding: lineSlice, as: UTF8.self)
+      } else {
+        // Slow path: Stitch together bytes split across chunk boundaries
+        buffer.append(lineSlice)
+        line = String(decoding: buffer, as: UTF8.self)
+        buffer.removeAll(keepingCapacity: true)
+      }
       lines.append(line)
-      buffer.removeAll(keepingCapacity: true)
 
       if byte == 0x0D {
         pendingCR = true

--- a/Sources/HTTPStreamingClient/HTTPLineDecoder.swift
+++ b/Sources/HTTPStreamingClient/HTTPLineDecoder.swift
@@ -40,17 +40,15 @@ package struct HTTPLineDecoder: Sendable {
     }
 
     while searchStartIndex < data.endIndex {
-      let slice = data[searchStartIndex...]
-      let lfIndex = slice.firstIndex(of: 0x0A)  // Line Feed (\n)
-      let crIndex = slice.firstIndex(of: 0x0D)  // Carriage Return (\r)
-
-      let nextNewlineIndex: Data.Index
-      if let lf = lfIndex, let cr = crIndex {
-        nextNewlineIndex = min(lf, cr)
-      } else if let found = lfIndex ?? crIndex {
-        nextNewlineIndex = found
-      } else {
-        buffer.append(slice)
+      // Uses a single `firstIndex(where:)` to avoid an O(N^2) performance edge-case.
+      // Two separate `firstIndex(of:)` scans would repeatedly scan the entire remainder
+      // of the chunk if one delimiter type (e.g. CR) is missing from the payload.
+      guard
+        let nextNewlineIndex = data[searchStartIndex...].firstIndex(where: {
+          $0 == 0x0A /* LF (\n) */ || $0 == 0x0D /* CR (\r) */
+        })
+      else {
+        buffer.append(data[searchStartIndex...])
         pendingCR = false
         break
       }

--- a/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
+++ b/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
@@ -57,8 +57,8 @@ package final class HTTPStreamingClient: Sendable {
     let (dataStream, dataContinuation) = AsyncThrowingStream<Data, any Error>.makeStream()
 
     let dataTask = session.dataTask(with: request)
-    dataContinuation.onTermination = { @Sendable _ in
-      dataTask.cancel()
+    dataContinuation.onTermination = { @Sendable [weak dataTask] _ in
+      dataTask?.cancel()
     }
 
     let taskDelegate = TaskDelegate(dataContinuation: dataContinuation)

--- a/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
+++ b/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
@@ -97,6 +97,7 @@ package struct HTTPAsyncLineSequence: AsyncSequence, Sendable {
 
   /// The underlying `URLSessionTask` performing the data transfer.
   package let task: URLSessionTask
+  /// Retained to prevent the client (and its session) from deallocating during iteration.
   private let client: HTTPStreamingClient
 
   /// Initializes a new async line sequence from a data stream.
@@ -127,6 +128,7 @@ package struct HTTPAsyncLineSequence: AsyncSequence, Sendable {
     private var streamIterator: AsyncThrowingStream<Data, any Error>.AsyncIterator
     private var decoder = HTTPLineDecoder()
     private var pendingLines: ArraySlice<String> = []
+    /// Retained to prevent the client (and its session) from deallocating during iteration.
     private let client: HTTPStreamingClient
 
     /// Initializes a new async iterator.

--- a/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
+++ b/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
@@ -21,54 +21,46 @@ package import Foundation
 /// An HTTP client that streams bytes and lines of text using `URLSession`.
 ///
 /// Supports Apple platforms and Linux with full Swift 6 strict concurrency compliance.
-@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 package struct HTTPStreamingClient: Sendable {
   private let session: URLSession
-  private let delegate: SessionDelegate
 
   /// Initializes a new HTTP streaming client with the specified configuration.
   ///
   /// - Parameter configuration: The `URLSessionConfiguration` to use. Defaults to `.default`.
-  package init(configuration: URLSessionConfiguration = .default) {
-    let delegate = SessionDelegate()
-    self.delegate = delegate
-    self.session = URLSession(
-      configuration: configuration,
-      delegate: delegate,
-      delegateQueue: nil
-    )
+  package init(configuration: URLSessionConfiguration = .ephemeral) {
+    self.session = URLSession(configuration: configuration)
   }
 
-  /// Sends a request and delivers an asynchronous sequence of bytes and the HTTP response metadata.
+  /// Sends a request and delivers an asynchronous sequence of lines of text and the HTTP response metadata.
   ///
   /// - Parameter request: The `URLRequest` to execute.
-  /// - Returns: A tuple containing the `HTTPAsyncBytes` stream and `HTTPURLResponse` metadata.
+  /// - Returns: A tuple containing the `HTTPAsyncLineSequence` stream and `HTTPURLResponse` metadata.
   /// - Throws: An error if the request fails to connect or if the response is not an HTTP response.
-  package func bytes(
+  package func lines(
     for request: URLRequest
-  ) async throws -> (bytes: HTTPAsyncBytes, response: HTTPURLResponse) {
+  ) async throws -> (lines: HTTPAsyncLineSequence, response: HTTPURLResponse) {
     let (dataStream, dataContinuation) = AsyncThrowingStream<Data, any Error>.makeStream()
 
-    let task = session.dataTask(with: request)
+    let dataTask = session.dataTask(with: request)
     dataContinuation.onTermination = { @Sendable _ in
-      task.cancel()
+      dataTask.cancel()
     }
+
+    let taskDelegate = TaskDelegate(dataContinuation: dataContinuation)
+    dataTask.delegate = taskDelegate
 
     let response: HTTPURLResponse = try await withTaskCancellationHandler {
       try await withCheckedThrowingContinuation { continuation in
-        delegate.register(
-          task: task,
-          responseContinuation: continuation,
-          dataContinuation: dataContinuation
-        )
-        task.resume()
+        taskDelegate.setResponseContinuation(continuation)
+        dataTask.resume()
       }
     } onCancel: {
-      task.cancel()
+      dataTask.cancel()
     }
 
-    let asyncBytes = HTTPAsyncBytes(dataStream: dataStream, task: task)
-    return (bytes: asyncBytes, response: response)
+    let asyncLines = HTTPAsyncLineSequence(dataStream: dataStream, task: dataTask)
+    return (lines: asyncLines, response: response)
   }
 
   /// Invalidates the session, allowing any outstanding tasks to finish.
@@ -82,14 +74,12 @@ package struct HTTPStreamingClient: Sendable {
   }
 }
 
-// MARK: - HTTP Async Bytes
+// MARK: - HTTP Async Line Sequence
 
-/// An asynchronous sequence of bytes delivered from an HTTP request.
-@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-package struct HTTPAsyncBytes: AsyncSequence, Sendable {
-  /// The type of element produced by this asynchronous byte stream.
-  package typealias Element = UInt8
-
+/// An asynchronous sequence of lines of text parsed from an HTTP byte stream.
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+/// Safety: `URLSessionTask` is inherently thread-safe in Foundation.
+package struct HTTPAsyncLineSequence: AsyncSequence, Sendable {
   private let dataStream: AsyncThrowingStream<Data, any Error>
 
   /// The underlying `URLSessionTask` performing the data transfer.
@@ -97,78 +87,10 @@ package struct HTTPAsyncBytes: AsyncSequence, Sendable {
 
   init(
     dataStream: AsyncThrowingStream<Data, any Error>,
-    task: URLSessionTask? = nil
+    task: URLSessionDataTask? = nil
   ) {
     self.dataStream = dataStream
     self.task = task
-  }
-
-  /// An asynchronous sequence of lines of text extracted from this byte stream.
-  package var lines: HTTPAsyncLineSequence {
-    HTTPAsyncLineSequence(dataStream: dataStream)
-  }
-
-  /// Collects all bytes from the stream into a single `Data` instance.
-  ///
-  /// - Returns: The complete response body as `Data`.
-  /// - Throws: An error if the stream encounters a network failure.
-  package func collect() async throws -> Data {
-    var accumulated = Data()
-    for try await chunk in dataStream {
-      accumulated.append(chunk)
-    }
-    return accumulated
-  }
-
-  /// Creates an asynchronous iterator over the byte sequence.
-  ///
-  /// - Returns: An `AsyncIterator` instance.
-  package func makeAsyncIterator() -> AsyncIterator {
-    AsyncIterator(streamIterator: dataStream.makeAsyncIterator())
-  }
-
-  /// An asynchronous iterator over the bytes of an HTTP response body.
-  package struct AsyncIterator: AsyncIteratorProtocol {
-    private var streamIterator: AsyncThrowingStream<Data, any Error>.AsyncIterator
-    private var currentChunk: Data = Data()
-    private var currentIndex: Data.Index = 0
-
-    init(streamIterator: AsyncThrowingStream<Data, any Error>.AsyncIterator) {
-      self.streamIterator = streamIterator
-    }
-
-    /// Asynchronously advances to and returns the next byte in the stream.
-    ///
-    /// - Returns: The next byte, or `nil` if the stream has finished.
-    /// - Throws: An error if reading from the stream fails.
-    package mutating func next() async throws -> UInt8? {
-      while currentIndex >= currentChunk.endIndex {
-        guard let nextChunk = try await streamIterator.next() else {
-          return nil
-        }
-        currentChunk = nextChunk
-        currentIndex = currentChunk.startIndex
-      }
-
-      let byte = currentChunk[currentIndex]
-      currentIndex = currentChunk.index(after: currentIndex)
-      return byte
-    }
-  }
-}
-
-// MARK: - HTTP Async Line Sequence
-
-/// An asynchronous sequence of lines of text parsed from an HTTP byte stream.
-@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-package struct HTTPAsyncLineSequence: AsyncSequence, Sendable {
-  /// The type of element produced by this line sequence.
-  package typealias Element = String
-
-  private let dataStream: AsyncThrowingStream<Data, any Error>
-
-  init(dataStream: AsyncThrowingStream<Data, any Error>) {
-    self.dataStream = dataStream
   }
 
   /// Creates an asynchronous iterator over the line sequence.
@@ -247,28 +169,28 @@ private final class LockProtected<State>: @unchecked Sendable {
   }
 }
 
-// MARK: - Internal Session Delegate
+// MARK: - Internal Task Delegate
 
-@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-private final class SessionDelegate: NSObject, URLSessionDataDelegate, Sendable {
-  private struct TaskState {
-    var responseContinuation: CheckedContinuation<HTTPURLResponse, any Error>?
-    let dataContinuation: AsyncThrowingStream<Data, any Error>.Continuation
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+/// Safety: Protected by `LockProtected` for all mutable state.
+private final class TaskDelegate: NSObject, URLSessionDataDelegate, Sendable {
+  let responseContinuation = LockProtected<CheckedContinuation<HTTPURLResponse, any Error>?>(nil)
+  let dataContinuation: AsyncThrowingStream<Data, any Error>.Continuation
+
+  init(dataContinuation: AsyncThrowingStream<Data, any Error>.Continuation) {
+    self.dataContinuation = dataContinuation
   }
 
-  private let tasks = LockProtected<[URLSessionTask: TaskState]>([:])
-
-  func register(
-    task: URLSessionTask,
-    responseContinuation: CheckedContinuation<HTTPURLResponse, any Error>,
-    dataContinuation: AsyncThrowingStream<Data, any Error>.Continuation
-  ) {
-    tasks.withLock {
-      $0[task] = TaskState(
-        responseContinuation: responseContinuation,
-        dataContinuation: dataContinuation
-      )
+  func takeResponseContinuation() -> CheckedContinuation<HTTPURLResponse, any Error>? {
+    responseContinuation.withLock { state in
+      let value = state
+      state = nil
+      return value
     }
+  }
+
+  func setResponseContinuation(_ continuation: CheckedContinuation<HTTPURLResponse, any Error>) {
+    responseContinuation.withLock { $0 = continuation }
   }
 
   func urlSession(
@@ -277,30 +199,16 @@ private final class SessionDelegate: NSObject, URLSessionDataDelegate, Sendable 
     didReceive response: URLResponse,
     completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
   ) {
-    let outcome = tasks.withLock {
-      (state: inout [URLSessionTask: TaskState]) -> (
-        CheckedContinuation<HTTPURLResponse, any Error>?, Bool
-      )? in
-      guard let taskState = state[dataTask] else { return nil }
-      if response is HTTPURLResponse {
-        state[dataTask]?.responseContinuation = nil
-        return (taskState.responseContinuation, true)
-      } else {
-        state.removeValue(forKey: dataTask)
-        return (taskState.responseContinuation, false)
-      }
-    }
-
-    guard let (continuation, isHTTP) = outcome else {
+    guard let continuation = takeResponseContinuation() else {
       completionHandler(.cancel)
       return
     }
 
-    if isHTTP, let httpResponse = response as? HTTPURLResponse {
-      continuation?.resume(returning: httpResponse)
+    if let httpResponse = response as? HTTPURLResponse {
+      continuation.resume(returning: httpResponse)
       completionHandler(.allow)
     } else {
-      continuation?.resume(throwing: URLError(.badServerResponse))
+      continuation.resume(throwing: URLError(.badServerResponse))
       completionHandler(.cancel)
     }
   }
@@ -310,8 +218,7 @@ private final class SessionDelegate: NSObject, URLSessionDataDelegate, Sendable 
     dataTask: URLSessionDataTask,
     didReceive data: Data
   ) {
-    let continuation = tasks.withLock { $0[dataTask]?.dataContinuation }
-    continuation?.yield(data)
+    dataContinuation.yield(data)
   }
 
   func urlSession(
@@ -319,98 +226,14 @@ private final class SessionDelegate: NSObject, URLSessionDataDelegate, Sendable 
     task: URLSessionTask,
     didCompleteWithError error: (any Error)?
   ) {
-    let state = tasks.withLock { $0.removeValue(forKey: task) }
-    guard let state else { return }
-
     if let error {
-      state.responseContinuation?.resume(throwing: error)
-      state.dataContinuation.finish(throwing: error)
+      takeResponseContinuation()?.resume(throwing: error)
+      dataContinuation.finish(throwing: error)
     } else {
-      if let responseContinuation = state.responseContinuation {
-        responseContinuation.resume(throwing: URLError(.badServerResponse))
+      if let continuation = takeResponseContinuation() {
+        continuation.resume(throwing: URLError(.badServerResponse))
       }
-      state.dataContinuation.finish()
+      dataContinuation.finish()
     }
-  }
-}
-
-// MARK: - Incremental Line Decoder
-
-/// An incremental decoder that extracts UTF-8 lines of text from streaming byte chunks.
-package struct HTTPLineDecoder: Sendable {
-  private var buffer = Data()
-  private var pendingCR = false
-
-  /// Initializes a new line decoder with an empty buffer.
-  package init() {}
-
-  /// Feeds a new chunk of data and returns all complete lines found.
-  ///
-  /// - Parameter data: The incoming data chunk.
-  /// - Returns: An array of decoded lines with trailing line delimiters stripped.
-  package mutating func feed(_ data: Data) -> [String] {
-    guard !data.isEmpty else { return [] }
-
-    var lines: [String] = []
-    lines.reserveCapacity(data.count / 32)
-    var searchStartIndex = data.startIndex
-
-    if pendingCR {
-      pendingCR = false
-      if data[searchStartIndex] == 0x0A {
-        searchStartIndex = data.index(after: searchStartIndex)
-      }
-    }
-
-    while searchStartIndex < data.endIndex {
-      guard
-        let nextNewlineIndex = data[searchStartIndex...].firstIndex(where: {
-          $0 == 0x0A || $0 == 0x0D
-        })
-      else {
-        buffer.append(data[searchStartIndex...])
-        pendingCR = false
-        break
-      }
-
-      let byte = data[nextNewlineIndex]
-
-      if pendingCR {
-        pendingCR = false
-        if byte == 0x0A && nextNewlineIndex == searchStartIndex {
-          searchStartIndex = data.index(after: nextNewlineIndex)
-          continue
-        }
-      }
-
-      if nextNewlineIndex > searchStartIndex {
-        buffer.append(data[searchStartIndex..<nextNewlineIndex])
-      }
-
-      let line = String(decoding: buffer, as: UTF8.self)
-      lines.append(line)
-      buffer.removeAll(keepingCapacity: true)
-
-      if byte == 0x0D {
-        pendingCR = true
-      } else {
-        pendingCR = false
-      }
-
-      searchStartIndex = data.index(after: nextNewlineIndex)
-    }
-
-    return lines
-  }
-
-  /// Flushes any remaining bytes in the buffer as the final line.
-  ///
-  /// - Returns: The final line if the buffer is non-empty, or `nil`.
-  package mutating func flush() -> String? {
-    pendingCR = false
-    guard !buffer.isEmpty else { return nil }
-    let line = String(decoding: buffer, as: UTF8.self)
-    buffer.removeAll(keepingCapacity: false)
-    return line
   }
 }

--- a/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
+++ b/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
@@ -25,14 +25,25 @@ import Synchronization
 ///
 /// Supports Apple platforms and Linux with full Swift 6 strict concurrency compliance.
 @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-package struct HTTPStreamingClient: Sendable {
+package final class HTTPStreamingClient: Sendable {
   private let session: URLSession
+  private let sessionDelegate: SessionDelegate
 
   /// Initializes a new HTTP streaming client with the specified configuration.
   ///
   /// - Parameter configuration: The `URLSessionConfiguration` to use. Defaults to `.ephemeral`.
   package init(configuration: URLSessionConfiguration = .ephemeral) {
-    self.session = URLSession(configuration: configuration)
+    let delegate = SessionDelegate()
+    self.sessionDelegate = delegate
+    self.session = URLSession(
+      configuration: configuration,
+      delegate: delegate,
+      delegateQueue: nil
+    )
+  }
+
+  deinit {
+    session.invalidateAndCancel()
   }
 
   /// Sends a request and delivers an asynchronous sequence of lines of text and the HTTP response.
@@ -51,7 +62,7 @@ package struct HTTPStreamingClient: Sendable {
     }
 
     let taskDelegate = TaskDelegate(dataContinuation: dataContinuation)
-    dataTask.delegate = taskDelegate
+    sessionDelegate.addTaskDelegate(taskDelegate, for: dataTask.taskIdentifier)
 
     let response: HTTPURLResponse = try await withTaskCancellationHandler {
       try await withCheckedThrowingContinuation { continuation in
@@ -133,11 +144,66 @@ package struct HTTPAsyncLineSequence: AsyncSequence, Sendable {
   }
 }
 
+// MARK: - Internal Session Delegate Dispatcher
+
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private final class SessionDelegate: NSObject, URLSessionDataDelegate, Sendable {
+  private let taskDelegates = Mutex<[Int: TaskDelegate]>([:])
+
+  func addTaskDelegate(_ delegate: TaskDelegate, for taskIdentifier: Int) {
+    taskDelegates.withLock { $0[taskIdentifier] = delegate }
+  }
+
+  private func taskDelegate(for taskIdentifier: Int) -> TaskDelegate? {
+    taskDelegates.withLock { $0[taskIdentifier] }
+  }
+
+  private func removeTaskDelegate(for taskIdentifier: Int) -> TaskDelegate? {
+    taskDelegates.withLock { $0.removeValue(forKey: taskIdentifier) }
+  }
+
+  // MARK: - URLSessionDataDelegate
+
+  func urlSession(
+    _ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse,
+    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+  ) {
+    guard let delegate = taskDelegate(for: dataTask.taskIdentifier) else {
+      completionHandler(.allow)
+      return
+    }
+    delegate.urlSession(
+      session,
+      dataTask: dataTask,
+      didReceive: response,
+      completionHandler: completionHandler
+    )
+  }
+
+  func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+    guard let delegate = taskDelegate(for: dataTask.taskIdentifier) else { return }
+    delegate.urlSession(session, dataTask: dataTask, didReceive: data)
+  }
+
+  func urlSession(
+    _ session: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?
+  ) {
+    let delegate = removeTaskDelegate(for: task.taskIdentifier)
+    delegate?.urlSession(session, task: task, didCompleteWithError: error)
+  }
+}
+
 // MARK: - Internal Task Delegate
 
 @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 private final class TaskDelegate: NSObject, URLSessionDataDelegate, Sendable {
-  private let responseContinuation = Mutex<CheckedContinuation<HTTPURLResponse, any Error>?>(nil)
+  private enum ResponseState: Sendable {
+    case pending
+    case waiting(CheckedContinuation<HTTPURLResponse, any Error>)
+    case completed(Result<HTTPURLResponse, any Error>)
+  }
+
+  private let responseState = Mutex<ResponseState>(.pending)
   private let dataContinuation: AsyncThrowingStream<Data, any Error>.Continuation
 
   init(dataContinuation: AsyncThrowingStream<Data, any Error>.Continuation) {
@@ -145,17 +211,39 @@ private final class TaskDelegate: NSObject, URLSessionDataDelegate, Sendable {
   }
 
   func setResponseContinuation(_ continuation: CheckedContinuation<HTTPURLResponse, any Error>) {
-    responseContinuation.withLock { $0 = continuation }
+    let resultToResume: Result<HTTPURLResponse, any Error>? = responseState.withLock { state in
+      switch state {
+      case .pending:
+        state = .waiting(continuation)
+        return nil
+      case .waiting:
+        fatalError("Response continuation set multiple times")
+      case .completed(let result):
+        return result
+      }
+    }
+    if let resultToResume {
+      continuation.resume(with: resultToResume)
+    }
   }
 
-  /// Atomically consumes and resumes the continuation exactly once.
+  /// Atomically transitions the state to completed and resumes any waiting continuation.
   private func resumeResponse(with result: Result<HTTPURLResponse, any Error>) {
-    let continuation = responseContinuation.withLock { state in
-      let value = state
-      state = nil
-      return value
-    }
-    continuation?.resume(with: result)
+    let continuationToResume: CheckedContinuation<HTTPURLResponse, any Error>? =
+      responseState
+      .withLock { state in
+        switch state {
+        case .pending:
+          state = .completed(result)
+          return nil
+        case .waiting(let continuation):
+          state = .completed(result)
+          return continuation
+        case .completed:
+          return nil
+        }
+      }
+    continuationToResume?.resume(with: result)
   }
 
   // MARK: - URLSessionDataDelegate

--- a/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
+++ b/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package import Foundation
+import Synchronization
 
-#if canImport(FoundationNetworking)
+#if canImport(Darwin)
+  package import Foundation
+#else
+  import Foundation
   package import FoundationNetworking
 #endif
 
@@ -27,15 +30,15 @@ package struct HTTPStreamingClient: Sendable {
 
   /// Initializes a new HTTP streaming client with the specified configuration.
   ///
-  /// - Parameter configuration: The `URLSessionConfiguration` to use. Defaults to `.default`.
+  /// - Parameter configuration: The `URLSessionConfiguration` to use. Defaults to `.ephemeral`.
   package init(configuration: URLSessionConfiguration = .ephemeral) {
     self.session = URLSession(configuration: configuration)
   }
 
-  /// Sends a request and delivers an asynchronous sequence of lines of text and the HTTP response metadata.
+  /// Sends a request and delivers an asynchronous sequence of lines of text and the HTTP response.
   ///
   /// - Parameter request: The `URLRequest` to execute.
-  /// - Returns: A tuple containing the `HTTPAsyncLineSequence` stream and `HTTPURLResponse` metadata.
+  /// - Returns: A tuple of the `HTTPAsyncLineSequence` stream and `HTTPURLResponse` metadata.
   /// - Throws: An error if the request fails to connect or if the response is not an HTTP response.
   package func lines(
     for request: URLRequest
@@ -78,7 +81,6 @@ package struct HTTPStreamingClient: Sendable {
 
 /// An asynchronous sequence of lines of text parsed from an HTTP byte stream.
 @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-/// Safety: `URLSessionTask` is inherently thread-safe in Foundation.
 package struct HTTPAsyncLineSequence: AsyncSequence, Sendable {
   private let dataStream: AsyncThrowingStream<Data, any Error>
 
@@ -104,9 +106,7 @@ package struct HTTPAsyncLineSequence: AsyncSequence, Sendable {
   package struct AsyncIterator: AsyncIteratorProtocol {
     private var streamIterator: AsyncThrowingStream<Data, any Error>.AsyncIterator
     private var decoder = HTTPLineDecoder()
-    private var pendingLines: [String] = []
-    private var pendingIndex: Int = 0
-    private var isFinished = false
+    private var pendingLines: ArraySlice<String> = []
 
     init(streamIterator: AsyncThrowingStream<Data, any Error>.AsyncIterator) {
       self.streamIterator = streamIterator
@@ -117,122 +117,78 @@ package struct HTTPAsyncLineSequence: AsyncSequence, Sendable {
     /// - Returns: The next decoded line of text, or `nil` if the stream has finished.
     /// - Throws: An error if reading from the stream fails.
     package mutating func next() async throws -> String? {
-      while pendingIndex >= pendingLines.count {
-        if isFinished {
-          return nil
-        }
-
+      while pendingLines.isEmpty {
         guard let chunk = try await streamIterator.next() else {
-          isFinished = true
-          if let remainder = decoder.flush() {
-            return remainder
-          }
-          return nil
+          // Once the stream ends, flush any remaining bytes as a final line.
+          // Subsequent calls to next() will safely fall through and return nil.
+          return decoder.flush()
         }
 
-        let lines = decoder.feed(chunk)
-        if !lines.isEmpty {
-          pendingLines = lines
-          pendingIndex = 0
-          let firstLine = pendingLines[pendingIndex]
-          pendingIndex += 1
-          return firstLine
-        }
+        // Convert the returned Array into an ArraySlice
+        pendingLines = decoder.feed(chunk)[...]
       }
 
-      let line = pendingLines[pendingIndex]
-      pendingIndex += 1
-      return line
+      return pendingLines.popFirst()
     }
-  }
-}
-
-// MARK: - Lock Protected Container
-
-/// A thread-safe container for mutable state.
-///
-/// Safety: This class uses an `NSLock` to serialize all access to the underlying `state`.
-/// It is marked `@unchecked Sendable` because the compiler cannot verify `NSLock` isolation,
-/// but data-race safety is manually guaranteed.
-private final class LockProtected<State>: @unchecked Sendable {
-  private let lock = NSLock()
-  private var state: State
-
-  init(_ initialState: State) {
-    self.state = initialState
-  }
-
-  func withLock<Result>(_ body: (inout State) throws -> Result) rethrows -> Result {
-    lock.lock()
-    defer { lock.unlock() }
-    return try body(&state)
   }
 }
 
 // MARK: - Internal Task Delegate
 
 @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-/// Safety: Protected by `LockProtected` for all mutable state.
 private final class TaskDelegate: NSObject, URLSessionDataDelegate, Sendable {
-  let responseContinuation = LockProtected<CheckedContinuation<HTTPURLResponse, any Error>?>(nil)
-  let dataContinuation: AsyncThrowingStream<Data, any Error>.Continuation
+  private let responseContinuation = Mutex<CheckedContinuation<HTTPURLResponse, any Error>?>(nil)
+  private let dataContinuation: AsyncThrowingStream<Data, any Error>.Continuation
 
   init(dataContinuation: AsyncThrowingStream<Data, any Error>.Continuation) {
     self.dataContinuation = dataContinuation
-  }
-
-  func takeResponseContinuation() -> CheckedContinuation<HTTPURLResponse, any Error>? {
-    responseContinuation.withLock { state in
-      let value = state
-      state = nil
-      return value
-    }
   }
 
   func setResponseContinuation(_ continuation: CheckedContinuation<HTTPURLResponse, any Error>) {
     responseContinuation.withLock { $0 = continuation }
   }
 
+  /// Atomically consumes and resumes the continuation exactly once.
+  private func resumeResponse(with result: Result<HTTPURLResponse, any Error>) {
+    let continuation = responseContinuation.withLock { state in
+      let value = state
+      state = nil
+      return value
+    }
+    continuation?.resume(with: result)
+  }
+
+  // MARK: - URLSessionDataDelegate
+
   func urlSession(
-    _ session: URLSession,
-    dataTask: URLSessionDataTask,
-    didReceive response: URLResponse,
+    _ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse,
     completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
   ) {
-    guard let continuation = takeResponseContinuation() else {
-      completionHandler(.cancel)
-      return
-    }
-
+    // 1. Dedicated hook for the response header
     if let httpResponse = response as? HTTPURLResponse {
-      continuation.resume(returning: httpResponse)
+      resumeResponse(with: .success(httpResponse))
       completionHandler(.allow)
     } else {
-      continuation.resume(throwing: URLError(.badServerResponse))
+      resumeResponse(with: .failure(URLError(.badServerResponse)))
       completionHandler(.cancel)
     }
   }
 
-  func urlSession(
-    _ session: URLSession,
-    dataTask: URLSessionDataTask,
-    didReceive data: Data
-  ) {
+  func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+    // 2. Pure data passthrough
     dataContinuation.yield(data)
   }
 
   func urlSession(
-    _ session: URLSession,
-    task: URLSessionTask,
-    didCompleteWithError error: (any Error)?
+    _ session: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?
   ) {
+    // 3. Clean up stream and catch any pre-response failures
     if let error {
-      takeResponseContinuation()?.resume(throwing: error)
+      resumeResponse(with: .failure(error))
       dataContinuation.finish(throwing: error)
     } else {
-      if let continuation = takeResponseContinuation() {
-        continuation.resume(throwing: URLError(.badServerResponse))
-      }
+      // Fallback in case the task completes successfully but somehow never sent a response
+      resumeResponse(with: .failure(URLError(.badServerResponse)))
       dataContinuation.finish()
     }
   }

--- a/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
+++ b/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
@@ -73,7 +73,7 @@ package final class HTTPStreamingClient: Sendable {
       dataTask.cancel()
     }
 
-    let asyncLines = HTTPAsyncLineSequence(dataStream: dataStream, task: dataTask)
+    let asyncLines = HTTPAsyncLineSequence(dataStream: dataStream, task: dataTask, client: self)
     return (lines: asyncLines, response: response)
   }
 
@@ -97,25 +97,29 @@ package struct HTTPAsyncLineSequence: AsyncSequence, Sendable {
 
   /// The underlying `URLSessionTask` performing the data transfer.
   package let task: URLSessionTask
+  private let client: HTTPStreamingClient
 
   /// Initializes a new async line sequence from a data stream.
   ///
   /// - Parameters:
   ///   - dataStream: The underlying byte stream.
   ///   - task: The URL session data task.
+  ///   - client: The HTTP client that created this sequence.
   init(
     dataStream: AsyncThrowingStream<Data, any Error>,
-    task: URLSessionDataTask
+    task: URLSessionDataTask,
+    client: HTTPStreamingClient
   ) {
     self.dataStream = dataStream
     self.task = task
+    self.client = client
   }
 
   /// Creates an asynchronous iterator over the line sequence.
   ///
   /// - Returns: An `AsyncIterator` instance.
   package func makeAsyncIterator() -> AsyncIterator {
-    AsyncIterator(streamIterator: dataStream.makeAsyncIterator())
+    AsyncIterator(streamIterator: dataStream.makeAsyncIterator(), client: client)
   }
 
   /// An asynchronous iterator over lines of text decoded from an HTTP response.
@@ -123,12 +127,19 @@ package struct HTTPAsyncLineSequence: AsyncSequence, Sendable {
     private var streamIterator: AsyncThrowingStream<Data, any Error>.AsyncIterator
     private var decoder = HTTPLineDecoder()
     private var pendingLines: ArraySlice<String> = []
+    private let client: HTTPStreamingClient
 
     /// Initializes a new async iterator.
     ///
-    /// - Parameter streamIterator: The underlying byte stream iterator.
-    init(streamIterator: AsyncThrowingStream<Data, any Error>.AsyncIterator) {
+    /// - Parameters:
+    ///   - streamIterator: The underlying byte stream iterator.
+    ///   - client: The HTTP client that created this sequence.
+    init(
+      streamIterator: AsyncThrowingStream<Data, any Error>.AsyncIterator,
+      client: HTTPStreamingClient
+    ) {
       self.streamIterator = streamIterator
+      self.client = client
     }
 
     /// Asynchronously advances to and returns the next line of text.

--- a/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
+++ b/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
@@ -96,11 +96,16 @@ package struct HTTPAsyncLineSequence: AsyncSequence, Sendable {
   private let dataStream: AsyncThrowingStream<Data, any Error>
 
   /// The underlying `URLSessionTask` performing the data transfer.
-  package let task: URLSessionTask?
+  package let task: URLSessionTask
 
+  /// Initializes a new async line sequence from a data stream.
+  ///
+  /// - Parameters:
+  ///   - dataStream: The underlying byte stream.
+  ///   - task: The URL session data task.
   init(
     dataStream: AsyncThrowingStream<Data, any Error>,
-    task: URLSessionDataTask? = nil
+    task: URLSessionDataTask
   ) {
     self.dataStream = dataStream
     self.task = task
@@ -119,6 +124,9 @@ package struct HTTPAsyncLineSequence: AsyncSequence, Sendable {
     private var decoder = HTTPLineDecoder()
     private var pendingLines: ArraySlice<String> = []
 
+    /// Initializes a new async iterator.
+    ///
+    /// - Parameter streamIterator: The underlying byte stream iterator.
     init(streamIterator: AsyncThrowingStream<Data, any Error>.AsyncIterator) {
       self.streamIterator = streamIterator
     }

--- a/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
+++ b/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
@@ -1,0 +1,416 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package import Foundation
+
+#if canImport(FoundationNetworking)
+  package import FoundationNetworking
+#endif
+
+/// An HTTP client that streams bytes and lines of text using `URLSession`.
+///
+/// Supports Apple platforms and Linux with full Swift 6 strict concurrency compliance.
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+package struct HTTPStreamingClient: Sendable {
+  private let session: URLSession
+  private let delegate: SessionDelegate
+
+  /// Initializes a new HTTP streaming client with the specified configuration.
+  ///
+  /// - Parameter configuration: The `URLSessionConfiguration` to use. Defaults to `.default`.
+  package init(configuration: URLSessionConfiguration = .default) {
+    let delegate = SessionDelegate()
+    self.delegate = delegate
+    self.session = URLSession(
+      configuration: configuration,
+      delegate: delegate,
+      delegateQueue: nil
+    )
+  }
+
+  /// Sends a request and delivers an asynchronous sequence of bytes and the HTTP response metadata.
+  ///
+  /// - Parameter request: The `URLRequest` to execute.
+  /// - Returns: A tuple containing the `HTTPAsyncBytes` stream and `HTTPURLResponse` metadata.
+  /// - Throws: An error if the request fails to connect or if the response is not an HTTP response.
+  package func bytes(
+    for request: URLRequest
+  ) async throws -> (bytes: HTTPAsyncBytes, response: HTTPURLResponse) {
+    let (dataStream, dataContinuation) = AsyncThrowingStream<Data, any Error>.makeStream()
+
+    let task = session.dataTask(with: request)
+    dataContinuation.onTermination = { @Sendable _ in
+      task.cancel()
+    }
+
+    let response: HTTPURLResponse = try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { continuation in
+        delegate.register(
+          task: task,
+          responseContinuation: continuation,
+          dataContinuation: dataContinuation
+        )
+        task.resume()
+      }
+    } onCancel: {
+      task.cancel()
+    }
+
+    let asyncBytes = HTTPAsyncBytes(dataStream: dataStream, task: task)
+    return (bytes: asyncBytes, response: response)
+  }
+
+  /// Invalidates the session, allowing any outstanding tasks to finish.
+  package func finishTasksAndInvalidate() {
+    session.finishTasksAndInvalidate()
+  }
+
+  /// Invalidates the session and cancels all active tasks.
+  package func invalidateAndCancel() {
+    session.invalidateAndCancel()
+  }
+}
+
+// MARK: - HTTP Async Bytes
+
+/// An asynchronous sequence of bytes delivered from an HTTP request.
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+package struct HTTPAsyncBytes: AsyncSequence, Sendable {
+  /// The type of element produced by this asynchronous byte stream.
+  package typealias Element = UInt8
+
+  private let dataStream: AsyncThrowingStream<Data, any Error>
+
+  /// The underlying `URLSessionTask` performing the data transfer.
+  package let task: URLSessionTask?
+
+  init(
+    dataStream: AsyncThrowingStream<Data, any Error>,
+    task: URLSessionTask? = nil
+  ) {
+    self.dataStream = dataStream
+    self.task = task
+  }
+
+  /// An asynchronous sequence of lines of text extracted from this byte stream.
+  package var lines: HTTPAsyncLineSequence {
+    HTTPAsyncLineSequence(dataStream: dataStream)
+  }
+
+  /// Collects all bytes from the stream into a single `Data` instance.
+  ///
+  /// - Returns: The complete response body as `Data`.
+  /// - Throws: An error if the stream encounters a network failure.
+  package func collect() async throws -> Data {
+    var accumulated = Data()
+    for try await chunk in dataStream {
+      accumulated.append(chunk)
+    }
+    return accumulated
+  }
+
+  /// Creates an asynchronous iterator over the byte sequence.
+  ///
+  /// - Returns: An `AsyncIterator` instance.
+  package func makeAsyncIterator() -> AsyncIterator {
+    AsyncIterator(streamIterator: dataStream.makeAsyncIterator())
+  }
+
+  /// An asynchronous iterator over the bytes of an HTTP response body.
+  package struct AsyncIterator: AsyncIteratorProtocol {
+    private var streamIterator: AsyncThrowingStream<Data, any Error>.AsyncIterator
+    private var currentChunk: Data = Data()
+    private var currentIndex: Data.Index = 0
+
+    init(streamIterator: AsyncThrowingStream<Data, any Error>.AsyncIterator) {
+      self.streamIterator = streamIterator
+    }
+
+    /// Asynchronously advances to and returns the next byte in the stream.
+    ///
+    /// - Returns: The next byte, or `nil` if the stream has finished.
+    /// - Throws: An error if reading from the stream fails.
+    package mutating func next() async throws -> UInt8? {
+      while currentIndex >= currentChunk.endIndex {
+        guard let nextChunk = try await streamIterator.next() else {
+          return nil
+        }
+        currentChunk = nextChunk
+        currentIndex = currentChunk.startIndex
+      }
+
+      let byte = currentChunk[currentIndex]
+      currentIndex = currentChunk.index(after: currentIndex)
+      return byte
+    }
+  }
+}
+
+// MARK: - HTTP Async Line Sequence
+
+/// An asynchronous sequence of lines of text parsed from an HTTP byte stream.
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+package struct HTTPAsyncLineSequence: AsyncSequence, Sendable {
+  /// The type of element produced by this line sequence.
+  package typealias Element = String
+
+  private let dataStream: AsyncThrowingStream<Data, any Error>
+
+  init(dataStream: AsyncThrowingStream<Data, any Error>) {
+    self.dataStream = dataStream
+  }
+
+  /// Creates an asynchronous iterator over the line sequence.
+  ///
+  /// - Returns: An `AsyncIterator` instance.
+  package func makeAsyncIterator() -> AsyncIterator {
+    AsyncIterator(streamIterator: dataStream.makeAsyncIterator())
+  }
+
+  /// An asynchronous iterator over lines of text decoded from an HTTP response.
+  package struct AsyncIterator: AsyncIteratorProtocol {
+    private var streamIterator: AsyncThrowingStream<Data, any Error>.AsyncIterator
+    private var decoder = HTTPLineDecoder()
+    private var pendingLines: [String] = []
+    private var pendingIndex: Int = 0
+    private var isFinished = false
+
+    init(streamIterator: AsyncThrowingStream<Data, any Error>.AsyncIterator) {
+      self.streamIterator = streamIterator
+    }
+
+    /// Asynchronously advances to and returns the next line of text.
+    ///
+    /// - Returns: The next decoded line of text, or `nil` if the stream has finished.
+    /// - Throws: An error if reading from the stream fails.
+    package mutating func next() async throws -> String? {
+      while pendingIndex >= pendingLines.count {
+        if isFinished {
+          return nil
+        }
+
+        guard let chunk = try await streamIterator.next() else {
+          isFinished = true
+          if let remainder = decoder.flush() {
+            return remainder
+          }
+          return nil
+        }
+
+        let lines = decoder.feed(chunk)
+        if !lines.isEmpty {
+          pendingLines = lines
+          pendingIndex = 0
+          let firstLine = pendingLines[pendingIndex]
+          pendingIndex += 1
+          return firstLine
+        }
+      }
+
+      let line = pendingLines[pendingIndex]
+      pendingIndex += 1
+      return line
+    }
+  }
+}
+
+// MARK: - Lock Protected Container
+
+/// A thread-safe container for mutable state.
+///
+/// Safety: This class uses an `NSLock` to serialize all access to the underlying `state`.
+/// It is marked `@unchecked Sendable` because the compiler cannot verify `NSLock` isolation,
+/// but data-race safety is manually guaranteed.
+private final class LockProtected<State>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var state: State
+
+  init(_ initialState: State) {
+    self.state = initialState
+  }
+
+  func withLock<Result>(_ body: (inout State) throws -> Result) rethrows -> Result {
+    lock.lock()
+    defer { lock.unlock() }
+    return try body(&state)
+  }
+}
+
+// MARK: - Internal Session Delegate
+
+@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+private final class SessionDelegate: NSObject, URLSessionDataDelegate, Sendable {
+  private struct TaskState {
+    var responseContinuation: CheckedContinuation<HTTPURLResponse, any Error>?
+    let dataContinuation: AsyncThrowingStream<Data, any Error>.Continuation
+  }
+
+  private let tasks = LockProtected<[URLSessionTask: TaskState]>([:])
+
+  func register(
+    task: URLSessionTask,
+    responseContinuation: CheckedContinuation<HTTPURLResponse, any Error>,
+    dataContinuation: AsyncThrowingStream<Data, any Error>.Continuation
+  ) {
+    tasks.withLock {
+      $0[task] = TaskState(
+        responseContinuation: responseContinuation,
+        dataContinuation: dataContinuation
+      )
+    }
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    dataTask: URLSessionDataTask,
+    didReceive response: URLResponse,
+    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+  ) {
+    let outcome = tasks.withLock {
+      (state: inout [URLSessionTask: TaskState]) -> (
+        CheckedContinuation<HTTPURLResponse, any Error>?, Bool
+      )? in
+      guard let taskState = state[dataTask] else { return nil }
+      if response is HTTPURLResponse {
+        state[dataTask]?.responseContinuation = nil
+        return (taskState.responseContinuation, true)
+      } else {
+        state.removeValue(forKey: dataTask)
+        return (taskState.responseContinuation, false)
+      }
+    }
+
+    guard let (continuation, isHTTP) = outcome else {
+      completionHandler(.cancel)
+      return
+    }
+
+    if isHTTP, let httpResponse = response as? HTTPURLResponse {
+      continuation?.resume(returning: httpResponse)
+      completionHandler(.allow)
+    } else {
+      continuation?.resume(throwing: URLError(.badServerResponse))
+      completionHandler(.cancel)
+    }
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    dataTask: URLSessionDataTask,
+    didReceive data: Data
+  ) {
+    let continuation = tasks.withLock { $0[dataTask]?.dataContinuation }
+    continuation?.yield(data)
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didCompleteWithError error: (any Error)?
+  ) {
+    let state = tasks.withLock { $0.removeValue(forKey: task) }
+    guard let state else { return }
+
+    if let error {
+      state.responseContinuation?.resume(throwing: error)
+      state.dataContinuation.finish(throwing: error)
+    } else {
+      if let responseContinuation = state.responseContinuation {
+        responseContinuation.resume(throwing: URLError(.badServerResponse))
+      }
+      state.dataContinuation.finish()
+    }
+  }
+}
+
+// MARK: - Incremental Line Decoder
+
+/// An incremental decoder that extracts UTF-8 lines of text from streaming byte chunks.
+package struct HTTPLineDecoder: Sendable {
+  private var buffer = Data()
+  private var pendingCR = false
+
+  /// Initializes a new line decoder with an empty buffer.
+  package init() {}
+
+  /// Feeds a new chunk of data and returns all complete lines found.
+  ///
+  /// - Parameter data: The incoming data chunk.
+  /// - Returns: An array of decoded lines with trailing line delimiters stripped.
+  package mutating func feed(_ data: Data) -> [String] {
+    guard !data.isEmpty else { return [] }
+
+    var lines: [String] = []
+    lines.reserveCapacity(data.count / 32)
+    var searchStartIndex = data.startIndex
+
+    if pendingCR {
+      pendingCR = false
+      if data[searchStartIndex] == 0x0A {
+        searchStartIndex = data.index(after: searchStartIndex)
+      }
+    }
+
+    while searchStartIndex < data.endIndex {
+      guard
+        let nextNewlineIndex = data[searchStartIndex...].firstIndex(where: {
+          $0 == 0x0A || $0 == 0x0D
+        })
+      else {
+        buffer.append(data[searchStartIndex...])
+        pendingCR = false
+        break
+      }
+
+      let byte = data[nextNewlineIndex]
+
+      if pendingCR {
+        pendingCR = false
+        if byte == 0x0A && nextNewlineIndex == searchStartIndex {
+          searchStartIndex = data.index(after: nextNewlineIndex)
+          continue
+        }
+      }
+
+      if nextNewlineIndex > searchStartIndex {
+        buffer.append(data[searchStartIndex..<nextNewlineIndex])
+      }
+
+      let line = String(decoding: buffer, as: UTF8.self)
+      lines.append(line)
+      buffer.removeAll(keepingCapacity: true)
+
+      if byte == 0x0D {
+        pendingCR = true
+      } else {
+        pendingCR = false
+      }
+
+      searchStartIndex = data.index(after: nextNewlineIndex)
+    }
+
+    return lines
+  }
+
+  /// Flushes any remaining bytes in the buffer as the final line.
+  ///
+  /// - Returns: The final line if the buffer is non-empty, or `nil`.
+  package mutating func flush() -> String? {
+    pendingCR = false
+    guard !buffer.isEmpty else { return nil }
+    let line = String(decoding: buffer, as: UTF8.self)
+    buffer.removeAll(keepingCapacity: false)
+    return line
+  }
+}

--- a/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
+++ b/Sources/HTTPStreamingClient/HTTPStreamingClient.swift
@@ -273,6 +273,10 @@ private final class TaskDelegate: NSObject, URLSessionDataDelegate, Sendable {
   ) {
     // 1. Dedicated hook for the response header
     if let httpResponse = response as? HTTPURLResponse {
+      if (100...199).contains(httpResponse.statusCode) {
+        completionHandler(.allow)
+        return
+      }
       resumeResponse(with: .success(httpResponse))
       completionHandler(.allow)
     } else {

--- a/Tests/HTTPStreamingClientTests/HTTPLineDecoderTests.swift
+++ b/Tests/HTTPStreamingClientTests/HTTPLineDecoderTests.swift
@@ -1,0 +1,194 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import HTTPStreamingClient
+import Testing
+
+@Suite("HTTPLineDecoder Tests")
+struct HTTPLineDecoderTests {
+  @Test
+  func singleChunkWithMultipleLines() {
+    var decoder = HTTPLineDecoder()
+    let data = Data("line1\nline2\nline3\n".utf8)
+
+    let lines = decoder.feed(data)
+    let remainder = decoder.flush()
+
+    #expect(lines == ["line1", "line2", "line3"])
+    #expect(remainder == nil)
+  }
+
+  @Test
+  func linesSplitAcrossMultipleChunks() {
+    var decoder = HTTPLineDecoder()
+    let chunk1 = Data("hello ".utf8)
+    let chunk2 = Data("world\nsecond ".utf8)
+    let chunk3 = Data("line\n".utf8)
+
+    let lines1 = decoder.feed(chunk1)
+    let lines2 = decoder.feed(chunk2)
+    let lines3 = decoder.feed(chunk3)
+    let remainder = decoder.flush()
+
+    #expect(lines1.isEmpty)
+    #expect(lines2 == ["hello world"])
+    #expect(lines3 == ["second line"])
+    #expect(remainder == nil)
+  }
+
+  @Test
+  func splitCRLFBoundary() {
+    var decoder = HTTPLineDecoder()
+    let chunk1 = Data("first\r".utf8)
+    let chunk2 = Data("\nsecond\r\n".utf8)
+
+    let lines1 = decoder.feed(chunk1)
+    let lines2 = decoder.feed(chunk2)
+    let remainder = decoder.flush()
+
+    #expect(lines1 == ["first"])
+    #expect(lines2 == ["second"])
+    #expect(remainder == nil)
+  }
+
+  @Test
+  func standaloneCarriageReturn() {
+    var decoder = HTTPLineDecoder()
+    let chunk1 = Data("first\r".utf8)
+    let chunk2 = Data("second\r".utf8)
+    let chunk3 = Data("third".utf8)
+
+    let lines1 = decoder.feed(chunk1)
+    let lines2 = decoder.feed(chunk2)
+    let lines3 = decoder.feed(chunk3)
+    let remainder = decoder.flush()
+
+    #expect(lines1 == ["first"])
+    #expect(lines2 == ["second"])
+    #expect(lines3.isEmpty)
+    #expect(remainder == "third")
+  }
+
+  @Test
+  func splitMultiByteUTF8Character() {
+    var decoder = HTTPLineDecoder()
+    // "🎉" is 4 bytes: 0xF0, 0x9F, 0x8E, 0x89
+    let emojiBytes: [UInt8] = [0xF0, 0x9F, 0x8E, 0x89]
+    let chunk1 = Data("Start ".utf8) + Data(emojiBytes[0..<2])
+    let chunk2 = Data(emojiBytes[2..<4]) + Data(" End\n".utf8)
+
+    let lines1 = decoder.feed(chunk1)
+    let lines2 = decoder.feed(chunk2)
+    let remainder = decoder.flush()
+
+    #expect(lines1.isEmpty)
+    #expect(lines2 == ["Start 🎉 End"])
+    #expect(remainder == nil)
+  }
+
+  @Test
+  func preserveBlankLines() {
+    var decoder = HTTPLineDecoder()
+    let data = Data("line1\n\nline2\r\n\r\nline3\n".utf8)
+
+    let lines = decoder.feed(data)
+    let remainder = decoder.flush()
+
+    #expect(lines == ["line1", "", "line2", "", "line3"])
+    #expect(remainder == nil)
+  }
+
+  @Test
+  func flushRemainderWithoutTrailingNewline() {
+    var decoder = HTTPLineDecoder()
+    let data = Data("no newline at end".utf8)
+
+    let lines = decoder.feed(data)
+    let remainder = decoder.flush()
+
+    #expect(lines.isEmpty)
+    #expect(remainder == "no newline at end")
+  }
+
+  @Test
+  func emptyDataReturnsNoLines() {
+    var decoder = HTTPLineDecoder()
+
+    let lines = decoder.feed(Data())
+    let remainder = decoder.flush()
+
+    #expect(lines.isEmpty)
+    #expect(remainder == nil)
+  }
+
+  @Test
+  func multipleFlushesReturnNilAfterFirst() {
+    var decoder = HTTPLineDecoder()
+    _ = decoder.feed(Data("trailing".utf8))
+
+    let firstFlush = decoder.flush()
+    let secondFlush = decoder.flush()
+
+    #expect(firstFlush == "trailing")
+    #expect(secondFlush == nil)
+  }
+
+  @Test
+  func standaloneCRFollowedByNonNewlineChunk() {
+    var decoder = HTTPLineDecoder()
+    let chunk1 = Data("first\r".utf8)
+    let chunk2 = Data("second\n".utf8)
+
+    let lines1 = decoder.feed(chunk1)
+    let lines2 = decoder.feed(chunk2)
+    let remainder = decoder.flush()
+
+    #expect(lines1 == ["first"])
+    #expect(lines2 == ["second"])
+    #expect(remainder == nil)
+  }
+
+  @Test
+  func standaloneCRFollowedByNonNewlineInSameChunk() {
+    var decoder = HTTPLineDecoder()
+    let data = Data("first\rsecond\rthird\n".utf8)
+
+    let lines = decoder.feed(data)
+    let remainder = decoder.flush()
+
+    #expect(lines == ["first", "second", "third"])
+    #expect(remainder == nil)
+  }
+
+  @Test
+  func largePayloadWithMixedNewlines() {
+    var decoder = HTTPLineDecoder()
+    var expectedLines: [String] = []
+    var combinedData = Data()
+
+    for index in 1...500 {
+      let line = "Event item #\(index) with some UTF-8 data: 🚀✨"
+      expectedLines.append(line)
+      let delimiter = index.isMultiple(of: 2) ? "\r\n" : "\n"
+      combinedData.append(Data("\(line)\(delimiter)".utf8))
+    }
+
+    let lines = decoder.feed(combinedData)
+    let remainder = decoder.flush()
+
+    #expect(lines == expectedLines)
+    #expect(remainder == nil)
+  }
+}

--- a/Tests/HTTPStreamingClientTests/HTTPStreamingClientTests.swift
+++ b/Tests/HTTPStreamingClientTests/HTTPStreamingClientTests.swift
@@ -25,6 +25,7 @@ import Testing
 
 @Suite("HTTPStreamingClient Integration Tests", .serialized)
 struct HTTPStreamingClientTests {
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   private func makeClient() -> HTTPStreamingClient {
     MockHTTPURLProtocol.reset()
     let configuration = URLSessionConfiguration.ephemeral
@@ -33,7 +34,8 @@ struct HTTPStreamingClientTests {
   }
 
   @Test
-  func bytesMethodStreamsRawBytesAndLines() async throws {
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+  func streamsLinesAndReturnsTask() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/bytes-api"))
     let testResponse = try #require(
@@ -51,75 +53,19 @@ struct HTTPStreamingClientTests {
       proto.client?.urlProtocolDidFinishLoading(proto)
     }
 
-    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    let (linesSequence, response) = try await client.lines(for: URLRequest(url: testURL))
     var lines: [String] = []
-    for try await line in bytes.lines {
+    for try await line in linesSequence {
       lines.append(line)
     }
 
     #expect(response.statusCode == 200)
     #expect(lines == ["ABC", "DEF"])
-    #expect(bytes.task != nil)
+    #expect(linesSequence.task != nil)
   }
 
   @Test
-  func bytesIteratingRawBytes() async throws {
-    let client = makeClient()
-    let testURL = try #require(URL(string: "https://example.com/raw-bytes"))
-    let testResponse = try #require(
-      HTTPURLResponse(
-        url: testURL,
-        statusCode: 200,
-        httpVersion: "HTTP/1.1",
-        headerFields: nil
-      )
-    )
-
-    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
-      proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
-      proto.client?.urlProtocol(proto, didLoad: Data([0x01, 0x02]))
-      proto.client?.urlProtocol(proto, didLoad: Data([0x03, 0x04]))
-      proto.client?.urlProtocolDidFinishLoading(proto)
-    }
-
-    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
-    var receivedBytes: [UInt8] = []
-    for try await byte in bytes {
-      receivedBytes.append(byte)
-    }
-
-    #expect(response.statusCode == 200)
-    #expect(receivedBytes == [0x01, 0x02, 0x03, 0x04])
-  }
-
-  @Test
-  func bytesCollectBuffersEntireData() async throws {
-    let client = makeClient()
-    let testURL = try #require(URL(string: "https://example.com/collect-bytes"))
-    let testResponse = try #require(
-      HTTPURLResponse(
-        url: testURL,
-        statusCode: 200,
-        httpVersion: "HTTP/1.1",
-        headerFields: nil
-      )
-    )
-
-    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
-      proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
-      proto.client?.urlProtocol(proto, didLoad: Data("Hello, ".utf8))
-      proto.client?.urlProtocol(proto, didLoad: Data("World!".utf8))
-      proto.client?.urlProtocolDidFinishLoading(proto)
-    }
-
-    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
-    let data = try await bytes.collect()
-
-    #expect(response.statusCode == 200)
-    #expect(String(decoding: data, as: UTF8.self) == "Hello, World!")
-  }
-
-  @Test
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func streamSingleChunkMultipleLines() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/stream-single-chunk"))
@@ -138,9 +84,9 @@ struct HTTPStreamingClientTests {
       proto.client?.urlProtocolDidFinishLoading(proto)
     }
 
-    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    let (linesSequence, response) = try await client.lines(for: URLRequest(url: testURL))
     var collectedLines: [String] = []
-    for try await line in bytes.lines {
+    for try await line in linesSequence {
       collectedLines.append(line)
     }
 
@@ -149,6 +95,7 @@ struct HTTPStreamingClientTests {
   }
 
   @Test
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func linesSplitAcrossMultipleChunks() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/stream-split-chunks"))
@@ -169,9 +116,9 @@ struct HTTPStreamingClientTests {
       proto.client?.urlProtocolDidFinishLoading(proto)
     }
 
-    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    let (linesSequence, response) = try await client.lines(for: URLRequest(url: testURL))
     var collectedLines: [String] = []
-    for try await line in bytes.lines {
+    for try await line in linesSequence {
       collectedLines.append(line)
     }
 
@@ -180,6 +127,7 @@ struct HTTPStreamingClientTests {
   }
 
   @Test
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func streamSplitCRLFAndUTF8() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/stream-crlf-utf8"))
@@ -201,9 +149,9 @@ struct HTTPStreamingClientTests {
       proto.client?.urlProtocolDidFinishLoading(proto)
     }
 
-    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    let (linesSequence, response) = try await client.lines(for: URLRequest(url: testURL))
     var collectedLines: [String] = []
-    for try await line in bytes.lines {
+    for try await line in linesSequence {
       collectedLines.append(line)
     }
 
@@ -212,6 +160,7 @@ struct HTTPStreamingClientTests {
   }
 
   @Test
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func streamPreservesBlankLines() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/stream-blank-lines"))
@@ -233,9 +182,9 @@ struct HTTPStreamingClientTests {
       proto.client?.urlProtocolDidFinishLoading(proto)
     }
 
-    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    let (linesSequence, response) = try await client.lines(for: URLRequest(url: testURL))
     var collectedLines: [String] = []
-    for try await line in bytes.lines {
+    for try await line in linesSequence {
       collectedLines.append(line)
     }
 
@@ -244,6 +193,7 @@ struct HTTPStreamingClientTests {
   }
 
   @Test
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func streamNon2xxResponseReturnsStatusCodeAndBody() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/error-404"))
@@ -262,9 +212,9 @@ struct HTTPStreamingClientTests {
       proto.client?.urlProtocolDidFinishLoading(proto)
     }
 
-    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    let (linesSequence, response) = try await client.lines(for: URLRequest(url: testURL))
     var collectedLines: [String] = []
-    for try await line in bytes.lines {
+    for try await line in linesSequence {
       collectedLines.append(line)
     }
 
@@ -273,6 +223,7 @@ struct HTTPStreamingClientTests {
   }
 
   @Test
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func networkErrorBeforeResponseThrows() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/fail-before-response"))
@@ -282,7 +233,7 @@ struct HTTPStreamingClientTests {
     }
 
     do {
-      _ = try await client.bytes(for: URLRequest(url: testURL))
+      _ = try await client.lines(for: URLRequest(url: testURL))
       Issue.record("Expected request to throw network error")
     } catch {
       let urlError = try #require(error as? URLError)
@@ -291,6 +242,7 @@ struct HTTPStreamingClientTests {
   }
 
   @Test
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func networkErrorDuringStreamThrows() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/fail-during-stream"))
@@ -310,9 +262,9 @@ struct HTTPStreamingClientTests {
     }
 
     do {
-      let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+      let (linesSequence, response) = try await client.lines(for: URLRequest(url: testURL))
       #expect(response.statusCode == 200)
-      for try await _ in bytes.lines {}
+      for try await _ in linesSequence {}
       Issue.record("Expected stream to throw network error")
     } catch {
       let urlError = try #require(error as? URLError)
@@ -321,6 +273,7 @@ struct HTTPStreamingClientTests {
   }
 
   @Test
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func earlyTerminationCancelsStream() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/early-termination"))
@@ -339,9 +292,9 @@ struct HTTPStreamingClientTests {
       proto.client?.urlProtocolDidFinishLoading(proto)
     }
 
-    let (bytes, _) = try await client.bytes(for: URLRequest(url: testURL))
+    let (linesSequence, _) = try await client.lines(for: URLRequest(url: testURL))
     var receivedCount = 0
-    for try await _ in bytes.lines {
+    for try await _ in linesSequence {
       receivedCount += 1
       if receivedCount == 2 {
         break
@@ -352,6 +305,7 @@ struct HTTPStreamingClientTests {
   }
 
   @Test
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func nonHTTPResponseThrowsBadServerResponse() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/non-http"))
@@ -370,7 +324,7 @@ struct HTTPStreamingClientTests {
     }
 
     do {
-      _ = try await client.bytes(for: URLRequest(url: testURL))
+      _ = try await client.lines(for: URLRequest(url: testURL))
       Issue.record("Expected non-HTTP response to throw error")
     } catch {
       let urlError = try #require(error as? URLError)
@@ -379,6 +333,7 @@ struct HTTPStreamingClientTests {
   }
 
   @Test
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func sessionInvalidationMethods() {
     let client = makeClient()
 

--- a/Tests/HTTPStreamingClientTests/HTTPStreamingClientTests.swift
+++ b/Tests/HTTPStreamingClientTests/HTTPStreamingClientTests.swift
@@ -340,19 +340,4 @@ struct HTTPStreamingClientTests {
     client.finishTasksAndInvalidate()
     client.invalidateAndCancel()
   }
-
-  @Test
-  func requestHttpBodyDataFromBufferAndStream() throws {
-    let bufferURL = try #require(URL(string: "https://example.com/body"))
-    var bufferRequest = URLRequest(url: bufferURL)
-    bufferRequest.httpBody = Data("buffer-payload".utf8)
-
-    #expect(bufferRequest.httpBodyData == Data("buffer-payload".utf8))
-
-    let streamURL = try #require(URL(string: "https://example.com/stream"))
-    var streamRequest = URLRequest(url: streamURL)
-    streamRequest.httpBodyStream = InputStream(data: Data("stream-payload".utf8))
-
-    #expect(streamRequest.httpBodyData == Data("stream-payload".utf8))
-  }
 }

--- a/Tests/HTTPStreamingClientTests/HTTPStreamingClientTests.swift
+++ b/Tests/HTTPStreamingClientTests/HTTPStreamingClientTests.swift
@@ -33,19 +33,34 @@ struct HTTPStreamingClientTests {
     return HTTPStreamingClient(configuration: configuration)
   }
 
+  private func makeResponse(url: URL, statusCode: Int = 200, headerFields: [String: String]? = nil)
+    throws -> HTTPURLResponse
+  {
+    try #require(
+      HTTPURLResponse(
+        url: url,
+        statusCode: statusCode,
+        httpVersion: "HTTP/1.1",
+        headerFields: headerFields
+      )
+    )
+  }
+
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+  private func collectLines(from sequence: HTTPAsyncLineSequence) async throws -> [String] {
+    var lines: [String] = []
+    for try await line in sequence {
+      lines.append(line)
+    }
+    return lines
+  }
+
   @Test
   @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func streamsLinesAndReturnsTask() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/bytes-api"))
-    let testResponse = try #require(
-      HTTPURLResponse(
-        url: testURL,
-        statusCode: 200,
-        httpVersion: "HTTP/1.1",
-        headerFields: nil
-      )
-    )
+    let testResponse = try makeResponse(url: testURL, statusCode: 200, headerFields: nil)
 
     MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
       proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
@@ -54,14 +69,10 @@ struct HTTPStreamingClientTests {
     }
 
     let (linesSequence, response) = try await client.lines(for: URLRequest(url: testURL))
-    var lines: [String] = []
-    for try await line in linesSequence {
-      lines.append(line)
-    }
+    let collectedLines = try await collectLines(from: linesSequence)
 
     #expect(response.statusCode == 200)
-    #expect(lines == ["ABC", "DEF"])
-    #expect(linesSequence.task != nil)
+    #expect(collectedLines == ["ABC", "DEF"])
   }
 
   @Test
@@ -69,13 +80,8 @@ struct HTTPStreamingClientTests {
   func streamSingleChunkMultipleLines() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/stream-single-chunk"))
-    let testResponse = try #require(
-      HTTPURLResponse(
-        url: testURL,
-        statusCode: 200,
-        httpVersion: "HTTP/1.1",
-        headerFields: ["Content-Type": "text/plain"]
-      )
+    let testResponse = try makeResponse(
+      url: testURL, statusCode: 200, headerFields: ["Content-Type": "text/plain"]
     )
 
     MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
@@ -85,10 +91,7 @@ struct HTTPStreamingClientTests {
     }
 
     let (linesSequence, response) = try await client.lines(for: URLRequest(url: testURL))
-    var collectedLines: [String] = []
-    for try await line in linesSequence {
-      collectedLines.append(line)
-    }
+    let collectedLines = try await collectLines(from: linesSequence)
 
     #expect(response.statusCode == 200)
     #expect(collectedLines == ["line1", "line2", "line3"])
@@ -99,14 +102,7 @@ struct HTTPStreamingClientTests {
   func linesSplitAcrossMultipleChunks() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/stream-split-chunks"))
-    let testResponse = try #require(
-      HTTPURLResponse(
-        url: testURL,
-        statusCode: 200,
-        httpVersion: "HTTP/1.1",
-        headerFields: nil
-      )
-    )
+    let testResponse = try makeResponse(url: testURL, statusCode: 200, headerFields: nil)
 
     MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
       proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
@@ -117,10 +113,7 @@ struct HTTPStreamingClientTests {
     }
 
     let (linesSequence, response) = try await client.lines(for: URLRequest(url: testURL))
-    var collectedLines: [String] = []
-    for try await line in linesSequence {
-      collectedLines.append(line)
-    }
+    let collectedLines = try await collectLines(from: linesSequence)
 
     #expect(response.statusCode == 200)
     #expect(collectedLines == ["data: chunk1 part2", "data: chunk2"])
@@ -131,14 +124,7 @@ struct HTTPStreamingClientTests {
   func streamSplitCRLFAndUTF8() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/stream-crlf-utf8"))
-    let testResponse = try #require(
-      HTTPURLResponse(
-        url: testURL,
-        statusCode: 200,
-        httpVersion: "HTTP/1.1",
-        headerFields: nil
-      )
-    )
+    let testResponse = try makeResponse(url: testURL, statusCode: 200, headerFields: nil)
 
     let emojiBytes: [UInt8] = [0xF0, 0x9F, 0x8E, 0x89]  // 🎉
     MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
@@ -150,10 +136,7 @@ struct HTTPStreamingClientTests {
     }
 
     let (linesSequence, response) = try await client.lines(for: URLRequest(url: testURL))
-    var collectedLines: [String] = []
-    for try await line in linesSequence {
-      collectedLines.append(line)
-    }
+    let collectedLines = try await collectLines(from: linesSequence)
 
     #expect(response.statusCode == 200)
     #expect(collectedLines == ["Greeting", "Party 🎉 Time"])
@@ -164,14 +147,7 @@ struct HTTPStreamingClientTests {
   func streamPreservesBlankLines() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/stream-blank-lines"))
-    let testResponse = try #require(
-      HTTPURLResponse(
-        url: testURL,
-        statusCode: 200,
-        httpVersion: "HTTP/1.1",
-        headerFields: nil
-      )
-    )
+    let testResponse = try makeResponse(url: testURL, statusCode: 200, headerFields: nil)
 
     MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
       proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
@@ -183,10 +159,7 @@ struct HTTPStreamingClientTests {
     }
 
     let (linesSequence, response) = try await client.lines(for: URLRequest(url: testURL))
-    var collectedLines: [String] = []
-    for try await line in linesSequence {
-      collectedLines.append(line)
-    }
+    let collectedLines = try await collectLines(from: linesSequence)
 
     #expect(response.statusCode == 200)
     #expect(collectedLines == ["event: message", "data: hello", "", "event: done"])
@@ -197,14 +170,7 @@ struct HTTPStreamingClientTests {
   func streamNon2xxResponseReturnsStatusCodeAndBody() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/error-404"))
-    let testResponse = try #require(
-      HTTPURLResponse(
-        url: testURL,
-        statusCode: 404,
-        httpVersion: "HTTP/1.1",
-        headerFields: nil
-      )
-    )
+    let testResponse = try makeResponse(url: testURL, statusCode: 404, headerFields: nil)
 
     MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
       proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
@@ -213,10 +179,7 @@ struct HTTPStreamingClientTests {
     }
 
     let (linesSequence, response) = try await client.lines(for: URLRequest(url: testURL))
-    var collectedLines: [String] = []
-    for try await line in linesSequence {
-      collectedLines.append(line)
-    }
+    let collectedLines = try await collectLines(from: linesSequence)
 
     #expect(response.statusCode == 404)
     #expect(collectedLines == ["{", "  \"error\": \"not found\"", "}"])
@@ -246,14 +209,7 @@ struct HTTPStreamingClientTests {
   func networkErrorDuringStreamThrows() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/fail-during-stream"))
-    let testResponse = try #require(
-      HTTPURLResponse(
-        url: testURL,
-        statusCode: 200,
-        httpVersion: "HTTP/1.1",
-        headerFields: nil
-      )
-    )
+    let testResponse = try makeResponse(url: testURL, statusCode: 200, headerFields: nil)
 
     MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
       proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
@@ -277,14 +233,7 @@ struct HTTPStreamingClientTests {
   func earlyTerminationCancelsStream() async throws {
     let client = makeClient()
     let testURL = try #require(URL(string: "https://example.com/early-termination"))
-    let testResponse = try #require(
-      HTTPURLResponse(
-        url: testURL,
-        statusCode: 200,
-        httpVersion: "HTTP/1.1",
-        headerFields: nil
-      )
-    )
+    let testResponse = try makeResponse(url: testURL, statusCode: 200, headerFields: nil)
 
     MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
       proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)

--- a/Tests/HTTPStreamingClientTests/HTTPStreamingClientTests.swift
+++ b/Tests/HTTPStreamingClientTests/HTTPStreamingClientTests.swift
@@ -1,0 +1,403 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import HTTPStreamingClient
+import SharedTestUtilities
+import Testing
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+// MARK: - HTTPStreamingClient Integration Tests
+
+@Suite("HTTPStreamingClient Integration Tests", .serialized)
+struct HTTPStreamingClientTests {
+  private func makeClient() -> HTTPStreamingClient {
+    MockHTTPURLProtocol.reset()
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [MockHTTPURLProtocol.self]
+    return HTTPStreamingClient(configuration: configuration)
+  }
+
+  @Test
+  func bytesMethodStreamsRawBytesAndLines() async throws {
+    let client = makeClient()
+    let testURL = try #require(URL(string: "https://example.com/bytes-api"))
+    let testResponse = try #require(
+      HTTPURLResponse(
+        url: testURL,
+        statusCode: 200,
+        httpVersion: "HTTP/1.1",
+        headerFields: nil
+      )
+    )
+
+    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
+      proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
+      proto.client?.urlProtocol(proto, didLoad: Data("ABC\nDEF\n".utf8))
+      proto.client?.urlProtocolDidFinishLoading(proto)
+    }
+
+    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    var lines: [String] = []
+    for try await line in bytes.lines {
+      lines.append(line)
+    }
+
+    #expect(response.statusCode == 200)
+    #expect(lines == ["ABC", "DEF"])
+    #expect(bytes.task != nil)
+  }
+
+  @Test
+  func bytesIteratingRawBytes() async throws {
+    let client = makeClient()
+    let testURL = try #require(URL(string: "https://example.com/raw-bytes"))
+    let testResponse = try #require(
+      HTTPURLResponse(
+        url: testURL,
+        statusCode: 200,
+        httpVersion: "HTTP/1.1",
+        headerFields: nil
+      )
+    )
+
+    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
+      proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
+      proto.client?.urlProtocol(proto, didLoad: Data([0x01, 0x02]))
+      proto.client?.urlProtocol(proto, didLoad: Data([0x03, 0x04]))
+      proto.client?.urlProtocolDidFinishLoading(proto)
+    }
+
+    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    var receivedBytes: [UInt8] = []
+    for try await byte in bytes {
+      receivedBytes.append(byte)
+    }
+
+    #expect(response.statusCode == 200)
+    #expect(receivedBytes == [0x01, 0x02, 0x03, 0x04])
+  }
+
+  @Test
+  func bytesCollectBuffersEntireData() async throws {
+    let client = makeClient()
+    let testURL = try #require(URL(string: "https://example.com/collect-bytes"))
+    let testResponse = try #require(
+      HTTPURLResponse(
+        url: testURL,
+        statusCode: 200,
+        httpVersion: "HTTP/1.1",
+        headerFields: nil
+      )
+    )
+
+    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
+      proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
+      proto.client?.urlProtocol(proto, didLoad: Data("Hello, ".utf8))
+      proto.client?.urlProtocol(proto, didLoad: Data("World!".utf8))
+      proto.client?.urlProtocolDidFinishLoading(proto)
+    }
+
+    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    let data = try await bytes.collect()
+
+    #expect(response.statusCode == 200)
+    #expect(String(decoding: data, as: UTF8.self) == "Hello, World!")
+  }
+
+  @Test
+  func streamSingleChunkMultipleLines() async throws {
+    let client = makeClient()
+    let testURL = try #require(URL(string: "https://example.com/stream-single-chunk"))
+    let testResponse = try #require(
+      HTTPURLResponse(
+        url: testURL,
+        statusCode: 200,
+        httpVersion: "HTTP/1.1",
+        headerFields: ["Content-Type": "text/plain"]
+      )
+    )
+
+    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
+      proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
+      proto.client?.urlProtocol(proto, didLoad: Data("line1\nline2\nline3\n".utf8))
+      proto.client?.urlProtocolDidFinishLoading(proto)
+    }
+
+    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    var collectedLines: [String] = []
+    for try await line in bytes.lines {
+      collectedLines.append(line)
+    }
+
+    #expect(response.statusCode == 200)
+    #expect(collectedLines == ["line1", "line2", "line3"])
+  }
+
+  @Test
+  func linesSplitAcrossMultipleChunks() async throws {
+    let client = makeClient()
+    let testURL = try #require(URL(string: "https://example.com/stream-split-chunks"))
+    let testResponse = try #require(
+      HTTPURLResponse(
+        url: testURL,
+        statusCode: 200,
+        httpVersion: "HTTP/1.1",
+        headerFields: nil
+      )
+    )
+
+    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
+      proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
+      proto.client?.urlProtocol(proto, didLoad: Data("data: chunk1 ".utf8))
+      proto.client?.urlProtocol(proto, didLoad: Data("part2\ndata: ".utf8))
+      proto.client?.urlProtocol(proto, didLoad: Data("chunk2\n".utf8))
+      proto.client?.urlProtocolDidFinishLoading(proto)
+    }
+
+    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    var collectedLines: [String] = []
+    for try await line in bytes.lines {
+      collectedLines.append(line)
+    }
+
+    #expect(response.statusCode == 200)
+    #expect(collectedLines == ["data: chunk1 part2", "data: chunk2"])
+  }
+
+  @Test
+  func streamSplitCRLFAndUTF8() async throws {
+    let client = makeClient()
+    let testURL = try #require(URL(string: "https://example.com/stream-crlf-utf8"))
+    let testResponse = try #require(
+      HTTPURLResponse(
+        url: testURL,
+        statusCode: 200,
+        httpVersion: "HTTP/1.1",
+        headerFields: nil
+      )
+    )
+
+    let emojiBytes: [UInt8] = [0xF0, 0x9F, 0x8E, 0x89]  // 🎉
+    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
+      proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
+      proto.client?.urlProtocol(proto, didLoad: Data("Greeting\r".utf8))
+      proto.client?.urlProtocol(proto, didLoad: Data("\nParty ".utf8) + Data(emojiBytes[0..<2]))
+      proto.client?.urlProtocol(proto, didLoad: Data(emojiBytes[2..<4]) + Data(" Time\r\n".utf8))
+      proto.client?.urlProtocolDidFinishLoading(proto)
+    }
+
+    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    var collectedLines: [String] = []
+    for try await line in bytes.lines {
+      collectedLines.append(line)
+    }
+
+    #expect(response.statusCode == 200)
+    #expect(collectedLines == ["Greeting", "Party 🎉 Time"])
+  }
+
+  @Test
+  func streamPreservesBlankLines() async throws {
+    let client = makeClient()
+    let testURL = try #require(URL(string: "https://example.com/stream-blank-lines"))
+    let testResponse = try #require(
+      HTTPURLResponse(
+        url: testURL,
+        statusCode: 200,
+        httpVersion: "HTTP/1.1",
+        headerFields: nil
+      )
+    )
+
+    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
+      proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
+      proto.client?.urlProtocol(
+        proto,
+        didLoad: Data("event: message\ndata: hello\n\nevent: done\n".utf8)
+      )
+      proto.client?.urlProtocolDidFinishLoading(proto)
+    }
+
+    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    var collectedLines: [String] = []
+    for try await line in bytes.lines {
+      collectedLines.append(line)
+    }
+
+    #expect(response.statusCode == 200)
+    #expect(collectedLines == ["event: message", "data: hello", "", "event: done"])
+  }
+
+  @Test
+  func streamNon2xxResponseReturnsStatusCodeAndBody() async throws {
+    let client = makeClient()
+    let testURL = try #require(URL(string: "https://example.com/error-404"))
+    let testResponse = try #require(
+      HTTPURLResponse(
+        url: testURL,
+        statusCode: 404,
+        httpVersion: "HTTP/1.1",
+        headerFields: nil
+      )
+    )
+
+    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
+      proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
+      proto.client?.urlProtocol(proto, didLoad: Data("{\n  \"error\": \"not found\"\n}".utf8))
+      proto.client?.urlProtocolDidFinishLoading(proto)
+    }
+
+    let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+    var collectedLines: [String] = []
+    for try await line in bytes.lines {
+      collectedLines.append(line)
+    }
+
+    #expect(response.statusCode == 404)
+    #expect(collectedLines == ["{", "  \"error\": \"not found\"", "}"])
+  }
+
+  @Test
+  func networkErrorBeforeResponseThrows() async throws {
+    let client = makeClient()
+    let testURL = try #require(URL(string: "https://example.com/fail-before-response"))
+
+    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
+      proto.client?.urlProtocol(proto, didFailWithError: URLError(.cannotConnectToHost))
+    }
+
+    do {
+      _ = try await client.bytes(for: URLRequest(url: testURL))
+      Issue.record("Expected request to throw network error")
+    } catch {
+      let urlError = try #require(error as? URLError)
+      #expect(urlError.code == .cannotConnectToHost)
+    }
+  }
+
+  @Test
+  func networkErrorDuringStreamThrows() async throws {
+    let client = makeClient()
+    let testURL = try #require(URL(string: "https://example.com/fail-during-stream"))
+    let testResponse = try #require(
+      HTTPURLResponse(
+        url: testURL,
+        statusCode: 200,
+        httpVersion: "HTTP/1.1",
+        headerFields: nil
+      )
+    )
+
+    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
+      proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
+      proto.client?.urlProtocol(proto, didLoad: Data("first line\n".utf8))
+      proto.client?.urlProtocol(proto, didFailWithError: URLError(.networkConnectionLost))
+    }
+
+    do {
+      let (bytes, response) = try await client.bytes(for: URLRequest(url: testURL))
+      #expect(response.statusCode == 200)
+      for try await _ in bytes.lines {}
+      Issue.record("Expected stream to throw network error")
+    } catch {
+      let urlError = try #require(error as? URLError)
+      #expect(urlError.code == .networkConnectionLost)
+    }
+  }
+
+  @Test
+  func earlyTerminationCancelsStream() async throws {
+    let client = makeClient()
+    let testURL = try #require(URL(string: "https://example.com/early-termination"))
+    let testResponse = try #require(
+      HTTPURLResponse(
+        url: testURL,
+        statusCode: 200,
+        httpVersion: "HTTP/1.1",
+        headerFields: nil
+      )
+    )
+
+    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
+      proto.client?.urlProtocol(proto, didReceive: testResponse, cacheStoragePolicy: .notAllowed)
+      proto.client?.urlProtocol(proto, didLoad: Data("line1\nline2\nline3\nline4\n".utf8))
+      proto.client?.urlProtocolDidFinishLoading(proto)
+    }
+
+    let (bytes, _) = try await client.bytes(for: URLRequest(url: testURL))
+    var receivedCount = 0
+    for try await _ in bytes.lines {
+      receivedCount += 1
+      if receivedCount == 2 {
+        break
+      }
+    }
+
+    #expect(receivedCount == 2)
+  }
+
+  @Test
+  func nonHTTPResponseThrowsBadServerResponse() async throws {
+    let client = makeClient()
+    let testURL = try #require(URL(string: "https://example.com/non-http"))
+    let nonHTTPResponse = try #require(
+      URLResponse(
+        url: testURL,
+        mimeType: "text/plain",
+        expectedContentLength: 0,
+        textEncodingName: nil
+      )
+    )
+
+    MockHTTPURLProtocol.setHandler(for: testURL) { _, proto in
+      proto.client?.urlProtocol(proto, didReceive: nonHTTPResponse, cacheStoragePolicy: .notAllowed)
+      proto.client?.urlProtocolDidFinishLoading(proto)
+    }
+
+    do {
+      _ = try await client.bytes(for: URLRequest(url: testURL))
+      Issue.record("Expected non-HTTP response to throw error")
+    } catch {
+      let urlError = try #require(error as? URLError)
+      #expect(urlError.code == .badServerResponse)
+    }
+  }
+
+  @Test
+  func sessionInvalidationMethods() {
+    let client = makeClient()
+
+    client.finishTasksAndInvalidate()
+    client.invalidateAndCancel()
+  }
+
+  @Test
+  func requestHttpBodyDataFromBufferAndStream() throws {
+    let bufferURL = try #require(URL(string: "https://example.com/body"))
+    var bufferRequest = URLRequest(url: bufferURL)
+    bufferRequest.httpBody = Data("buffer-payload".utf8)
+
+    #expect(bufferRequest.httpBodyData == Data("buffer-payload".utf8))
+
+    let streamURL = try #require(URL(string: "https://example.com/stream"))
+    var streamRequest = URLRequest(url: streamURL)
+    streamRequest.httpBodyStream = InputStream(data: Data("stream-payload".utf8))
+
+    #expect(streamRequest.httpBodyData == Data("stream-payload".utf8))
+  }
+}

--- a/Tests/SharedTestUtilities/MockHTTPURLProtocol.swift
+++ b/Tests/SharedTestUtilities/MockHTTPURLProtocol.swift
@@ -92,27 +92,3 @@ package final class MockHTTPURLProtocol: URLProtocol {
     client?.urlProtocol(self, didFailWithError: URLError(.cancelled))
   }
 }
-
-// MARK: - URLRequest Body Helper
-
-extension URLRequest {
-  /// Reads the body data from either `httpBody` or `httpBodyStream`.
-  package var httpBodyData: Data? {
-    if let httpBody {
-      return httpBody
-    }
-    guard let stream = httpBodyStream else {
-      return nil
-    }
-    stream.open()
-    defer { stream.close() }
-    var data = Data()
-    let bufferSize = 1024
-    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
-    defer { buffer.deallocate() }
-    while case let read = stream.read(buffer, maxLength: bufferSize), read > 0 {
-      data.append(buffer, count: read)
-    }
-    return data
-  }
-}

--- a/Tests/SharedTestUtilities/MockHTTPURLProtocol.swift
+++ b/Tests/SharedTestUtilities/MockHTTPURLProtocol.swift
@@ -1,0 +1,138 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package import Foundation
+
+#if canImport(FoundationNetworking)
+  package import FoundationNetworking
+#endif
+
+// MARK: - Mock HTTP URL Protocol
+
+/// A custom `URLProtocol` for mocking network responses across package test targets.
+package final class MockHTTPURLProtocol: URLProtocol {
+  /// The closure signature for handling intercepted requests.
+  package typealias Handler = @Sendable (URLRequest, MockHTTPURLProtocol) throws -> Void
+
+  private static let handlers = LockProtected<[String: Handler]>([:])
+
+  /// Registers a mock response handler for the specified URL.
+  ///
+  /// - Parameters:
+  ///   - url: The target URL to intercept.
+  ///   - handler: The closure executed when a request matches the URL.
+  package static func setHandler(for url: URL, _ handler: @escaping Handler) {
+    setHandler(for: url.absoluteString, handler)
+  }
+
+  /// Registers a mock response handler for the specified URL string.
+  ///
+  /// - Parameters:
+  ///   - urlString: The target URL string to intercept.
+  ///   - handler: The closure executed when a request matches the URL string.
+  package static func setHandler(for urlString: String, _ handler: @escaping Handler) {
+    handlers.withLock { $0[urlString] = handler }
+  }
+
+  /// Clears all registered request handlers.
+  package static func reset() {
+    handlers.withLock { $0.removeAll() }
+  }
+
+  /// Determines whether this protocol can handle the given request.
+  ///
+  /// - Parameter request: The proposed request.
+  /// - Returns: Always `true` for all intercepted requests.
+  override package class func canInit(with request: URLRequest) -> Bool {
+    true
+  }
+
+  /// Returns the canonical version of the given request.
+  ///
+  /// - Parameter request: The request to canonicalize.
+  /// - Returns: The unmodified request.
+  override package class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  /// Starts loading the mocked request using the registered handler.
+  override package func startLoading() {
+    let handler: Handler? = {
+      guard let urlString = request.url?.absoluteString else { return nil }
+      return MockHTTPURLProtocol.handlers.withLock { $0[urlString] }
+    }()
+
+    guard let handler else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+      return
+    }
+
+    do {
+      try handler(request, self)
+    } catch {
+      client?.urlProtocol(self, didFailWithError: error)
+    }
+  }
+
+  /// Stops loading the mocked request.
+  override package func stopLoading() {
+    client?.urlProtocol(self, didFailWithError: URLError(.cancelled))
+  }
+}
+
+// MARK: - URLRequest Body Helper
+
+extension URLRequest {
+  /// Reads the body data from either `httpBody` or `httpBodyStream`.
+  package var httpBodyData: Data? {
+    if let httpBody {
+      return httpBody
+    }
+    guard let stream = httpBodyStream else {
+      return nil
+    }
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    let bufferSize = 1024
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+    while case let read = stream.read(buffer, maxLength: bufferSize), read > 0 {
+      data.append(buffer, count: read)
+    }
+    return data
+  }
+}
+
+// MARK: - Lock Protected Container
+
+/// A thread-safe container for mutable state.
+///
+/// Safety: This class uses an `NSLock` to serialize all access to the underlying `state`.
+/// It is marked `@unchecked Sendable` because the compiler cannot verify `NSLock` isolation,
+/// but data-race safety is manually guaranteed.
+private final class LockProtected<State>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var state: State
+
+  init(_ initialState: State) {
+    self.state = initialState
+  }
+
+  func withLock<Result>(_ body: (inout State) throws -> Result) rethrows -> Result {
+    lock.lock()
+    defer { lock.unlock() }
+    return try body(&state)
+  }
+}

--- a/Tests/SharedTestUtilities/MockHTTPURLProtocol.swift
+++ b/Tests/SharedTestUtilities/MockHTTPURLProtocol.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 package import Foundation
+import Synchronization
 
 #if canImport(FoundationNetworking)
   package import FoundationNetworking
@@ -21,11 +22,12 @@ package import Foundation
 // MARK: - Mock HTTP URL Protocol
 
 /// A custom `URLProtocol` for mocking network responses across package test targets.
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 package final class MockHTTPURLProtocol: URLProtocol {
   /// The closure signature for handling intercepted requests.
   package typealias Handler = @Sendable (URLRequest, MockHTTPURLProtocol) throws -> Void
 
-  private static let handlers = LockProtected<[String: Handler]>([:])
+  private static let handlers = Mutex<[String: Handler]>([:])
 
   /// Registers a mock response handler for the specified URL.
   ///
@@ -112,27 +114,5 @@ extension URLRequest {
       data.append(buffer, count: read)
     }
     return data
-  }
-}
-
-// MARK: - Lock Protected Container
-
-/// A thread-safe container for mutable state.
-///
-/// Safety: This class uses an `NSLock` to serialize all access to the underlying `state`.
-/// It is marked `@unchecked Sendable` because the compiler cannot verify `NSLock` isolation,
-/// but data-race safety is manually guaranteed.
-private final class LockProtected<State>: @unchecked Sendable {
-  private let lock = NSLock()
-  private var state: State
-
-  init(_ initialState: State) {
-    self.state = initialState
-  }
-
-  func withLock<Result>(_ body: (inout State) throws -> Result) rethrows -> Result {
-    lock.lock()
-    defer { lock.unlock() }
-    return try body(&state)
   }
 }


### PR DESCRIPTION
Add a lightweight HTTP client backed by `URLSession` that supports asynchronous text line streaming to prepare for handling Server-Sent Event (SSE) streaming.

- Introduce `HTTPStreamingClient` with a `lines(for:)` streaming API.
- Provide `HTTPAsyncLineSequence` mirroring standard `URLSession.AsyncBytes.lines` (`AsyncLineSequence`) ergonomics.
- Implement incremental UTF-8 line decoding supporting CRLF, LF, CR, and split multi-byte unicode characters across chunk boundaries.
- Adopt Swift 6 strict concurrency with compiler-checked `Sendable` types and properly synchronized task delegate management.
- Add comprehensive unit test suite in `HTTPStreamingClientTests`.
