### PR TITLE
[Functions, Storage] Emulator authentication fix

### DIFF
--- a/FirebaseFunctions/CHANGELOG.md
+++ b/FirebaseFunctions/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [changed] Requests directed to the local emulator over a non-loopback HTTP connection when tokens
+  are present will now explicitly fail with an `unauthenticated` error instead of silently omitting
+  the tokens and proceeding. (#16536)
+
 # 12.17.0
 - [fixed] Resolved a concurrency resource leak in Functions stream cancellation. (#16392)
 - [changed] Enforced stricter transport layer security when using the emulator:

--- a/FirebaseFunctions/CHANGELOG.md
+++ b/FirebaseFunctions/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
-- [changed] Requests directed to the local emulator over a non-loopback HTTP connection when tokens
-  are present will now explicitly fail with an `unauthenticated` error instead of silently omitting
-  the tokens and proceeding. (#16536)
+- [changed] Requests directed to the local emulator over a non-loopback HTTP connection
+  when tokens are present will now explicitly fail with an `unauthenticated` error
+  instead of silently omitting the tokens and proceeding. (#16536)
+- [added] Added a DEBUG-only `allowInsecureTokenAttachment` property on `Functions` to
+  allow insecure token attachment over HTTP for physical device testing. (#16536)
 
 # 12.17.0
 - [fixed] Resolved a concurrency resource leak in Functions stream cancellation. (#16392)

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -580,14 +580,22 @@ enum FunctionsConstants {
     urlRequest.httpMethod = "POST"
 
     let shouldAttachTokens = url.isSecureOrLoopback
+    let hasTokens = context.authToken != nil || context.fcmToken != nil || context
+      .appCheckToken != nil || context.limitedUseAppCheckToken != nil
 
     guard shouldAttachTokens else {
-      if url.scheme?.lowercased() == "http" {
+      if hasTokens && url.scheme?.lowercased() == "http" {
         FirebaseLogger.log(
           level: .warning,
           service: "[FirebaseFunctions]",
           code: "I-FUN000001",
           message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
+        )
+        throw FunctionsError(
+          .unauthenticated,
+          userInfo: [
+            NSLocalizedDescriptionKey: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host.",
+          ]
         )
       }
       return urlRequest
@@ -646,14 +654,22 @@ enum FunctionsConstants {
     }
 
     let shouldAttachTokens = url.isSecureOrLoopback
+    let hasTokens = context.authToken != nil || context.fcmToken != nil || context
+      .appCheckToken != nil || context.limitedUseAppCheckToken != nil
 
     guard shouldAttachTokens else {
-      if url.scheme?.lowercased() == "http" {
+      if hasTokens && url.scheme?.lowercased() == "http" {
         FirebaseLogger.log(
           level: .warning,
           service: "[FirebaseFunctions]",
           code: "I-FUN000002",
           message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
+        )
+        throw FunctionsError(
+          .unauthenticated,
+          userInfo: [
+            NSLocalizedDescriptionKey: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host.",
+          ]
         )
       }
       return fetcher

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -75,7 +75,7 @@ enum FunctionsConstants {
     /// connections.
     /// This should only be used for local testing and debugging on physical devices.
     /// To prevent accidental credential leaks, this property is only available in DEBUG builds.
-    @objc open var allowInsecureTokenAttachment: Bool = false
+    @nonobjc public var allowInsecureTokenAttachment: Bool = false
   #endif
 
   /// Creates a Cloud Functions client using the default or returns a pre-existing instance if it
@@ -587,30 +587,7 @@ enum FunctionsConstants {
     urlRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
     urlRequest.httpMethod = "POST"
 
-    var shouldAttachTokens = url.isSecureOrLoopback
-    #if DEBUG
-      if allowInsecureTokenAttachment {
-        shouldAttachTokens = true
-      }
-    #endif
-    let hasTokens = context.authToken != nil || context.fcmToken != nil || context
-      .appCheckToken != nil || context.limitedUseAppCheckToken != nil
-
-    guard shouldAttachTokens else {
-      if hasTokens && url.scheme?.lowercased() == "http" {
-        FirebaseLogger.log(
-          level: .warning,
-          service: "[FirebaseFunctions]",
-          code: "I-FUN000001",
-          message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
-        )
-        throw FunctionsError(
-          .unauthenticated,
-          userInfo: [
-            NSLocalizedDescriptionKey: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host.",
-          ]
-        )
-      }
+    guard try shouldAttachTokens(to: url, context: context, logCode: "I-FUN000001") else {
       return urlRequest
     }
 
@@ -666,30 +643,7 @@ enum FunctionsConstants {
       fetcher.allowedInsecureSchemes = ["http"]
     }
 
-    var shouldAttachTokens = url.isSecureOrLoopback
-    #if DEBUG
-      if allowInsecureTokenAttachment {
-        shouldAttachTokens = true
-      }
-    #endif
-    let hasTokens = context.authToken != nil || context.fcmToken != nil || context
-      .appCheckToken != nil || context.limitedUseAppCheckToken != nil
-
-    guard shouldAttachTokens else {
-      if hasTokens && url.scheme?.lowercased() == "http" {
-        FirebaseLogger.log(
-          level: .warning,
-          service: "[FirebaseFunctions]",
-          code: "I-FUN000002",
-          message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
-        )
-        throw FunctionsError(
-          .unauthenticated,
-          userInfo: [
-            NSLocalizedDescriptionKey: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host.",
-          ]
-        )
-      }
+    guard try shouldAttachTokens(to: url, context: context, logCode: "I-FUN000002") else {
       return fetcher
     }
 
@@ -775,6 +729,45 @@ enum FunctionsConstants {
     }
 
     return dataJSON
+  }
+
+  /// Validates whether tokens can safely be attached to the request.
+  /// - Throws: `FunctionsError.unauthenticated` when credentials would be transmitted insecurely
+  /// over HTTP to a non-loopback host.
+  /// - Returns: `true` if tokens should be attached, `false` otherwise.
+  private func shouldAttachTokens(to url: URL,
+                                  context: FunctionsContext,
+                                  logCode: String) throws -> Bool {
+    #if DEBUG
+      let shouldAttachTokens = url.isSecureOrLoopback || allowInsecureTokenAttachment
+    #else
+      let shouldAttachTokens = url.isSecureOrLoopback
+    #endif
+
+    guard shouldAttachTokens else {
+      let hasTokens = context.authToken != nil ||
+        context.fcmToken != nil ||
+        context.appCheckToken != nil ||
+        context.limitedUseAppCheckToken != nil
+
+      if hasTokens && url.scheme?.lowercased() == "http" {
+        FirebaseLogger.log(
+          level: .warning,
+          service: "[FirebaseFunctions]",
+          code: logCode,
+          message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
+        )
+        throw FunctionsError(
+          .unauthenticated,
+          userInfo: [
+            NSLocalizedDescriptionKey: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host.",
+          ]
+        )
+      }
+      return false
+    }
+
+    return true
   }
 }
 

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -70,6 +70,14 @@ enum FunctionsConstants {
     _emulatorOrigin.value()
   }
 
+  #if DEBUG
+    /// Allows authentication and AppCheck tokens to be attached to requests over insecure HTTP
+    /// connections.
+    /// This should only be used for local testing and debugging on physical devices.
+    /// To prevent accidental credential leaks, this property is only available in DEBUG builds.
+    @objc open var allowInsecureTokenAttachment: Bool = false
+  #endif
+
   /// Creates a Cloud Functions client using the default or returns a pre-existing instance if it
   /// already exists.
   /// - Returns: A shared Functions instance initialized with the default `FirebaseApp`.
@@ -579,7 +587,12 @@ enum FunctionsConstants {
     urlRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
     urlRequest.httpMethod = "POST"
 
-    let shouldAttachTokens = url.isSecureOrLoopback
+    var shouldAttachTokens = url.isSecureOrLoopback
+    #if DEBUG
+      if allowInsecureTokenAttachment {
+        shouldAttachTokens = true
+      }
+    #endif
     let hasTokens = context.authToken != nil || context.fcmToken != nil || context
       .appCheckToken != nil || context.limitedUseAppCheckToken != nil
 
@@ -653,7 +666,12 @@ enum FunctionsConstants {
       fetcher.allowedInsecureSchemes = ["http"]
     }
 
-    let shouldAttachTokens = url.isSecureOrLoopback
+    var shouldAttachTokens = url.isSecureOrLoopback
+    #if DEBUG
+      if allowInsecureTokenAttachment {
+        shouldAttachTokens = true
+      }
+    #endif
     let hasTokens = context.authToken != nil || context.fcmToken != nil || context
       .appCheckToken != nil || context.limitedUseAppCheckToken != nil
 

--- a/FirebaseFunctions/Tests/Unit/FunctionsTests.swift
+++ b/FirebaseFunctions/Tests/Unit/FunctionsTests.swift
@@ -356,7 +356,7 @@ class FunctionsTests: XCTestCase {
     }
   }
 
-  @MainActor func testCallFunctionOverHttpWithoutLocalhostDoesNotAttachTokens() {
+  @MainActor func testCallFunctionOverHttpWithoutLocalhostFailsWhenTokensPresent() {
     let authFake = FIRAuthInteropFake(token: "fake_auth_token", userID: nil, error: nil)
     let functionsInsecure = Functions(
       projectID: "my-project",
@@ -370,6 +370,31 @@ class FunctionsTests: XCTestCase {
     functionsInsecure.useEmulator(withHost: "10.0.0.1", port: 5005)
     appCheckFake.tokenResult = FIRAppCheckTokenResultFake(token: "shared_valid_token", error: nil)
 
+    let completionExpectation = expectation(description: "completionExpectation")
+    functionsInsecure
+      .httpsCallable("fake_func")
+      .call { result, error in
+        let nsError = error as NSError?
+        XCTAssertEqual(nsError?.domain, FunctionsErrorDomain)
+        XCTAssertEqual(nsError?.code, FunctionsErrorCode.unauthenticated.rawValue)
+        completionExpectation.fulfill()
+      }
+
+    waitForExpectations(timeout: 1.5)
+  }
+
+  @MainActor func testCallFunctionOverHttpWithoutLocalhostSucceedsWhenNoTokensPresent() {
+    let functionsInsecure = Functions(
+      projectID: "my-project",
+      region: "my-region",
+      customDomain: nil,
+      auth: nil,
+      messaging: nil,
+      appCheck: nil,
+      fetcherService: fetcherService
+    )
+    functionsInsecure.useEmulator(withHost: "10.0.0.1", port: 5005)
+
     let httpRequestExpectation = expectation(description: "HTTPRequestExpectation")
     fetcherService.testBlock = { fetcherToTest, testResponse in
       XCTAssertNil(fetcherToTest.request?.value(forHTTPHeaderField: "Authorization"))
@@ -382,6 +407,7 @@ class FunctionsTests: XCTestCase {
     functionsInsecure
       .httpsCallable("fake_func")
       .call { result, error in
+        XCTAssertNil(error)
         completionExpectation.fulfill()
       }
 

--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 - [fixed] Fixed an issue where constructing a download URL could fail or produce
   an invalid path if the storage bucket name contained special characters. (#16529)
+- [changed] Requests directed to the local emulator over a non-loopback HTTP connection
+  when token providers are configured will now explicitly fail with an `unauthenticated`
+  error instead of silently omitting the tokens and proceeding. (#16536)
 
 # 12.17.0
 - [changed] Enforced stricter transport layer security when using the emulator: Auth and AppCheck

--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -2,8 +2,10 @@
 - [fixed] Fixed an issue where constructing a download URL could fail or produce
   an invalid path if the storage bucket name contained special characters. (#16529)
 - [changed] Requests directed to the local emulator over a non-loopback HTTP connection
-  when token providers are configured will now explicitly fail with an `unauthenticated`
+  when tokens are present will now explicitly fail with an `unauthenticated`
   error instead of silently omitting the tokens and proceeding. (#16536)
+- [added] Added a DEBUG-only `allowInsecureTokenAttachment` property on `Storage` to
+  allow insecure token attachment over HTTP for physical device testing. (#16536)
 
 # 12.17.0
 - [changed] Enforced stricter transport layer security when using the emulator: Auth and AppCheck

--- a/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
+++ b/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
@@ -40,11 +40,16 @@ actor StorageFetcherService {
       fetcherService.allowLocalhostRequest = true
       fetcherService.maxRetryInterval = storage.maxOperationRetryInterval
       fetcherService.testBlock = testBlock
+      var allowInsecureTokenAttachment = false
+      #if DEBUG
+        allowInsecureTokenAttachment = storage.allowInsecureTokenAttachment
+      #endif
       let authorizer = StorageTokenAuthorizer(
         googleAppID: app.options.googleAppID,
         callbackQueue: storage.callbackQueue,
         authProvider: storage.auth,
-        appCheck: storage.appCheck
+        appCheck: storage.appCheck,
+        allowInsecureTokenAttachment: allowInsecureTokenAttachment
       )
       fetcherService.authorizer = authorizer
       if storage.usesEmulator {

--- a/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
+++ b/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
@@ -40,16 +40,18 @@ actor StorageFetcherService {
       fetcherService.allowLocalhostRequest = true
       fetcherService.maxRetryInterval = storage.maxOperationRetryInterval
       fetcherService.testBlock = testBlock
-      var allowInsecureTokenAttachment = false
-      #if DEBUG
-        allowInsecureTokenAttachment = storage.allowInsecureTokenAttachment
-      #endif
       let authorizer = StorageTokenAuthorizer(
         googleAppID: app.options.googleAppID,
         callbackQueue: storage.callbackQueue,
         authProvider: storage.auth,
         appCheck: storage.appCheck,
-        allowInsecureTokenAttachment: allowInsecureTokenAttachment
+        allowInsecureTokenAttachment: { [weak storage] in
+          #if DEBUG
+            return storage?.allowInsecureTokenAttachment ?? false
+          #else
+            return false
+          #endif
+        }
       )
       fetcherService.authorizer = authorizer
       if storage.usesEmulator {

--- a/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
+++ b/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
@@ -43,14 +43,22 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
     let host = request?.url?.host?.lowercased() ?? ""
     let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]"
     let shouldFetchTokens = isHttps || isLoopback
+    let hasTokenProviders = auth != nil || appCheck != nil
+
     guard shouldFetchTokens else {
-      if scheme == "http" {
+      if hasTokenProviders && scheme == "http" {
         FirebaseLogger.log(
           level: .warning,
           service: "[FirebaseStorage]",
           code: "I-STR000002",
           message: "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host."
         )
+        tokenError = StorageError
+          .unauthenticated(
+            serverError: [
+              "message": "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host.",
+            ]
+          ) as NSError
       }
       fetchTokenGroup.notify(queue: callbackQueue) {
         handler(tokenError)

--- a/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
+++ b/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
@@ -42,7 +42,12 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
     let isHttps = scheme == "https"
     let host = request?.url?.host?.lowercased() ?? ""
     let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]"
-    let shouldFetchTokens = isHttps || isLoopback
+    var shouldFetchTokens = isHttps || isLoopback
+    #if DEBUG
+      if allowInsecureTokenAttachment {
+        shouldFetchTokens = true
+      }
+    #endif
     let hasTokenProviders = auth != nil || appCheck != nil
 
     guard shouldFetchTokens else {
@@ -133,16 +138,23 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
   private let googleAppID: String
   private let auth: AuthInterop?
   private let appCheck: AppCheckInterop?
+  #if DEBUG
+    private let allowInsecureTokenAttachment: Bool
+  #endif
 
   private let serialAuthArgsQueue = DispatchQueue(label: "com.google.firebasestorage.authorizer")
 
   init(googleAppID: String,
        callbackQueue: DispatchQueue = DispatchQueue.main,
        authProvider: AuthInterop?,
-       appCheck: AppCheckInterop?) {
+       appCheck: AppCheckInterop?,
+       allowInsecureTokenAttachment: Bool = false) {
     self.googleAppID = googleAppID
     self.callbackQueue = callbackQueue
     auth = authProvider
     self.appCheck = appCheck
+    #if DEBUG
+      self.allowInsecureTokenAttachment = allowInsecureTokenAttachment
+    #endif
   }
 }

--- a/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
+++ b/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
@@ -42,34 +42,11 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
     let isHttps = scheme == "https"
     let host = request?.url?.host?.lowercased() ?? ""
     let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]"
-    var shouldFetchTokens = isHttps || isLoopback
     #if DEBUG
-      if allowInsecureTokenAttachment {
-        shouldFetchTokens = true
-      }
+      let shouldAttachTokens = isHttps || isLoopback || allowInsecureTokenAttachment()
+    #else
+      let shouldAttachTokens = isHttps || isLoopback
     #endif
-    let hasTokenProviders = auth != nil || appCheck != nil
-
-    guard shouldFetchTokens else {
-      if hasTokenProviders && scheme == "http" {
-        FirebaseLogger.log(
-          level: .warning,
-          service: "[FirebaseStorage]",
-          code: "I-STR000002",
-          message: "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host."
-        )
-        tokenError = StorageError
-          .unauthenticated(
-            serverError: [
-              "message": "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host.",
-            ]
-          ) as NSError
-      }
-      fetchTokenGroup.notify(queue: callbackQueue) {
-        handler(tokenError)
-      }
-      return
-    }
 
     if let auth {
       fetchTokenGroup.enter()
@@ -104,6 +81,28 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
     }
 
     fetchTokenGroup.notify(queue: callbackQueue) {
+      let tokensWereAttached = request?.value(forHTTPHeaderField: "Authorization") != nil ||
+        request?.value(forHTTPHeaderField: "X-Firebase-AppCheck") != nil
+
+      if tokensWereAttached && !shouldAttachTokens && scheme == "http" {
+        // Strip tokens so credentials aren't transmitted over cleartext HTTP
+        request?.setValue(nil, forHTTPHeaderField: "Authorization")
+        request?.setValue(nil, forHTTPHeaderField: "X-Firebase-AppCheck")
+
+        FirebaseLogger.log(
+          level: .warning,
+          service: "[FirebaseStorage]",
+          code: "I-STR000002",
+          message: "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host."
+        )
+        tokenError = StorageError
+          .unauthenticated(
+            serverError: [
+              "message": "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host.",
+            ]
+          ) as NSError
+      }
+
       handler(tokenError)
     }
   }
@@ -139,7 +138,7 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
   private let auth: AuthInterop?
   private let appCheck: AppCheckInterop?
   #if DEBUG
-    private let allowInsecureTokenAttachment: Bool
+    private let allowInsecureTokenAttachment: () -> Bool
   #endif
 
   private let serialAuthArgsQueue = DispatchQueue(label: "com.google.firebasestorage.authorizer")
@@ -148,7 +147,7 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
        callbackQueue: DispatchQueue = DispatchQueue.main,
        authProvider: AuthInterop?,
        appCheck: AppCheckInterop?,
-       allowInsecureTokenAttachment: Bool = false) {
+       allowInsecureTokenAttachment: @escaping () -> Bool = { false }) {
     self.googleAppID = googleAppID
     self.callbackQueue = callbackQueue
     auth = authProvider

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -116,7 +116,7 @@ internal import FirebaseCoreExtension
     /// connections.
     /// This should only be used for local testing and debugging on physical devices.
     /// To prevent accidental credential leaks, this property is only available in DEBUG builds.
-    @objc public var allowInsecureTokenAttachment: Bool = false
+    @nonobjc public var allowInsecureTokenAttachment: Bool = false
   #endif
 
   /// Creates a `StorageReference` initialized at the root Firebase Storage location.

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -111,6 +111,14 @@ internal import FirebaseCoreExtension
   /// A `DispatchQueue` that all developer callbacks are fired on. Defaults to the main queue.
   @objc public var callbackQueue: DispatchQueue = .main
 
+  #if DEBUG
+    /// Allows authentication and AppCheck tokens to be attached to requests over insecure HTTP
+    /// connections.
+    /// This should only be used for local testing and debugging on physical devices.
+    /// To prevent accidental credential leaks, this property is only available in DEBUG builds.
+    @objc public var allowInsecureTokenAttachment: Bool = false
+  #endif
+
   /// Creates a `StorageReference` initialized at the root Firebase Storage location.
   /// - Returns: An instance of `StorageReference` referencing the root of the storage bucket.
   @objc open func reference() -> StorageReference {

--- a/FirebaseStorage/Tests/Unit/StorageAuthorizerTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageAuthorizerTests.swift
@@ -188,7 +188,7 @@ class StorageAuthorizerTests: StorageTestHelpers {
     let _ = try await fetcher?.beginFetch()
   }
 
-  func testInsecureHostDoesNotAttachTokens() async throws {
+  func testInsecureHostFailsWhenTokensPresent() async throws {
     appCheck?.tokenResult = appCheckTokenSuccess!
     let insecureRequest = URLRequest(url: URL(string: "http://10.0.0.1/v0/b/bucket/o/object")!)
     fetcher = GTMSessionFetcher(request: insecureRequest)
@@ -198,6 +198,27 @@ class StorageAuthorizerTests: StorageTestHelpers {
       callbackQueue: DispatchQueue.main,
       authProvider: auth,
       appCheck: appCheck
+    )
+
+    do {
+      let _ = try await fetcher?.beginFetch()
+      XCTFail("Expected fetch to fail due to insecure token attachment")
+    } catch {
+      let nsError = error as NSError
+      XCTAssertEqual(nsError.domain, StorageErrorDomain)
+      XCTAssertEqual(nsError.code, StorageErrorCode.unauthenticated.rawValue)
+    }
+  }
+
+  func testInsecureHostSucceedsWhenNoTokensPresent() async throws {
+    let insecureRequest = URLRequest(url: URL(string: "http://10.0.0.1/v0/b/bucket/o/object")!)
+    fetcher = GTMSessionFetcher(request: insecureRequest)
+    fetcher?.allowedInsecureSchemes = ["http"]
+    fetcher?.authorizer = StorageTokenAuthorizer(
+      googleAppID: "dummyAppID",
+      callbackQueue: DispatchQueue.main,
+      authProvider: nil,
+      appCheck: nil
     )
 
     setFetcherTestBlock(with: 200) { fetcher in

--- a/FirebaseStorage/Tests/Unit/StorageAuthorizerTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageAuthorizerTests.swift
@@ -230,6 +230,27 @@ class StorageAuthorizerTests: StorageTestHelpers {
     XCTAssertNil(headers?["X-Firebase-AppCheck"])
   }
 
+  func testInsecureHostSucceedsWhenAuthProviderIsPresentButUserSignedOut() async throws {
+    let unauthenticatedAuthFake = FIRAuthInteropFake(token: nil, userID: nil, error: nil)
+    let insecureRequest = URLRequest(url: URL(string: "http://10.0.0.1/v0/b/bucket/o/object")!)
+    fetcher = GTMSessionFetcher(request: insecureRequest)
+    fetcher?.allowedInsecureSchemes = ["http"]
+    fetcher?.authorizer = StorageTokenAuthorizer(
+      googleAppID: "dummyAppID",
+      callbackQueue: DispatchQueue.main,
+      authProvider: unauthenticatedAuthFake,
+      appCheck: nil
+    )
+
+    setFetcherTestBlock(with: 200) { fetcher in
+      self.checkAuthorizer(fetcher: fetcher, trueFalse: false)
+    }
+    let _ = try await fetcher?.beginFetch()
+    let headers = fetcher!.request?.allHTTPHeaderFields
+    XCTAssertNil(headers?["Authorization"])
+    XCTAssertNil(headers?["X-Firebase-AppCheck"])
+  }
+
   func testLocalhostDoesAttachTokensOverHttp() async throws {
     appCheck?.tokenResult = appCheckTokenSuccess!
     let localRequest = URLRequest(url: URL(string: "http://localhost/v0/b/bucket/o/object")!)
@@ -249,6 +270,77 @@ class StorageAuthorizerTests: StorageTestHelpers {
     let headers = fetcher!.request?.allHTTPHeaderFields
     XCTAssertEqual(headers?["Authorization"], "Firebase \(StorageTestAuthToken)")
     XCTAssertEqual(headers?["X-Firebase-AppCheck"], appCheckTokenSuccess?.token)
+  }
+
+  func testDynamicAllowInsecureTokenAttachment() async throws {
+    appCheck?.tokenResult = appCheckTokenSuccess!
+    let insecureRequest = URLRequest(url: URL(string: "http://10.0.0.1/v0/b/bucket/o/object")!)
+    fetcher = GTMSessionFetcher(request: insecureRequest)
+    fetcher?.allowedInsecureSchemes = ["http"]
+
+    var allowInsecure = false
+    fetcher?.authorizer = StorageTokenAuthorizer(
+      googleAppID: "dummyAppID",
+      callbackQueue: DispatchQueue.main,
+      authProvider: auth,
+      appCheck: appCheck,
+      allowInsecureTokenAttachment: { allowInsecure }
+    )
+
+    // Update allowInsecure to true after authorizer has been initialized
+    allowInsecure = true
+
+    setFetcherTestBlock(with: 200) { fetcher in
+      self.checkAuthorizer(fetcher: fetcher, trueFalse: true)
+    }
+
+    let _ = try await fetcher?.beginFetch()
+    let headers = fetcher!.request?.allHTTPHeaderFields
+    XCTAssertEqual(headers?["Authorization"], "Firebase \(StorageTestAuthToken)")
+    XCTAssertEqual(headers?["X-Firebase-AppCheck"], appCheckTokenSuccess?.token)
+  }
+
+  func testInsecureHostFailsWhenOnlyAppCheckTokenIsPresent() async throws {
+    appCheck?.tokenResult = appCheckTokenSuccess!
+    let insecureRequest = URLRequest(url: URL(string: "http://10.0.0.1/v0/b/bucket/o/object")!)
+    fetcher = GTMSessionFetcher(request: insecureRequest)
+    fetcher?.allowedInsecureSchemes = ["http"]
+    fetcher?.authorizer = StorageTokenAuthorizer(
+      googleAppID: "dummyAppID",
+      callbackQueue: DispatchQueue.main,
+      authProvider: nil,
+      appCheck: appCheck
+    )
+
+    do {
+      let _ = try await fetcher?.beginFetch()
+      XCTFail("Expected fetch to fail due to insecure AppCheck token attachment")
+    } catch {
+      let nsError = error as NSError
+      XCTAssertEqual(nsError.domain, StorageErrorDomain)
+      XCTAssertEqual(nsError.code, StorageErrorCode.unauthenticated.rawValue)
+    }
+  }
+
+  func testInsecureHostFailsWhenOnlyAuthTokenIsPresent() async throws {
+    let insecureRequest = URLRequest(url: URL(string: "http://10.0.0.1/v0/b/bucket/o/object")!)
+    fetcher = GTMSessionFetcher(request: insecureRequest)
+    fetcher?.allowedInsecureSchemes = ["http"]
+    fetcher?.authorizer = StorageTokenAuthorizer(
+      googleAppID: "dummyAppID",
+      callbackQueue: DispatchQueue.main,
+      authProvider: auth,
+      appCheck: nil
+    )
+
+    do {
+      let _ = try await fetcher?.beginFetch()
+      XCTFail("Expected fetch to fail due to insecure Auth token attachment")
+    } catch {
+      let nsError = error as NSError
+      XCTAssertEqual(nsError.domain, StorageErrorDomain)
+      XCTAssertEqual(nsError.code, StorageErrorCode.unauthenticated.rawValue)
+    }
   }
 
   // MARK: Helpers


### PR DESCRIPTION
# Enforce explicit errors for insecure HTTP token withholding and refactor authorization logic
## Description
This pull request improves the developer experience and safety of the transport layer security rules introduced for Firebase Functions and Firebase Storage. It addresses an issue where silently stripping credentials over non-loopback HTTP connections could result in confusing application behavior (such as unexpected guest onboarding) by instead failing fast with an explicit error.
### Key Changes
- **Fail Fast on Insecure Connections**: When a request is directed to a non-loopback HTTP endpoint *and* authentication tokens are present, the SDKs now explicitly fail the request with an `unauthenticated` error (instead of silently sending an unauthenticated request). Unauthenticated requests (where no tokens are present) remain unaffected and will still proceed normally.
- **Refactored Token Authorization**: Flattened the token attachment logic in both `Functions.swift` and `StorageTokenAuthorizer.swift` by using early-return `guard` statements, significantly improving code readability.
- **Optimized Scheme Evaluation**: Extracted the URL scheme evaluation in `StorageTokenAuthorizer.swift` into a local variable to prevent redundant `.lowercased()` string operations.
### Testing
- Updated `testCallFunctionOverHttpWithoutLocalhostFailsWhenTokensPresent` and `testInsecureHostFailsWhenTokensPresent` to verify that requests are explicitly blocked with `unauthenticated` errors when tokens are withheld.
- Added `testCallFunctionOverHttpWithoutLocalhostSucceedsWhenNoTokensPresent` and `testInsecureHostSucceedsWhenNoTokensPresent` to ensure that standard, unauthenticated HTTP requests continue to work as expected.
- Initialized mock `GTMSessionFetcher` instances with `allowedInsecureSchemes = ["http"]` during unit tests to accurately simulate the emulator networking conditions.
## Related Issues
- Resolves #[16536](https://github.com/firebase/firebase-ios-sdk/issues/16536)