### PR TITLE
fix(fiam): banner status bar height lookup on deprecated UIApplication.keyWindow

### DIFF
--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+- [fixed] Replaced the deprecated `UIApplication.keyWindow` lookup used to
+  measure the status bar height when laying out a banner. The height is now
+  read from the foreground window scene the banner is rendered in, which is
+  correct in multi-scene apps. (#13068)
+
 # 12.1.0
 - [fixed] Fix Xcode 26 crash from missing `NSUserActivityTypeBrowsingWeb`
   symbol. Note that this fix isn't in the 12.1.0 zip and Carthage

--- a/FirebaseInAppMessaging/Sources/DefaultUI/Banner/FIRIAMBannerViewController.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/Banner/FIRIAMBannerViewController.m
@@ -163,7 +163,7 @@ static const CGFloat kSwipeUpThreshold = -10.0f;
   // Calculate status bar height.
   UIStatusBarManager *manager =
       [[UIApplication sharedApplication] fir_foregroundWindowScene].statusBarManager;
-  CGFloat statusBarHeight = manager.statusBarFrame.size.height;
+  CGFloat statusBarHeight = manager ? manager.statusBarFrame.size.height : 0.0;
 
   // Pin title label below status bar with cushion.
   [[self.titleLabel.topAnchor constraintEqualToAnchor:self.view.topAnchor

--- a/FirebaseInAppMessaging/Sources/DefaultUI/Banner/FIRIAMBannerViewController.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/Banner/FIRIAMBannerViewController.m
@@ -19,6 +19,7 @@
 
 #import "FirebaseInAppMessaging/Sources/DefaultUI/Banner/FIRIAMBannerViewController.h"
 #import "FirebaseInAppMessaging/Sources/DefaultUI/FIRCore+InAppMessagingDisplay.h"
+#import "FirebaseInAppMessaging/Sources/Private/Util/UIApplication+FIRForegroundWindowScene.h"
 
 @interface FIRIAMBannerViewController ()
 
@@ -160,12 +161,8 @@ static const CGFloat kSwipeUpThreshold = -10.0f;
   self.view.layer.shadowOpacity = 0.4;
 
   // Calculate status bar height.
-  // TODO(#13068) : Fix keyWindow deprecation.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   UIStatusBarManager *manager =
-      [UIApplication sharedApplication].keyWindow.windowScene.statusBarManager;
-#pragma clang diagnostic pop
+      [[UIApplication sharedApplication] fir_foregroundWindowScene].statusBarManager;
   CGFloat statusBarHeight = manager.statusBarFrame.size.height;
 
   // Pin title label below status bar with cushion.


### PR DESCRIPTION
### Discussion
Fixes #13068.

`FIRIAMBannerViewController` measured the status bar height using the deprecated `UIApplication.keyWindow`. The warning was suppressed by a `-Wdeprecated-declarations` pragma + `TODO(#13068)`.

This switches to the existing `-[UIApplication fir_foregroundWindowScene]` helper. This is the same scene `FIRIAMRenderingWindowHelper` uses to build the banner's window so the measurement and the window now come from the same source. Both paths degrade to a nil manager and `statusBarHeight = 0`, and the helper additionally filters non-`UIWindowScene` scenes (#9376). No public API change.

### Testing
xcodebuild -scheme FirebaseInAppMessaging-Beta -destination 'platform=iOS Simulator,name=iPhone 17' build

No test is added b/c `FirebaseInAppMessaging/Tests/` has no existing coverage of `FIRIAMBannerViewController` or status bar measurement.
