### PR TITLE
Fix #16542: Pre-cache Foundation locale and calendar to prevent C locale race condition

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+- [fixed] Fixed a race condition where initializing Firebase in a multi-threaded
+  environment could temporarily corrupt Foundation's locale and calendar caches,
+  resulting in unexpected behavior (e.g., losing the user's "First Day of Week"
+  override). (#16542)
+
 # Firebase 12.17.0
 - [changed] Removed the  (never activated) `recaptchaSiteKey` property from `FirebaseOptions`.
   This feature is part of the public preview reCAPTCHA provider.

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -136,16 +136,19 @@ static FIRApp *sDefaultApp;
 }
 
 + (void)configureWithName:(NSString *)name options:(FIROptions *)options {
-  // Pre-cache the locale and calendar to prevent a race condition with C++ dependencies
-  // that temporarily mutate the global POSIX C locale during initialization.
-  // See https://github.com/firebase/firebase-ios-sdk/issues/16542
-  (void)[NSLocale currentLocale];
-  (void)[NSCalendar currentCalendar];
-  (void)[NSCalendar autoupdatingCurrentCalendar];
-
   if (!name || !options) {
     [NSException raise:kFirebaseCoreErrorDomain format:@"Neither name nor options can be nil."];
   }
+
+  // Pre-cache the locale and calendar to prevent a race condition with C++ dependencies
+  // that temporarily mutate the global POSIX C locale during initialization.
+  // See https://github.com/firebase/firebase-ios-sdk/issues/16542
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    (void)[NSLocale currentLocale];
+    (void)[NSCalendar currentCalendar];
+    (void)[NSCalendar autoupdatingCurrentCalendar];
+  });
   if (name.length == 0) {
     [NSException raise:kFirebaseCoreErrorDomain format:@"Name cannot be empty."];
   }

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -143,8 +143,8 @@ static FIRApp *sDefaultApp;
   // Pre-cache the locale and calendar to prevent a race condition with C++ dependencies
   // that temporarily mutate the global POSIX C locale during initialization.
   // See https://github.com/firebase/firebase-ios-sdk/issues/16542
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
+  static dispatch_once_t localeCacheOnceToken;
+  dispatch_once(&localeCacheOnceToken, ^{
     (void)[NSLocale currentLocale];
     (void)[NSCalendar currentCalendar];
     (void)[NSCalendar autoupdatingCurrentCalendar];

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -136,6 +136,13 @@ static FIRApp *sDefaultApp;
 }
 
 + (void)configureWithName:(NSString *)name options:(FIROptions *)options {
+  // Pre-cache the locale and calendar to prevent a race condition with C++ dependencies
+  // that temporarily mutate the global POSIX C locale during initialization.
+  // See https://github.com/firebase/firebase-ios-sdk/issues/16542
+  (void)[NSLocale currentLocale];
+  (void)[NSCalendar currentCalendar];
+  (void)[NSCalendar autoupdatingCurrentCalendar];
+
   if (!name || !options) {
     [NSException raise:kFirebaseCoreErrorDomain format:@"Neither name nor options can be nil."];
   }


### PR DESCRIPTION
Fixes #16542.

### Description
This PR fixes a race condition where initializing Firebase in a multi-threaded environment could temporarily corrupt Foundation's locale and calendar caches, resulting in unexpected behavior (e.g., losing the user's 'First Day of Week' override).

By pre-caching  and  at the beginning of , we force Foundation to securely cache the iOS region configurations before any C++ dependencies (like those in Analytics) have a chance to temporarily alter the POSIX C locale.

**Gemini's full analysis:**

Here is my analysis of the root cause, which perfectly aligns with all of your findings (the "observer effect", and why both Analytics and Crashlytics are required to reproduce it).

### The Root Cause
This is a classic race condition involving Foundation's lazy locale caching and POSIX C locale mutation.

1. **Analytics corrupts the C locale:** During its initialization, `FirebaseAnalytics` (via `GoogleAppMeasurement` or a C++ dependency) likely calls `setlocale(LC_ALL, "C")` temporarily to safely parse JSON, floats, or interact with SQLite, and then restores it. This temporarily strips the iOS-specific region overrides (like First Day of Week).
2. **Crashlytics forces the cache concurrently:** At the exact same time, `FIRCrashlytics` spawns a background task during its initialization (`FIRCLSContextInitialize`) to record host metadata. In `FIRCLSHostRecord()`, it calls `[[NSLocale currentLocale] localeIdentifier]`.
3. **The Race:** Because Crashlytics reads `[NSLocale currentLocale]` on a background thread *while* the C locale is temporarily corrupted by Analytics on another thread, **Foundation lazily resolves and permanently caches the corrupted locale** (which resolves to `en_001` and loses the region overrides) for the rest of the app's lifetime.

### Why your experiments worked:
* **The "Observer Effect" (reading `Locale.current` before `configure()`):** By reading the locale early, you force Foundation to resolve and cache the *correct* locale. Once cached, Foundation ignores the temporary C locale corruption caused by Analytics, masking the bug.
* **Removing Analytics:** Without Analytics, the C locale is never temporarily corrupted, so Crashlytics safely caches the correct locale.
* **Removing Crashlytics:** Without Crashlytics, no one reads `NSLocale` concurrently during Analytics' initialization window. By the time your app eventually reads `Calendar.current` later, Analytics has already restored the C locale, so Foundation caches the correct locale.

### Suggested Fixes for the Firebase Team

1. **FirebaseCore (Most Robust):** The safest fix is to add `_ = [NSLocale currentLocale];` and `_ = [NSCalendar autoupdatingCurrentCalendar];` at the very beginning of `+[FIRApp configure]`. By explicitly pre-caching Foundation's locale before any component initialization begins, it immunizes the app from any C++ dependencies that briefly mutate the POSIX locale.
2. **Crashlytics:** `FIRCrashlytics` could read `[[NSLocale currentLocale] localeIdentifier]` synchronously on the main thread *before* dispatching its `FIRCLSContextRecordMetadata` block to the background queue, avoiding the concurrent read.
3. **Analytics (GoogleAppMeasurement):** Audit the C++ code for `setlocale(LC_ALL, "C")`. If it must be used, try using `uselocale()` (thread-local locale) instead of `setlocale()` (global locale), as POSIX `setlocale` is notoriously unsafe in multi-threaded environments like iOS.