### PR TITLE
Update logic for swizzling NSProxy's to exclude weak instance variables.

### DIFF
--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -64,7 +64,7 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
   s.dependency 'FirebaseSessions', '~> 12.19.0'
   s.dependency 'GoogleDataTransport', '~> 10.1'
   s.dependency 'GoogleUtilities/Environment', '~> 8.1'
-  s.dependency 'GoogleUtilities/MethodSwizzler', '~> 8.1'
+  s.dependency 'GoogleUtilities/MethodSwizzler', '~> 8.1.3'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 8.1'
   s.dependency 'nanopb', '~> 3.30910.0'
 

--- a/FirebasePerformance/CHANGELOG.md
+++ b/FirebasePerformance/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [fixed] Revert to using `kFPRSlowFrameThreshold` for slow frames on iOS to prevent
   falsely classifying 60 FPS frames as slow on ProMotion devices,
   while preserving dynamic frame rate support for tvOS.
+- [fixed] Fixed a crash caused due to ISA swizzling weak ivars. (#16469)
 
 # 12.16.0
 - [fixed] Fixed a crash in `FPRMemoryGaugeCollector` by collecting memory usage

--- a/FirebasePerformance/Sources/Instrumentation/FPRProxyObjectHelper.m
+++ b/FirebasePerformance/Sources/Instrumentation/FPRProxyObjectHelper.m
@@ -14,39 +14,14 @@
 
 #import "FirebasePerformance/Sources/Instrumentation/FPRProxyObjectHelper.h"
 
-#import <objc/runtime.h>
-#import <string.h>
-
-FOUNDATION_STATIC_INLINE NSArray<id> *FPRIvarObjectsForProxy(id proxy) {
-  NSMutableArray<id> *array = [NSMutableArray array];
-  // NSProxy subclasses can forward -class to a wrapped object, so use the runtime class.
-  Class currentClass = object_getClass(proxy);
-  while (currentClass && currentClass != [NSProxy class]) {
-    unsigned int count = 0;
-    Ivar *ivars = class_copyIvarList(currentClass, &count);
-    if (ivars) {
-      for (NSUInteger i = 0; i < count; i++) {
-        const char *typeEncoding = ivar_getTypeEncoding(ivars[i]);
-        if (typeEncoding && strncmp(typeEncoding, "@", 1) == 0) {
-          id ivarObject = object_getIvar(proxy, ivars[i]);
-          if (ivarObject) {
-            [array addObject:ivarObject];
-          }
-        }
-      }
-      free(ivars);
-    }
-    currentClass = class_getSuperclass(currentClass);
-  }
-  return array;
-}
+#import <GoogleUtilities/GULSwizzler.h>
 
 @implementation FPRProxyObjectHelper
 
 + (void)registerProxyObject:(id)proxy
               forSuperclass:(Class)superclass
             varFoundHandler:(void (^)(id ivar))varFoundHandler {
-  NSArray<id> *ivars = FPRIvarObjectsForProxy(proxy);
+  NSArray<id> *ivars = [GULSwizzler ivarObjectsForObject:proxy];
   for (id ivar in ivars) {
     if ([ivar isKindOfClass:superclass]) {
       varFoundHandler(ivar);
@@ -57,7 +32,7 @@ FOUNDATION_STATIC_INLINE NSArray<id> *FPRIvarObjectsForProxy(id proxy) {
 + (void)registerProxyObject:(id)proxy
                 forProtocol:(Protocol *)protocol
             varFoundHandler:(void (^)(id ivar))varFoundHandler {
-  NSArray *ivars = FPRIvarObjectsForProxy(proxy);
+  NSArray *ivars = [GULSwizzler ivarObjectsForObject:proxy];
   for (id ivar in ivars) {
     if ([ivar conformsToProtocol:protocol]) {
       varFoundHandler(ivar);

--- a/FirebasePerformance/Tests/Unit/Instruments/FPRNSURLSessionInstrumentTest.m
+++ b/FirebasePerformance/Tests/Unit/Instruments/FPRNSURLSessionInstrumentTest.m
@@ -84,6 +84,10 @@
   return self;
 }
 
+- (Class)class {
+  return [self.delegate class];
+}
+
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)selector {
   return [_delegate methodSignatureForSelector:selector];
 }
@@ -102,13 +106,39 @@
 
 @end
 
-@interface FPRNSURLSessionDelegateClassReportingProxy : FPRNSURLSessionDelegateProxy
+@interface FPRNSURLSessionDelegateWeakProxy : NSProxy {
+  // The wrapped delegate object.
+  __weak id _delegate;
+}
+
+/** @return an instance of the delegate proxy. */
+- (instancetype)initWithDelegate:(id)delegate;
+
 @end
 
-@implementation FPRNSURLSessionDelegateClassReportingProxy
+@implementation FPRNSURLSessionDelegateWeakProxy
+
+- (instancetype)initWithDelegate:(id)delegate {
+  if (self) {
+    _delegate = delegate;
+  }
+  return self;
+}
 
 - (Class)class {
-  return [[self delegate] class];
+  return [self->_delegate class];
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)selector {
+  return [_delegate methodSignatureForSelector:selector];
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector {
+  return [_delegate respondsToSelector:aSelector];
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation {
+  [invocation invokeWithTarget:_delegate];
 }
 
 @end
@@ -650,20 +680,20 @@
   [instrument deregisterInstrumentors];
 }
 
-/** Tests that proxy delegate lookup uses the proxy's runtime class instead of -class. */
-- (void)testProxyDelegateUsesRuntimeClassWhenProxyReportsWrappedDelegateClass {
-  FPRNSURLSessionTestDelegate *delegate = [[FPRNSURLSessionTestDelegate alloc] init];
-  FPRNSURLSessionDelegateClassReportingProxy *proxyDelegate =
-      [[FPRNSURLSessionDelegateClassReportingProxy alloc] initWithDelegate:delegate];
+/** Tests that the delegate class is not instrumented in an NSProxy if it is weak. */
+- (void)testWeakProxyDelegateSkipsSwizzlingDelegate {
   FPRNSURLSessionInstrument *instrument = [[FPRNSURLSessionInstrument alloc] init];
   [instrument registerInstrumentors];
+  FPRNSURLSessionCompleteTestDelegate *delegate =
+      [[FPRNSURLSessionCompleteTestDelegate alloc] init];
+  FPRNSURLSessionDelegateWeakProxy *proxyDelegate =
+      [[FPRNSURLSessionDelegateWeakProxy alloc] initWithDelegate:delegate];
   NSURLSessionConfiguration *configuration =
       [NSURLSessionConfiguration defaultSessionConfiguration];
-  XCTAssertFalse([delegate respondsToSelector:@selector(URLSession:task:didCompleteWithError:)]);
-  XCTAssertNoThrow([NSURLSession sessionWithConfiguration:configuration
-                                                 delegate:proxyDelegate
-                                            delegateQueue:nil]);
-  XCTAssertTrue([delegate respondsToSelector:@selector(URLSession:task:didCompleteWithError:)]);
+  [NSURLSession sessionWithConfiguration:configuration delegate:proxyDelegate delegateQueue:nil];
+  [NSURLSession sessionWithConfiguration:configuration delegate:proxyDelegate delegateQueue:nil];
+  XCTAssertEqual(instrument.delegateInstrument.classInstrumentors.count, 0);
+  XCTAssertEqual(instrument.delegateInstrument.instrumentedClasses.count, 0);
   [instrument deregisterInstrumentors];
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -164,7 +164,7 @@ func packageDependencies() -> [Package.Dependency] {
       ),
       .package(
         url: "https://github.com/google/GoogleUtilities.git",
-        "8.1.0" ..< "9.0.0"
+        "8.1.3" ..< "9.0.0"
       ),
       .package(
         url: "https://github.com/google/gtm-session-fetcher.git",


### PR DESCRIPTION
Updates the logic where NSProxys are swizzled to revert back to using https://github.com/google/GoogleUtilities/pull/244.

Also updates unit tests.

Fixes https://github.com/firebase/firebase-ios-sdk/issues/16469