### PR TITLE
guard numeric accessors on untrusted incoming FCM message fields

### DIFF
--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -69,7 +69,10 @@ BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
   if ([message[kFIRMessagingMessageViaAPNSRootKey] isKindOfClass:[NSDictionary class]]) {
     NSDictionary *aps = message[kFIRMessagingMessageViaAPNSRootKey];
     if (aps && [aps isKindOfClass:[NSDictionary class]]) {
-      return [aps[kFIRMessagingMessageAPNSContentAvailableKey] boolValue];
+      id contentAvailable = aps[kFIRMessagingMessageAPNSContentAvailableKey];
+      if ([contentAvailable respondsToSelector:@selector(boolValue)]) {
+        return [contentAvailable boolValue];
+      }
     }
   }
   return NO;

--- a/FirebaseMessaging/Sources/FIRMessagingAnalytics.m
+++ b/FirebaseMessaging/Sources/FIRMessagingAnalytics.m
@@ -144,8 +144,9 @@ static NSString *const kAnalyticsTrackConversions = @"google.c.a.tc";
 
 + (void)logUserPropertyForConversionTracking:(NSDictionary *)notification
                                  toAnalytics:(id<FIRAnalyticsInterop> _Nullable)analytics {
-  NSInteger shouldTrackConversions = [notification[kAnalyticsTrackConversions] integerValue];
-  if (shouldTrackConversions != 1) {
+  id trackConversions = notification[kAnalyticsTrackConversions];
+  if (![trackConversions respondsToSelector:@selector(integerValue)] ||
+      [trackConversions integerValue] != 1) {
     return;
   }
 

--- a/FirebaseMessaging/Sources/FIRMessagingSyncMessageManager.m
+++ b/FirebaseMessaging/Sources/FIRMessagingSyncMessageManager.m
@@ -77,8 +77,9 @@ static const int64_t kDefaultSyncMessageTTL = 4 * 7 * 24 * 60 * 60;  // 4 weeks
 
 + (int64_t)expirationTimeForSyncMessage:(NSDictionary *)message {
   int64_t ttl = kDefaultSyncMessageTTL;
-  if (message[kFIRMessagingMessageSyncMessageTTLKey]) {
-    ttl = [message[kFIRMessagingMessageSyncMessageTTLKey] longLongValue];
+  id ttlValue = message[kFIRMessagingMessageSyncMessageTTLKey];
+  if ([ttlValue respondsToSelector:@selector(longLongValue)]) {
+    ttl = [ttlValue longLongValue];
   }
   int64_t currentTime = FIRMessagingCurrentTimestampInSeconds();
   return currentTime + ttl;

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingAnalyticsTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingAnalyticsTest.m
@@ -425,6 +425,25 @@ static FakeAnalyticsLogEventHandler _userPropertyHandler;
   [FIRMessagingAnalytics logUserPropertyForConversionTracking:notification toAnalytics:analytics];
 }
 
+- (void)testConversionTrackingWithNonNumericValueDoesNotCrash {
+  // A sender controls the payload types. "google.c.a.tc" is expected to be a numeric
+  // string, but a JSON object/array/null does not respond to -integerValue.
+  for (id trackingValue in @[ @{}, @[ @1 ], [NSNull null] ]) {
+    NSDictionary *notification = @{
+      @"gcm.message_id" : @"0:1522880049414338%944841cd944841cd",
+      @"google.c.a.c_id" : @"575315420755741863",
+      @"google.c.a.e" : @"1",
+      @"google.c.a.tc" : trackingValue,
+    };
+    FakeAnalytics *analytics = [[FakeAnalytics alloc]
+        initWithEventHandler:^(NSString *origin, NSString *name, NSDictionary *parameters) {
+          XCTFail(@"Conversion tracking must not fire for a non-numeric tracking value.");
+        }];
+    XCTAssertNoThrow([FIRMessagingAnalytics logUserPropertyForConversionTracking:notification
+                                                                     toAnalytics:analytics]);
+  }
+}
+
 #if !SWIFT_PACKAGE
 // This test depends on a sharedApplication which is not available in the Swift PM test env.
 - (void)testLogMessage {

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingHandlingTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingHandlingTest.m
@@ -195,6 +195,33 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
   OCMVerifyAll(_testUtil.mockMessaging);
 }
 
+- (void)testMalformedContentAvailableDoesNotCrash {
+  // "content-available" is attacker-controlled and read with -boolValue while detecting
+  // APNS sync messages; a JSON object/array/null does not respond to -boolValue.
+  for (id contentAvailable in @[ @{}, @[ @1 ], [NSNull null] ]) {
+    NSDictionary *notificationPayload = @{
+      @"aps" : @{@"content-available" : contentAvailable},
+      @"gcm.message_id" : @"1566513591299872",
+      @"google.c.a.e" : @1,
+    };
+    XCTAssertNoThrow([_testUtil.messaging appDidReceiveMessage:notificationPayload]);
+  }
+}
+
+- (void)testMalformedSyncMessageTTLDoesNotCrash {
+  // A sync message's "gcm.ttl" is attacker-controlled and read with -longLongValue; a JSON
+  // object/array/null does not respond to it.
+  for (id ttl in @[ @{}, @[ @1 ], [NSNull null] ]) {
+    NSDictionary *notificationPayload = @{
+      @"aps" : @{@"content-available" : @1},
+      @"gcm.message_id" : [NSUUID UUID].UUIDString,
+      @"gcm.ttl" : ttl,
+      @"google.c.a.e" : @1,
+    };
+    XCTAssertNoThrow([_testUtil.messaging appDidReceiveMessage:notificationPayload]);
+  }
+}
+
 - (void)testMCSNotification {
   NSDictionary *notificationPayload = @{@"from" : @"35006771263", @"image" : @"bunny.png"};
   OCMExpect([_testUtil.mockMessaging handleContextManagerMessage:notificationPayload]);


### PR DESCRIPTION
appDidReceiveMessage: reads several fields off the untrusted push payload with numeric accessors and no type check: FIRMessagingIsAPNSSyncMessage sends -boolValue to aps.content-available, expirationTimeForSyncMessage: sends -longLongValue to gcm.ttl, and logUserPropertyForConversionTracking: sends -integerValue to google.c.a.tc. A sender who sets any of those to a JSON object, array, or null crashes the app with an unrecognized selector when the message arrives or the notification is opened. Guard each with respondsToSelector before the accessor, matching the check already used for google.c.a.ts a few lines up in FIRMessagingAnalytics.