### PR TITLE
Fix AppCheck concurrency infinite recursion bug in Auth

### DIFF
--- a/FirebaseAI/Sources/Types/Internal/AppCheck.swift
+++ b/FirebaseAI/Sources/Types/Internal/AppCheck.swift
@@ -27,7 +27,7 @@ extension AppCheckInterop {
   ///   - domain: A string dictating where this method is being called from. Used in any thrown
   ///     errors, to avoid hard-to-parse traces.
   func fetchAppCheckToken(limitedUse: Bool,
-                          domain: String) async throws -> FIRAppCheckTokenResultInterop {
+                          domain: String) async throws -> (token: String, error: Error?) {
     if limitedUse {
       if let token = await getLimitedUseTokenAsync() {
         return token
@@ -47,14 +47,18 @@ extension AppCheckInterop {
       #endif
     }
 
-    return await getToken(forcingRefresh: false)
+    return await withCheckedContinuation { continuation in
+      self.getToken(forcingRefresh: false) { result in
+        continuation.resume(returning: (token: result?.token ?? "", error: result?.error))
+      }
+    }
   }
 
   private func getLimitedUseTokenAsync() async
-    -> FIRAppCheckTokenResultInterop? {
+    -> (token: String, error: Error?)? {
     // At the moment, `await` doesn’t get along with Objective-C’s optional protocol methods.
     await withCheckedContinuation { (continuation: CheckedContinuation<
-      FIRAppCheckTokenResultInterop?,
+      (token: String, error: Error?)?,
       Never
     >) in
       guard
@@ -67,7 +71,7 @@ extension AppCheckInterop {
 
       limitedUseTokenClosure { tokenResult in
         // The placeholder token should be used in the case of App Check error.
-        continuation.resume(returning: tokenResult)
+        continuation.resume(returning: (token: tokenResult?.token ?? "", error: tokenResult?.error))
       }
     }
   }

--- a/FirebaseAI/Sources/Types/Internal/AppCheck.swift
+++ b/FirebaseAI/Sources/Types/Internal/AppCheck.swift
@@ -49,7 +49,7 @@ extension AppCheckInterop {
 
     return await withCheckedContinuation { continuation in
       self.getToken(forcingRefresh: false) { result in
-        continuation.resume(returning: (token: result?.token ?? "", error: result?.error))
+        continuation.resume(returning: (token: result.token, error: result.error))
       }
     }
   }
@@ -71,7 +71,7 @@ extension AppCheckInterop {
 
       limitedUseTokenClosure { tokenResult in
         // The placeholder token should be used in the case of App Check error.
-        continuation.resume(returning: (token: tokenResult?.token ?? "", error: tokenResult?.error))
+        continuation.resume(returning: (token: tokenResult.token, error: tokenResult.error))
       }
     }
   }

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
-- [fixed] Fixed a persistent crash when interacting with App Check under some Swift toolchains (like the Flutter SDK) by avoiding a compiler bug in Swift concurrency thunk generation. (#16549)
+- [fixed] Fixed a persistent crash when interacting with App Check under some
+  Swift toolchains (like the Flutter SDK) by avoiding a compiler bug in Swift
+  concurrency thunk generation. (#16549)
 - [fixed] Fixed an issue on iOS 15+ where users were randomly logged out during
   prewarming while the device was locked. (#16498)
 

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [fixed] Fixed a persistent crash when interacting with App Check under some Swift toolchains (like the Flutter SDK) by avoiding a compiler bug in Swift concurrency thunk generation. (#16549)
 - [fixed] Fixed an issue on iOS 15+ where users were randomly logged out during
   prewarming while the device was locked. (#16498)
 

--- a/FirebaseAuth/Sources/Swift/Auth/AppCheckInterop+FirebaseAuth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AppCheckInterop+FirebaseAuth.swift
@@ -1,0 +1,16 @@
+import Foundation
+#if SWIFT_PACKAGE
+  @preconcurrency import FirebaseAppCheckInterop
+#endif
+
+extension AppCheckInterop {
+  func getTokenResult(forcingRefresh: Bool) async -> (token: String, error: Error?) {
+    await withCheckedContinuation { continuation in
+      self.getToken(forcingRefresh: forcingRefresh) { result in
+        let token = result?.token ?? ""
+        let error = result?.error
+        continuation.resume(returning: (token, error))
+      }
+    }
+  }
+}

--- a/FirebaseAuth/Sources/Swift/Auth/AppCheckInterop+FirebaseAuth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AppCheckInterop+FirebaseAuth.swift
@@ -13,14 +13,15 @@
 // limitations under the License.
 
 import Foundation
+
 @preconcurrency import FirebaseAppCheckInterop
 
 extension AppCheckInterop {
   func getTokenResult(forcingRefresh: Bool) async -> (token: String, error: Error?) {
     await withCheckedContinuation { continuation in
       self.getToken(forcingRefresh: forcingRefresh) { result in
-        let token = result?.token ?? ""
-        let error = result?.error
+        let token = result.token
+        let error = result.error
         continuation.resume(returning: (token, error))
       }
     }

--- a/FirebaseAuth/Sources/Swift/Auth/AppCheckInterop+FirebaseAuth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AppCheckInterop+FirebaseAuth.swift
@@ -20,9 +20,7 @@ extension AppCheckInterop {
   func getTokenResult(forcingRefresh: Bool) async -> (token: String, error: Error?) {
     await withCheckedContinuation { continuation in
       self.getToken(forcingRefresh: forcingRefresh) { result in
-        let token = result.token
-        let error = result.error
-        continuation.resume(returning: (token, error))
+        continuation.resume(returning: (token: result.token, error: result.error))
       }
     }
   }

--- a/FirebaseAuth/Sources/Swift/Auth/AppCheckInterop+FirebaseAuth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AppCheckInterop+FirebaseAuth.swift
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 import Foundation
-#if SWIFT_PACKAGE
-  @preconcurrency import FirebaseAppCheckInterop
-#endif
+@preconcurrency import FirebaseAppCheckInterop
 
 extension AppCheckInterop {
   func getTokenResult(forcingRefresh: Bool) async -> (token: String, error: Error?) {

--- a/FirebaseAuth/Sources/Swift/Auth/AppCheckInterop+FirebaseAuth.swift
+++ b/FirebaseAuth/Sources/Swift/Auth/AppCheckInterop+FirebaseAuth.swift
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import Foundation
 #if SWIFT_PACKAGE
   @preconcurrency import FirebaseAppCheckInterop

--- a/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift
@@ -435,7 +435,7 @@ import Foundation
     }
 
     if let appCheck {
-      let tokenResult = await appCheck.getToken(forcingRefresh: false)
+      let tokenResult = await appCheck.getTokenResult(forcingRefresh: false)
       if let error = tokenResult.error {
         AuthLog.logWarning(code: "I-AUT000018",
                            message: "Error getting App Check token; using placeholder " +

--- a/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
+++ b/FirebaseAuth/Sources/Swift/AuthProvider/PhoneAuthProvider.swift
@@ -641,7 +641,7 @@ import Foundation
       components?.queryItems = queryItems
 
       if let appCheck {
-        let tokenResult = await appCheck.getToken(forcingRefresh: false)
+        let tokenResult = await appCheck.getTokenResult(forcingRefresh: false)
         if let error = tokenResult.error {
           AuthLog.logWarning(code: "I-AUT000018",
                              message: "Error getting App Check token; using placeholder " +

--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
@@ -70,7 +70,7 @@ final class AuthBackend: AuthBackendProtocol {
       await requestConfiguration.heartbeatLogger?.asyncHeaderValue()
     }
     let appCheckTokenHeaderValue = Task {
-      await requestConfiguration.appCheck?.getToken(forcingRefresh: false)
+      await requestConfiguration.appCheck?.getTokenResult(forcingRefresh: false)
     }
 
     return await withTaskCancellationHandler {

--- a/FirebaseFunctions/Sources/Internal/FunctionsContext.swift
+++ b/FirebaseFunctions/Sources/Internal/FunctionsContext.swift
@@ -66,12 +66,13 @@ struct FunctionsContextProvider: Sendable {
   }
 
   private func getAppCheckToken(options: HTTPSCallableOptions?) async -> String? {
-    guard
-      options?.requireLimitedUseAppCheckTokens != true,
-      let tokenResult = await appCheck?.getToken(forcingRefresh: false)
-    else { return nil }
-    // The placeholder token should be used in the case of App Check error.
-    return tokenResult.token
+    guard options?.requireLimitedUseAppCheckTokens != true, let appCheck else { return nil }
+
+    return await withCheckedContinuation { continuation in
+      appCheck.getToken(forcingRefresh: false) { result in
+        continuation.resume(returning: result.token)
+      }
+    }
   }
 
   private func getLimitedUseAppCheckToken(options: HTTPSCallableOptions?) async -> String? {


### PR DESCRIPTION
Resolves #16549.

### Description
This PR addresses an infinite recursion crash (yielding `EXC_BREAKPOINT` / `SIGTRAP` inside `_assertionFailure`) that happens in `FirebaseAuth`, `FirebaseAI`, and `FirebaseFunctions` when bridging `AppCheckInterop` into Swift concurrency.

The root cause of the crash is a known bug in Swift concurrency (particularly manifesting on older deployments or in some toolchains, like the Flutter iOS build environment) regarding generic reabstraction thunks.
When the compiler attempts to automatically synthesize the `async` counterpart for the Objective-C protocol method `getToken(forcingRefresh:completion:)`, or when the return type of a `Task` / `withCheckedContinuation` generic contains the protocol existential `FIRAppCheckTokenResultInterop?`, it produces a faulty reabstraction thunk (`partial apply forwarder for generic not re-abstracted specialization <__C.FIRAppCheckTokenResultInterop?>...`). This thunk infinitely loops on itself when the continuation resumes.

Because the old code invoked the auto-bridged `await appCheck.getToken(forcingRefresh:)` directly, this buggy generic thunk was inevitably linked into the local `Task` or async state machine.

### The Fix
To completely avoid the compiler bug, we must prevent the existential protocol object from ever crossing an `async/await` boundary. 

This PR updates the internal implementations across `FirebaseAuth`, `FirebaseAI`, and `FirebaseFunctions` to use `withCheckedContinuation` wrapping the raw block-based `getToken(forcingRefresh:completion:)` selector. Inside the completion block, we extract the concrete native Swift types (`token` as `String` and `error` as `Error?`) and resume the continuation with a tuple `(String, Error?)` (or just `String?`). 

Since `String` and `Error?` are native concrete `Sendable` types, the async state machine is fully decoupled from the Objective-C protocol existential, bypassing the compiler's buggy thunk generation entirely.