### PR TITLE
guard non-string payload fields in FIRMessagingContextManagerService

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
+++ b/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
@@ -109,16 +109,16 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
     return NO;
   }
   NSString *startTimeString = startTime;
-  if (!startTimeString) {
+  NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+  dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+  [dateFormatter setDateFormat:kLocalTimeFormatString];
+  NSDate *startDate = [dateFormatter dateFromString:startTimeString];
+  if (!startDate) {
     FIRMessagingLoggerError(kFIRMessagingMessageCodeContextManagerService002,
                             @"Invalid local start date format %@. Message dropped",
                             startTimeString);
     return NO;
   }
-  NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-  dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-  [dateFormatter setDateFormat:kLocalTimeFormatString];
-  NSDate *startDate = [dateFormatter dateFromString:startTimeString];
   NSDate *currentDate = [NSDate date];
 
   if ([currentDate compare:startDate] == NSOrderedAscending) {
@@ -140,7 +140,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
     NSString *endTimeString = endTime;
 
     NSDate *endDate = [dateFormatter dateFromString:endTimeString];
-    if (!endTimeString) {
+    if (!endDate) {
       FIRMessagingLoggerError(kFIRMessagingMessageCodeContextManagerService004,
                               @"Invalid local end date format %@. Message dropped", endTimeString);
       return NO;

--- a/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
+++ b/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
@@ -84,7 +84,13 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
 }
 
 + (BOOL)handleContextManagerMessage:(NSDictionary *)message {
-  NSString *startTimeString = message[kFIRMessagingContextManagerLocalTimeStart];
+  // The start time comes straight from the untrusted push payload, so it is not
+  // necessarily a string.
+  id startTime = message[kFIRMessagingContextManagerLocalTimeStart];
+  if (![startTime isKindOfClass:[NSString class]]) {
+    return NO;
+  }
+  NSString *startTimeString = startTime;
   if (startTimeString.length) {
     FIRMessagingLoggerDebug(kFIRMessagingMessageCodeContextManagerService001,
                             @"%@ Received context manager message with local time %@", kLogTag,
@@ -96,7 +102,13 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
 }
 
 + (BOOL)handleContextManagerLocalTimeMessage:(NSDictionary *)message {
-  NSString *startTimeString = message[kFIRMessagingContextManagerLocalTimeStart];
+  id startTime = message[kFIRMessagingContextManagerLocalTimeStart];
+  if (![startTime isKindOfClass:[NSString class]]) {
+    FIRMessagingLoggerError(kFIRMessagingMessageCodeContextManagerService002,
+                            @"Invalid local start date format %@. Message dropped", startTime);
+    return NO;
+  }
+  NSString *startTimeString = startTime;
   if (!startTimeString) {
     FIRMessagingLoggerError(kFIRMessagingMessageCodeContextManagerService002,
                             @"Invalid local start date format %@. Message dropped",
@@ -113,13 +125,19 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
     [self scheduleLocalNotificationForMessage:message atDate:startDate];
   } else {
     // check end time has not passed
-    NSString *endTimeString = message[kFIRMessagingContextManagerLocalTimeEnd];
-    if (!endTimeString) {
+    id endTime = message[kFIRMessagingContextManagerLocalTimeEnd];
+    if (!endTime) {
       FIRMessagingLoggerInfo(
           kFIRMessagingMessageCodeContextManagerService003,
           @"No end date specified for message, start date elapsed. Message dropped.");
       return YES;
     }
+    if (![endTime isKindOfClass:[NSString class]]) {
+      FIRMessagingLoggerError(kFIRMessagingMessageCodeContextManagerService004,
+                              @"Invalid local end date format %@. Message dropped", endTime);
+      return NO;
+    }
+    NSString *endTimeString = endTime;
 
     NSDate *endDate = [dateFormatter dateFromString:endTimeString];
     if (!endTimeString) {

--- a/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
+++ b/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
@@ -70,8 +70,10 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
 @implementation FIRMessagingContextManagerService
 
 + (BOOL)isContextManagerMessage:(NSDictionary *)message {
-  // For now we only support local time in ContextManager.
-  if (![message[kFIRMessagingContextManagerLocalTimeStart] length]) {
+  // For now we only support local time in ContextManager. The start time comes
+  // straight from the untrusted push payload, so it is not necessarily a string.
+  id startTime = message[kFIRMessagingContextManagerLocalTimeStart];
+  if (![startTime isKindOfClass:[NSString class]] || ![(NSString *)startTime length]) {
     FIRMessagingLoggerDebug(
         kFIRMessagingMessageCodeContextManagerService000,
         @"Received message missing local start time, not a contextual message.");
@@ -178,32 +180,38 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
   UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
   NSDictionary *apsDictionary = message;
 
+  // Every field below comes from the untrusted push payload, so its type is not
+  // guaranteed. Verify each before invoking type-specific selectors on it.
   // Badge is universal
-  if (apsDictionary[kFIRMessagingContextManagerBadgeKey]) {
-    content.badge = apsDictionary[kFIRMessagingContextManagerBadgeKey];
+  id badge = apsDictionary[kFIRMessagingContextManagerBadgeKey];
+  if ([badge isKindOfClass:[NSNumber class]]) {
+    content.badge = badge;
   }
 #if !TARGET_OS_TV
   // The following fields are not available on tvOS
-  if ([apsDictionary[kFIRMessagingContextManagerBodyKey] length]) {
-    content.body = apsDictionary[kFIRMessagingContextManagerBodyKey];
+  id body = apsDictionary[kFIRMessagingContextManagerBodyKey];
+  if ([body isKindOfClass:[NSString class]] && [body length]) {
+    content.body = body;
   }
 
-  if ([apsDictionary[kFIRMessagingContextManagerTitleKey] length]) {
-    content.title = apsDictionary[kFIRMessagingContextManagerTitleKey];
+  id title = apsDictionary[kFIRMessagingContextManagerTitleKey];
+  if ([title isKindOfClass:[NSString class]] && [title length]) {
+    content.title = title;
   }
 
-  if (apsDictionary[kFIRMessagingContextManagerSoundKey]) {
+  id soundName = apsDictionary[kFIRMessagingContextManagerSoundKey];
+  if ([soundName isKindOfClass:[NSString class]]) {
 #if !TARGET_OS_WATCH
     // UNNotificationSound soundNamded: is not available in watchOS
-    content.sound =
-        [UNNotificationSound soundNamed:apsDictionary[kFIRMessagingContextManagerSoundKey]];
+    content.sound = [UNNotificationSound soundNamed:soundName];
 #else   // !TARGET_OS_WATCH
     content.sound = [UNNotificationSound defaultSound];
 #endif  // !TARGET_OS_WATCH
   }
 
-  if (apsDictionary[kFIRMessagingContextManagerCategoryKey]) {
-    content.categoryIdentifier = apsDictionary[kFIRMessagingContextManagerCategoryKey];
+  id category = apsDictionary[kFIRMessagingContextManagerCategoryKey];
+  if ([category isKindOfClass:[NSString class]]) {
+    content.categoryIdentifier = category;
   }
 
   NSDictionary *userInfo = [self parseDataFromMessage:message];

--- a/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
+++ b/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
@@ -102,16 +102,15 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
 }
 
 + (BOOL)handleContextManagerLocalTimeMessage:(NSDictionary *)message {
-  id startTime = message[kFIRMessagingContextManagerLocalTimeStart];
-  if (![startTime isKindOfClass:[NSString class]]) {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeContextManagerService002,
-                            @"Invalid local start date format %@. Message dropped", startTime);
-    return NO;
-  }
-  NSString *startTimeString = startTime;
-  NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-  dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-  [dateFormatter setDateFormat:kLocalTimeFormatString];
+  // The start time was already validated as a non-empty NSString by the caller.
+  NSString *startTimeString = message[kFIRMessagingContextManagerLocalTimeStart];
+  static NSDateFormatter *dateFormatter;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    dateFormatter = [[NSDateFormatter alloc] init];
+    dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+    [dateFormatter setDateFormat:kLocalTimeFormatString];
+  });
   NSDate *startDate = [dateFormatter dateFromString:startTimeString];
   if (!startDate) {
     FIRMessagingLoggerError(kFIRMessagingMessageCodeContextManagerService002,

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
@@ -123,6 +123,25 @@ API_AVAILABLE(macos(10.14))
 }
 
 /**
+ *  A string start/end time that does not parse yields a nil date. That must be
+ *  dropped rather than crash on -[NSDate compare:] with a nil argument.
+ */
+- (void)testHandleContextManagerMessage_unparseableTimes {
+  NSDictionary *badStart = @{
+    kFIRMessagingContextManagerLocalTimeStart : @"not-a-date",
+  };
+  XCTAssertFalse([FIRMessagingContextManagerService handleContextManagerMessage:badStart]);
+
+  // Elapsed start time with an unparseable end time must also be dropped safely.
+  NSString *pastStart = [self.dateFormatter stringFromDate:[NSDate distantPast]];
+  NSDictionary *badEnd = @{
+    kFIRMessagingContextManagerLocalTimeStart : pastStart,
+    kFIRMessagingContextManagerLocalTimeEnd : @"not-a-date",
+  };
+  XCTAssertFalse([FIRMessagingContextManagerService handleContextManagerMessage:badEnd]);
+}
+
+/**
  *  Notification content fields also come from the untrusted payload. Non-string
  *  body/title/sound/category and a non-number badge must be ignored, not crash.
  */

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
@@ -87,6 +87,46 @@ API_AVAILABLE(macos(10.14))
 }
 
 /**
+ *  A start time that is not a string (a sender can put any JSON type there) must
+ *  not be treated as a contextual message, and must not crash the type check.
+ */
+- (void)testContextManagerMessage_nonStringStartTime {
+  NSDictionary *numberMessage = @{
+    kFIRMessagingContextManagerLocalTimeStart : @1623702615599207,
+  };
+  XCTAssertFalse([FIRMessagingContextManagerService isContextManagerMessage:numberMessage]);
+
+  NSDictionary *arrayMessage = @{
+    kFIRMessagingContextManagerLocalTimeStart : @[ @"2015-12-12 00:00:00" ],
+  };
+  XCTAssertFalse([FIRMessagingContextManagerService isContextManagerMessage:arrayMessage]);
+}
+
+/**
+ *  Notification content fields also come from the untrusted payload. Non-string
+ *  body/title/sound/category and a non-number badge must be ignored, not crash.
+ */
+- (void)testContentFromContextualMessage_nonStringFields {
+  NSDictionary *message = @{
+    @"gcm.notification.badge" : @"not-a-number",
+    @"gcm.notification.body" : @42,
+    @"gcm.notification.title" : @[ @"array-title" ],
+    @"gcm.notification.sound" : @1,
+    @"gcm.notification.click_action" : @{@"k" : @"v"},
+    @"google.c.cm.lt_start" : @"2021-06-15 10:30:00",
+  };
+  UNMutableNotificationContent *content =
+      [FIRMessagingContextManagerService contentFromContextualMessage:message];
+  XCTAssertNil(content.badge);
+#if TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_WATCH
+  XCTAssertEqualObjects(content.body, @"");
+  XCTAssertEqualObjects(content.title, @"");
+  XCTAssertNil(content.sound);
+  XCTAssertEqualObjects(content.categoryIdentifier, @"");
+#endif
+}
+
+/**
  *  Context Manager message with future start date should be successfully scheduled.
  */
 - (void)testMessageWithFutureStartTime {

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
@@ -158,10 +158,12 @@ API_AVAILABLE(macos(10.14))
       [FIRMessagingContextManagerService contentFromContextualMessage:message];
   XCTAssertNil(content.badge);
 #if TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_WATCH
-  XCTAssertEqualObjects(content.body, @"");
-  XCTAssertEqualObjects(content.title, @"");
+  // The non-string fields are ignored, so these stay at their unset default,
+  // which is nil on some platforms and @"" on others. Either way they are empty.
+  XCTAssertEqual(content.body.length, 0u);
+  XCTAssertEqual(content.title.length, 0u);
   XCTAssertNil(content.sound);
-  XCTAssertEqualObjects(content.categoryIdentifier, @"");
+  XCTAssertEqual(content.categoryIdentifier.length, 0u);
 #endif
 }
 

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
@@ -103,6 +103,26 @@ API_AVAILABLE(macos(10.14))
 }
 
 /**
+ *  handleContextManagerMessage: is public and can be called directly, so a
+ *  non-string start or end time must be dropped rather than crash on -length or
+ *  -[NSDateFormatter dateFromString:].
+ */
+- (void)testHandleContextManagerMessage_nonStringTimes {
+  NSDictionary *numberStart = @{
+    kFIRMessagingContextManagerLocalTimeStart : @1623702615599207,
+  };
+  XCTAssertFalse([FIRMessagingContextManagerService handleContextManagerMessage:numberStart]);
+
+  // Elapsed start time with a non-string end time must also be dropped safely.
+  NSString *pastStart = [self.dateFormatter stringFromDate:[NSDate distantPast]];
+  NSDictionary *numberEnd = @{
+    kFIRMessagingContextManagerLocalTimeStart : pastStart,
+    kFIRMessagingContextManagerLocalTimeEnd : @1623702615599207,
+  };
+  XCTAssertFalse([FIRMessagingContextManagerService handleContextManagerMessage:numberEnd]);
+}
+
+/**
  *  Notification content fields also come from the untrusted payload. Non-string
  *  body/title/sound/category and a non-number badge must be ignored, not crash.
  */


### PR DESCRIPTION
Repro: send a push whose `google.c.cm.lt_start` is a number rather than a date string. On receipt `isContextManagerMessage:` calls `-length` on that value and the app hits `-[__NSCFNumber length]: unrecognized selector`, so a single message crashes the receiver. The same holds for the body, title, sound, category and badge fields in `contentFromContextualMessage:`.
Cause: those fields are read straight from the untrusted push payload and assumed to be a specific type before a type-specific selector is sent to them.
Fix: check each field with `isKindOfClass:` before use, the way the rest of the module already guards payload dictionaries. Valid payloads behave the same, and a regression test covers a non-string start time and non-string content fields.