### PR TITLE
ci: add workflow for Gemini for Foundation Models

### DIFF
--- a/.github/workflows/gemini-fm.yml
+++ b/.github/workflows/gemini-fm.yml
@@ -4,11 +4,7 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/gemini-fm.yml
+++ b/.github/workflows/gemini-fm.yml
@@ -35,11 +35,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Swift
-        uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
-        with:
-          swift-version: "6.3"
-
       - name: Build
         run: swift build -Xswiftc -warnings-as-errors
 

--- a/.github/workflows/gemini-fm.yml
+++ b/.github/workflows/gemini-fm.yml
@@ -1,0 +1,51 @@
+name: gemini-for-foundation-models
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos:
+    name: macOS
+    runs-on: macos-26
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Build
+        run: swift build -Xswiftc -warnings-as-errors
+
+      - name: Test
+        run: swift test -Xswiftc -warnings-as-errors
+
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
+        with:
+          swift-version: "6.3"
+
+      - name: Build
+        run: swift build -Xswiftc -warnings-as-errors
+
+      - name: Test
+        run: swift test -Xswiftc -warnings-as-errors


### PR DESCRIPTION
Add continuous integration workflow to validate builds and tests across macOS and Linux environments on pull requests for `ah/gemini-for-foundation-models`.

Highlights:
- Build and test on macOS (`macos-26`) and Linux (`ubuntu-latest`).
- Enforce zero compiler warnings using `-Xswiftc -warnings-as-errors`.
- Enable automatic cancellation of redundant in-progress workflow runs.