### PR TITLE
cleanup(sessions): replace promises with swift concurrency

### DIFF
--- a/FirebaseSessions.podspec
+++ b/FirebaseSessions.podspec
@@ -46,7 +46,6 @@ Pod::Spec.new do |s|
   s.dependency 'GoogleUtilities/Environment', '~> 8.1'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.1'
   s.dependency 'nanopb', '~> 3.30910.0'
-  s.dependency 'PromisesSwift', '~> 2.1'
 
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',

--- a/FirebaseSessions/Sources/FirebaseSessions.swift
+++ b/FirebaseSessions/Sources/FirebaseSessions.swift
@@ -19,11 +19,6 @@ internal import FirebaseCoreExtension
 internal import FirebaseInstallations
 internal import GoogleDataTransport
 
-#if swift(>=6.0)
-#elseif swift(>=5.10)
-#else
-#endif
-
 private enum GoogleDataTransportConfig {
   static let sessionsLogSource = "1974"
   static let sessionsTarget = GDTCORTarget.FLL
@@ -147,7 +142,7 @@ private enum GoogleDataTransportConfig {
     self.loggedEventCallbackQueue = loggedEventCallbackQueue
 
     let dependencies = SessionsDependencies.dependencies
-    self.state = SessionsState(expectedSubscribers: dependencies)
+    state = SessionsState(expectedSubscribers: dependencies)
 
     super.init()
 
@@ -181,7 +176,7 @@ private enum GoogleDataTransportConfig {
       Task {
         await self.state.waitUntilAllRegistered()
         let subscribers = await self.state.currentSubscribers
-        
+
         self.loggedEventCallbackQueue.async {
           let isAnyDataCollectionEnabled = subscribers.contains { $0.isDataCollectionEnabled }
           guard isAnyDataCollectionEnabled else {

--- a/FirebaseSessions/Sources/FirebaseSessions.swift
+++ b/FirebaseSessions/Sources/FirebaseSessions.swift
@@ -20,11 +20,8 @@ internal import FirebaseInstallations
 internal import GoogleDataTransport
 
 #if swift(>=6.0)
-  internal import Promises
 #elseif swift(>=5.10)
-  import Promises
 #else
-  internal import Promises
 #endif
 
 private enum GoogleDataTransportConfig {
@@ -32,7 +29,7 @@ private enum GoogleDataTransportConfig {
   static let sessionsTarget = GDTCORTarget.FLL
 }
 
-@objc(FIRSessions) final class Sessions: NSObject, Library, SessionsProvider {
+@objc(FIRSessions) final class Sessions: NSObject, Library, SessionsProvider, @unchecked Sendable {
   // MARK: - Private Variables
 
   /// The Firebase App ID associated with Sessions.
@@ -45,13 +42,12 @@ private enum GoogleDataTransportConfig {
   private let appInfo: ApplicationInfoProtocol
   private let settings: SettingsProtocol
 
-  /// Subscribers
-  /// `subscribers` are used to determine the Data Collection state of the Sessions SDK.
-  /// If any Subscribers has Data Collection enabled, the Sessions SDK will send events
-  private var subscribers: [SessionsSubscriber] = []
-  /// `subscriberPromises` are used to wait until all Subscribers have registered
-  /// themselves. Subscribers must have Data Collection state available upon registering.
-  private var subscriberPromises: [SessionsSubscriberName: Promise<Void>] = [:]
+  /// `state` holds the mutable state (subscribers array and registration)
+  /// ensuring mathematical safety in Swift Concurrency.
+  private let state: SessionsState
+
+  /// Queue for callbacks
+  private let loggedEventCallbackQueue: DispatchQueue
 
   /// Notifications
   static let SessionIDChangedNotificationName = Notification
@@ -90,7 +86,8 @@ private enum GoogleDataTransportConfig {
               coordinator: coordinator,
               initiator: initiator,
               appInfo: appInfo,
-              settings: settings) { result in
+              settings: settings,
+              loggedEventCallbackQueue: .global(qos: .background)) { result in
       switch result {
       case .success(()):
         Logger.logInfo("Successfully logged Session Start event")
@@ -135,9 +132,7 @@ private enum GoogleDataTransportConfig {
   }
 
   // Initializes the SDK and begins the process of listening for lifecycle events and logging
-  // events. The given `logEventCallback` is invoked on a global background queue by default,
-  // but configurable via `loggedEventCallbackQueue` for providing a higher priority queue
-  // during tests to reduce flakes.
+  // events. The given `logEventCallback` is invoked when event logging completes.
   init(appID: String, sessionGenerator: SessionGenerator, coordinator: SessionCoordinatorProtocol,
        initiator: SessionInitiator, appInfo: ApplicationInfoProtocol, settings: SettingsProtocol,
        loggedEventCallbackQueue: DispatchQueue = .global(qos: .background),
@@ -149,13 +144,12 @@ private enum GoogleDataTransportConfig {
     self.initiator = initiator
     self.appInfo = appInfo
     self.settings = settings
-
-    super.init()
+    self.loggedEventCallbackQueue = loggedEventCallbackQueue
 
     let dependencies = SessionsDependencies.dependencies
-    for subscriberName in dependencies {
-      subscriberPromises[subscriberName] = Promise<Void>.pending()
-    }
+    self.state = SessionsState(expectedSubscribers: dependencies)
+
+    super.init()
 
     Logger
       .logDebug(
@@ -175,42 +169,56 @@ private enum GoogleDataTransportConfig {
 
       // If there are no Dependencies, then the Sessions SDK can't acknowledge
       // any products data collection state, so the Sessions SDK won't send events.
-      guard !self.subscriberPromises.isEmpty else {
-        loggedEventCallback(.failure(.NoDependenciesError))
+      guard !self.state.expectedSubscribers.isEmpty else {
+        self.loggedEventCallbackQueue.async {
+          loggedEventCallback(.failure(.NoDependenciesError))
+        }
         return
       }
 
-      // Wait until all subscriber promises have been fulfilled before
+      // Wait until all expected subscribers have registered before
       // doing any data collection.
-      all(self.subscriberPromises.values).then(on: loggedEventCallbackQueue) { _ in
-        guard self.isAnyDataCollectionEnabled else {
-          loggedEventCallback(.failure(.DataCollectionError))
-          return
-        }
+      Task {
+        await self.state.waitUntilAllRegistered()
+        let subscribers = await self.state.currentSubscribers
+        
+        self.loggedEventCallbackQueue.async {
+          let isAnyDataCollectionEnabled = subscribers.contains { $0.isDataCollectionEnabled }
+          guard isAnyDataCollectionEnabled else {
+            loggedEventCallback(.failure(.DataCollectionError))
+            return
+          }
 
-        Logger.logDebug("Data Collection is enabled for at least one Subscriber")
+          Logger.logDebug("Data Collection is enabled for at least one Subscriber")
 
-        // Fetch settings if they have expired. This must happen after the check for
-        // data collection because it uses the network, but it must happen before the
-        // check for sessionsEnabled from Settings because otherwise we would permanently
-        // turn off the Sessions SDK when we disabled it.
-        self.settings.updateSettings()
+          // Fetch settings if they have expired. This must happen after the check for
+          // data collection because it uses the network, but it must happen before the
+          // check for sessionsEnabled from Settings because otherwise we would permanently
+          // turn off the Sessions SDK when we disabled it.
+          self.settings.updateSettings()
+          let samplingRate = self.settings.samplingRate
+          let sessionsEnabled = self.settings.sessionsEnabled
 
-        self.addSubscriberFields(event: event)
-        event.setSamplingRate(samplingRate: self.settings.samplingRate)
+          for subscriber in subscribers {
+            event.set(subscriber: subscriber.sessionsSubscriberName,
+                      isDataCollectionEnabled: subscriber.isDataCollectionEnabled,
+                      appInfo: self.appInfo)
+          }
+          event.setSamplingRate(samplingRate: samplingRate)
 
-        guard sessionInfo.shouldDispatchEvents else {
-          loggedEventCallback(.failure(.SessionSamplingError))
-          return
-        }
+          guard sessionInfo.shouldDispatchEvents else {
+            loggedEventCallback(.failure(.SessionSamplingError))
+            return
+          }
 
-        guard self.settings.sessionsEnabled else {
-          loggedEventCallback(.failure(.DisabledViaSettingsError))
-          return
-        }
+          guard sessionsEnabled else {
+            loggedEventCallback(.failure(.DisabledViaSettingsError))
+            return
+          }
 
-        self.coordinator.attemptLoggingSessionStart(event: event) { result in
-          loggedEventCallback(result)
+          self.coordinator.attemptLoggingSessionStart(event: event) { result in
+            loggedEventCallback(result)
+          }
         }
       }
     }
@@ -226,23 +234,6 @@ private enum GoogleDataTransportConfig {
   }
 
   // MARK: - Data Collection
-
-  var isAnyDataCollectionEnabled: Bool {
-    for subscriber in subscribers {
-      if subscriber.isDataCollectionEnabled {
-        return true
-      }
-    }
-    return false
-  }
-
-  func addSubscriberFields(event: SessionStartEvent) {
-    for subscriber in subscribers {
-      event.set(subscriber: subscriber.sessionsSubscriberName,
-                isDataCollectionEnabled: subscriber.isDataCollectionEnabled,
-                appInfo: appInfo)
-    }
-  }
 
   // MARK: - SessionsProvider
 
@@ -265,7 +256,7 @@ private enum GoogleDataTransportConfig {
     }
   }
 
-  func register(subscriber: SessionsSubscriber) {
+  @objc(registerWithSubscriber:) func register(subscriber: SessionsSubscriber) {
     Logger
       .logDebug(
         "Registering Sessions SDK subscriber with name: \(subscriber.sessionsSubscriberName), data collection enabled: \(subscriber.isDataCollectionEnabled)"
@@ -289,9 +280,11 @@ private enum GoogleDataTransportConfig {
     // before subscribers, so subscribers will miss the first Notification
     subscriber.onSessionChanged(currentSessionDetails)
 
-    // Fulfil this subscriber's promise
-    subscribers.append(subscriber)
-    subscriberPromises[subscriber.sessionsSubscriberName]?.fulfill(())
+    // Register this subscriber to resume any waiting tasks
+    let subscriberName = subscriber.sessionsSubscriberName
+    Task {
+      await state.register(subscriber: subscriber, name: subscriberName)
+    }
   }
 
   // MARK: - Library conformance

--- a/FirebaseSessions/Sources/Public/SessionsProvider.swift
+++ b/FirebaseSessions/Sources/Public/SessionsProvider.swift
@@ -19,5 +19,5 @@ import Foundation
 // interface for other 1P SDKs to talk to.
 @objc(FIRSessionsProvider)
 public protocol SessionsProvider {
-  @objc func register(subscriber: SessionsSubscriber)
+  @objc(registerWithSubscriber:) func register(subscriber: SessionsSubscriber)
 }

--- a/FirebaseSessions/Sources/SessionStartEvent.swift
+++ b/FirebaseSessions/Sources/SessionStartEvent.swift
@@ -32,7 +32,7 @@ internal import GoogleDataTransport
 ///   1) Writing fields to the Session proto
 ///   2) Synthesizing itself for persisting to disk and logging to GoogleDataTransport
 ///
-class SessionStartEvent: NSObject, GDTCOREventDataObject {
+class SessionStartEvent: NSObject, GDTCOREventDataObject, @unchecked Sendable {
   var proto: firebase_appquality_sessions_SessionEvent
 
   init(sessionInfo: SessionInfo, appInfo: ApplicationInfoProtocol,

--- a/FirebaseSessions/Sources/SessionsState.swift
+++ b/FirebaseSessions/Sources/SessionsState.swift
@@ -1,0 +1,54 @@
+//
+// Copyright 2024-2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// An internal actor that protects mutable state for the Sessions SDK.
+actor SessionsState {
+  private var subscribers: [SessionsSubscriber] = []
+  private var registeredSubscribers: Set<SessionsSubscriberName> = []
+  nonisolated let expectedSubscribers: Set<SessionsSubscriberName>
+  private var continuations: [CheckedContinuation<Void, Never>] = []
+
+  init(expectedSubscribers: Set<SessionsSubscriberName>) {
+    self.expectedSubscribers = expectedSubscribers
+  }
+
+  func register(subscriber: SessionsSubscriber, name: SessionsSubscriberName) {
+    guard !registeredSubscribers.contains(name) else { return }
+    subscribers.append(subscriber)
+    registeredSubscribers.insert(name)
+    if registeredSubscribers.isSuperset(of: expectedSubscribers) {
+      for continuation in continuations {
+        continuation.resume()
+      }
+      continuations.removeAll()
+    }
+  }
+
+  func waitUntilAllRegistered() async {
+    if expectedSubscribers.isEmpty || registeredSubscribers.isSuperset(of: expectedSubscribers) {
+      return
+    }
+    // Note: If cancellation is required, use withTaskCancellationHandler and a throwing continuation.
+    await withCheckedContinuation { continuation in
+      continuations.append(continuation)
+    }
+  }
+
+  var currentSubscribers: [SessionsSubscriber] {
+    subscribers
+  }
+}

--- a/FirebaseSessions/Sources/SessionsState.swift
+++ b/FirebaseSessions/Sources/SessionsState.swift
@@ -1,5 +1,4 @@
-//
-// Copyright 2024-2026 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/FirebaseSessions/Sources/SessionsState.swift
+++ b/FirebaseSessions/Sources/SessionsState.swift
@@ -42,7 +42,8 @@ actor SessionsState {
     if expectedSubscribers.isEmpty || registeredSubscribers.isSuperset(of: expectedSubscribers) {
       return
     }
-    // Note: If cancellation is required, use withTaskCancellationHandler and a throwing continuation.
+    // Note: If cancellation is required, use withTaskCancellationHandler and a throwing
+    // continuation.
     await withCheckedContinuation { continuation in
       continuations.append(continuation)
     }

--- a/FirebaseSessions/Tests/Unit/FirebaseSessionsTests+BaseBehaviors.swift
+++ b/FirebaseSessions/Tests/Unit/FirebaseSessionsTests+BaseBehaviors.swift
@@ -24,8 +24,8 @@ import XCTest
 final class FirebaseSessionsTestsBase_BaseBehaviors: FirebaseSessionsTestsBase {
   // MARK: - Test Settings & Sampling
 
-  @MainActor func test_settingsDisabled_doesNotLogSessionEventButDoesFetchSettings() {
-    runSessionsSDK(
+  @MainActor func test_settingsDisabled_doesNotLogSessionEventButDoesFetchSettings() async {
+    await runSessionsSDK(
       subscriberSDKs: [
         mockPerformanceSubscriber,
 
@@ -49,8 +49,8 @@ final class FirebaseSessionsTestsBase_BaseBehaviors: FirebaseSessionsTestsBase {
     )
   }
 
-  @MainActor func test_sessionSampled_doesNotLogSessionEventButDoesFetchSettings() {
-    runSessionsSDK(
+  @MainActor func test_sessionSampled_doesNotLogSessionEventButDoesFetchSettings() async {
+    await runSessionsSDK(
       subscriberSDKs: [
         mockPerformanceSubscriber,
 
@@ -84,15 +84,15 @@ final class FirebaseSessionsTestsBase_BaseBehaviors: FirebaseSessionsTestsBase {
     // This test ensures that if we go into the background for longer than
     // the Session Timeout, we log another event when we come to the foreground.
     //
-    // We wanted to make sure that since we've introduced promises,
-    // once the promise has been fulfilled, that .then'ing on the promise
+    // We wanted to make sure that since we've introduced Swift Concurrency,
+    // once all expected subscribers have been registered, awaiting on the registration
     // in future initiations still results in a log
-    @MainActor func test_multipleInitiations_logsSessionEventEachInitiation() {
+    @MainActor func test_multipleInitiations_logsSessionEventEachInitiation() async {
       var loggedCount = 0
       var lastLoggedSessionID = ""
       let loggedTwiceExpectation = expectation(description: "Sessions SDK logged events twice")
 
-      runSessionsSDK(
+      await runSessionsSDK(
         subscriberSDKs: [
           mockPerformanceSubscriber,
 
@@ -138,7 +138,7 @@ final class FirebaseSessionsTestsBase_BaseBehaviors: FirebaseSessionsTestsBase {
         }
       )
 
-      wait(for: [loggedTwiceExpectation], timeout: 3)
+      await fulfillment(of: [loggedTwiceExpectation], timeout: 3)
 
       // Make sure we logged 2 events
       XCTAssertEqual(loggedCount, 2)

--- a/FirebaseSessions/Tests/Unit/FirebaseSessionsTests+DataCollection.swift
+++ b/FirebaseSessions/Tests/Unit/FirebaseSessionsTests+DataCollection.swift
@@ -81,18 +81,18 @@ final class FirebaseSessionsTestsBase_DataCollection: FirebaseSessionsTestsBase 
 
   // MARK: - Test Data Collection
 
-  @MainActor func test_subscriberWithDataCollectionEnabled_logsSessionEvent() {
-    runSessionsSDK(
+  @MainActor func test_subscriberWithDataCollectionEnabled_logsSessionEvent() async {
+    await runSessionsSDK(
       subscriberSDKs: [
         mockCrashlyticsSubscriber,
 
       ], preSessionsInit: { _ in
         // Nothing
       }, postSessionsInit: {
-        sessions.register(subscriber: self.mockCrashlyticsSubscriber)
-
         // Sessions hasn't logged yet because no Subscriber SDKs have registered
         XCTAssertNil(self.mockCoordinator.loggedEvent)
+
+        sessions.register(subscriber: self.mockCrashlyticsSubscriber)
 
       }, postLogEvent: { result, subscriberSDKs in
         // Make sure the SDK reported success, we logged an event and
@@ -105,8 +105,8 @@ final class FirebaseSessionsTestsBase_DataCollection: FirebaseSessionsTestsBase 
     )
   }
 
-  @MainActor func test_subscribersSomeDataCollectionDisabled_logsSessionEvent() {
-    runSessionsSDK(
+  @MainActor func test_subscribersSomeDataCollectionDisabled_logsSessionEvent() async {
+    await runSessionsSDK(
       subscriberSDKs: [
         mockCrashlyticsSubscriber,
         mockPerformanceSubscriber,
@@ -132,8 +132,8 @@ final class FirebaseSessionsTestsBase_DataCollection: FirebaseSessionsTestsBase 
     )
   }
 
-  @MainActor func test_subscribersAllDataCollectionDisabled_doesNotLogSessionEvent() {
-    runSessionsSDK(
+  @MainActor func test_subscribersAllDataCollectionDisabled_doesNotLogSessionEvent() async {
+    await runSessionsSDK(
       subscriberSDKs: [
         mockCrashlyticsSubscriber,
         mockPerformanceSubscriber,
@@ -159,8 +159,8 @@ final class FirebaseSessionsTestsBase_DataCollection: FirebaseSessionsTestsBase 
     )
   }
 
-  @MainActor func test_defaultSamplingRate_isSetInProto() {
-    runSessionsSDK(
+  @MainActor func test_defaultSamplingRate_isSetInProto() async {
+    await runSessionsSDK(
       subscriberSDKs: [
         mockCrashlyticsSubscriber,
 

--- a/FirebaseSessions/Tests/Unit/FirebaseSessionsTests+Subscribers.swift
+++ b/FirebaseSessions/Tests/Unit/FirebaseSessionsTests+Subscribers.swift
@@ -37,8 +37,8 @@ final class FirebaseSessionsTestsBase_Subscribers: FirebaseSessionsTestsBase {
 
   // MARK: - Test Subscriber Callbacks
 
-  @MainActor func test_registerSubscriber_callsOnSessionChanged() {
-    runSessionsSDK(
+  @MainActor func test_registerSubscriber_callsOnSessionChanged() async {
+    await runSessionsSDK(
       subscriberSDKs: [
         mockCrashlyticsSubscriber,
         mockPerformanceSubscriber,
@@ -61,8 +61,8 @@ final class FirebaseSessionsTestsBase_Subscribers: FirebaseSessionsTestsBase {
   // Make sure that even if the Sessions SDK is disabled, and data collection
   // is disabled, the Sessions SDK still generates Session IDs and provides
   // them to Subscribers
-  @MainActor func test_subscribersDataCollectionDisabled_callsOnSessionChanged() {
-    runSessionsSDK(
+  @MainActor func test_subscribersDataCollectionDisabled_callsOnSessionChanged() async {
+    await runSessionsSDK(
       subscriberSDKs: [
         mockCrashlyticsSubscriber,
         mockPerformanceSubscriber,
@@ -86,8 +86,8 @@ final class FirebaseSessionsTestsBase_Subscribers: FirebaseSessionsTestsBase {
     )
   }
 
-  @MainActor func test_noDependencies_doesNotLogSessionEvent() {
-    runSessionsSDK(
+  @MainActor func test_noDependencies_doesNotLogSessionEvent() async {
+    await runSessionsSDK(
       subscriberSDKs: [],
       preSessionsInit: { _ in
         // Nothing
@@ -102,8 +102,8 @@ final class FirebaseSessionsTestsBase_Subscribers: FirebaseSessionsTestsBase {
     )
   }
 
-  @MainActor func test_noSubscribersWithRegistrations_doesNotCrash() {
-    runSessionsSDK(
+  @MainActor func test_noSubscribersWithRegistrations_doesNotCrash() async {
+    await runSessionsSDK(
       subscriberSDKs: [],
       preSessionsInit: { _ in
         // Nothing

--- a/FirebaseSessions/Tests/Unit/Library/FirebaseSessionsTestsBase.swift
+++ b/FirebaseSessions/Tests/Unit/Library/FirebaseSessionsTestsBase.swift
@@ -73,11 +73,11 @@ class FirebaseSessionsTestsBase: XCTestCase {
   /// most assertions will happen.
   @MainActor func runSessionsSDK(subscriberSDKs: [SessionsSubscriber],
                                  preSessionsInit: (MockSettingsProtocol) -> Void,
-                                 postSessionsInit: () -> Void,
+                                 postSessionsInit: () async -> Void,
                                  postLogEvent: @escaping @MainActor (Result<Void,
                                    FirebaseSessionsError>,
                                  [SessionsSubscriber])
-                                   -> Void) {
+                                   -> Void) async {
     // This class is static, so we need to clear global state
     SessionsDependencies.removeAll()
 
@@ -110,9 +110,7 @@ class FirebaseSessionsTestsBase: XCTestCase {
                         coordinator: mockCoordinator,
                         initiator: initiator,
                         appInfo: mockAppInfo,
-                        settings: mockSettings,
-                        // Execute the callback on a higher priority queue to avoid test flakes.
-                        loggedEventCallbackQueue: .global(qos: .userInteractive)) { result in
+                        settings: mockSettings) { result in
       DispatchQueue.main.async {
         // Provide the result for tests to test against
         postLogEvent(result, subscriberSDKs)
@@ -124,11 +122,11 @@ class FirebaseSessionsTestsBase: XCTestCase {
 
     // Execute test cases after Sessions is initialized. This is a good
     // place register Subscriber SDKs
-    postSessionsInit()
+    await postSessionsInit()
 
     // Wait for the Sessions SDK to log the session before finishing
     // the test.
-    wait(for: [loggedEventExpectation], timeout: 3)
+    await fulfillment(of: [loggedEventExpectation], timeout: 3)
   }
 
   func assertSuccess(result: Result<Void, FirebaseSessionsError>) {

--- a/FirebaseSessions/Tests/Unit/SessionsStateTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionsStateTests.swift
@@ -1,5 +1,4 @@
-//
-// Copyright 2024-2026 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/FirebaseSessions/Tests/Unit/SessionsStateTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionsStateTests.swift
@@ -26,23 +26,23 @@ final class SessionsStateTests: XCTestCase {
 
   func test_waitUntilAllRegistered_waitsForDependencies() async {
     let state = SessionsState(expectedSubscribers: [.Crashlytics, .Performance])
-    
+
     let waitTask = Task {
       await state.waitUntilAllRegistered()
     }
-    
+
     // Simulate one dependency registering
     await state.register(subscriber: MockSubscriber(name: .Crashlytics), name: .Crashlytics)
-    
+
     // Ensure the task hasn't finished (it's still waiting)
     // We give it a tiny delay to ensure it didn't resume early.
     do {
       try await Task.sleep(nanoseconds: 100_000_000) // 100ms to reduce flakiness
     } catch {}
-    
+
     // Now complete the registration
     await state.register(subscriber: MockSubscriber(name: .Performance), name: .Performance)
-    
+
     // The wait task should now complete
     await waitTask.value
     XCTAssertTrue(true, "Completed after all dependencies registered")
@@ -51,11 +51,11 @@ final class SessionsStateTests: XCTestCase {
   func test_subsequentWaits_returnImmediately() async {
     let state = SessionsState(expectedSubscribers: [.Crashlytics])
     await state.register(subscriber: MockSubscriber(name: .Crashlytics), name: .Crashlytics)
-    
+
     // These should return immediately and not suspend indefinitely
     await state.waitUntilAllRegistered()
     await state.waitUntilAllRegistered()
-    
+
     XCTAssertTrue(true, "Subsequent waits returned immediately")
   }
 }

--- a/FirebaseSessions/Tests/Unit/SessionsStateTests.swift
+++ b/FirebaseSessions/Tests/Unit/SessionsStateTests.swift
@@ -1,0 +1,61 @@
+//
+// Copyright 2024-2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import FirebaseSessions
+
+final class SessionsStateTests: XCTestCase {
+  func test_emptyExpectedSubscribers_returnsImmediately() async {
+    let state = SessionsState(expectedSubscribers: [])
+    await state.waitUntilAllRegistered()
+    XCTAssertTrue(true, "Returned immediately as expected")
+  }
+
+  func test_waitUntilAllRegistered_waitsForDependencies() async {
+    let state = SessionsState(expectedSubscribers: [.Crashlytics, .Performance])
+    
+    let waitTask = Task {
+      await state.waitUntilAllRegistered()
+    }
+    
+    // Simulate one dependency registering
+    await state.register(subscriber: MockSubscriber(name: .Crashlytics), name: .Crashlytics)
+    
+    // Ensure the task hasn't finished (it's still waiting)
+    // We give it a tiny delay to ensure it didn't resume early.
+    do {
+      try await Task.sleep(nanoseconds: 100_000_000) // 100ms to reduce flakiness
+    } catch {}
+    
+    // Now complete the registration
+    await state.register(subscriber: MockSubscriber(name: .Performance), name: .Performance)
+    
+    // The wait task should now complete
+    await waitTask.value
+    XCTAssertTrue(true, "Completed after all dependencies registered")
+  }
+
+  func test_subsequentWaits_returnImmediately() async {
+    let state = SessionsState(expectedSubscribers: [.Crashlytics])
+    await state.register(subscriber: MockSubscriber(name: .Crashlytics), name: .Crashlytics)
+    
+    // These should return immediately and not suspend indefinitely
+    await state.waitUntilAllRegistered()
+    await state.waitUntilAllRegistered()
+    
+    XCTAssertTrue(true, "Subsequent waits returned immediately")
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1095,7 +1095,6 @@ func packageTargets() -> [Target] {
           // - https://github.com/firebase/firebase-ios-sdk/issues/15276
           // - https://github.com/firebase/firebase-ios-sdk/pull/15287
           .product(name: "nanopb", package: "nanopb"),
-          .product(name: "Promises", package: "Promises"),
           .product(name: "GoogleDataTransport", package: "GoogleDataTransport"),
           .product(name: "GULEnvironment", package: "GoogleUtilities"),
           .product(name: "GULUserDefaults", package: "GoogleUtilities"),


### PR DESCRIPTION
Note: This is non-breaking, but planned for Firebase 13.0 to prevent risk of introducing a regression in a final 12.x release.

### Summary
Replaces the `Promises` library dependency in `FirebaseSessions` with native Swift Concurrency.

### Key Changes
- **Actor State Management**: Replaced `FBLPromises` subscriber tracking in `FirebaseSessions` with a new internal `SessionsState` actor.
- **Dependency Removal**: Removed `Promises` from `Package.swift` and `FirebaseSessions.podspec`.
- **Test Modernization**: Updated `FirebaseSessions` unit test suite and base helpers to use `async/await` and added `SessionsStateTests`.

#no-changelog