### PR TITLE
fix(ci): bump json gem to 2.21.2 in testing_report_generation

### DIFF
--- a/.github/actions/testing_report_generation/Gemfile.lock
+++ b/.github/actions/testing_report_generation/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       logger
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
-    json (2.20.0)
+    json (2.21.2)
     logger (1.7.0)
     net-http (0.9.1)
       uri (>= 0.11.1)


### PR DESCRIPTION
This bumps the json gem in the testing_report_generation action's Gemfile.lock to resolve a Dependabot alert regarding a heap-use-after-free vulnerability.

#no-changelog