### PR TITLE
escape bucket in downloadURLFromMetadataDictionary

### DIFF
--- a/FirebaseStorage/Sources/Internal/StorageGetDownloadURLTask.swift
+++ b/FirebaseStorage/Sources/Internal/StorageGetDownloadURLTask.swift
@@ -54,9 +54,10 @@ enum StorageGetDownloadURLTask {
       return nil
     }
     let downloadTokenArray = downloadTokens.components(separatedBy: ",")
-    let bucket = dictionary["bucket"] ?? "<error: missing bucket>"
+    let bucket = dictionary["bucket"] as? String ?? "<error: missing bucket>"
     let path = dictionary["name"] as? String ?? "<error: missing path name>"
-    let fullPath = "/v0/b/\(bucket)/o/\(StorageUtils.GCSEscapedString(path))"
+    let fullPath =
+      "/v0/b/\(StorageUtils.GCSEscapedString(bucket))/o/\(StorageUtils.GCSEscapedString(path))"
     var components = URLComponents()
     components.scheme = reference.storage.scheme
     components.host = reference.storage.host

--- a/FirebaseStorage/Tests/Unit/StorageMetadataTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageMetadataTests.swift
@@ -150,6 +150,26 @@ class StorageMetadataTests: StorageTestHelpers {
     XCTAssertEqual(actualURL?.absoluteString, expectedURL)
   }
 
+  func testInitializeDownloadURLEscapesBucket() {
+    // A bucket value from the server response must be percent-escaped the same way the
+    // object name is, otherwise a bucket containing a URL path delimiter (e.g. "#" or "?")
+    // makes percentEncodedPath raise, and one containing "/" rewrites the object path.
+    let metaDict = [
+      "bucket": "bucket#/o/other",
+      "downloadTokens": "12345,ignored",
+      "name": "path/to/object",
+    ] as [String: String]
+
+    let rootReference = rootReference()
+    let escapedBucket = StorageUtils.GCSEscapedString(metaDict["bucket"]!)
+    let escapedPath = StorageUtils.GCSEscapedString(metaDict["name"]!)
+    let expectedURL =
+      "https://firebasestorage.googleapis.com:443/v0/b/\(escapedBucket)/o/\(escapedPath)?alt=media&token=12345"
+    let actualURL = StorageGetDownloadURLTask.downloadURLFromMetadataDictionary(metaDict,
+                                                                                rootReference)
+    XCTAssertEqual(actualURL?.absoluteString, expectedURL)
+  }
+
   func testInitializeMetadataWithFile() {
     let metaDict = ["bucket": "bucket", "name": "/path/to/file"]
     let metadata = StorageMetadata(dictionary: metaDict)


### PR DESCRIPTION
downloadURLFromMetadataDictionary interpolates the bucket from the fetch response straight into the URL path while the object name goes through GCSEscapedString, so a bucket value carrying a path delimiter like "#" or "?" makes percentEncodedPath raise, one carrying a "/" rewrites the /o/ segment of the returned download URL, and a non-string JSON value is stringified as its Swift description. StorageUtils.encodedURL(for:) escapes the bucket the same way, so this is the one path that skips it. Read the bucket as a String and run it through GCSEscapedString, matching the object handling one line down.