### PR TITLE
Disable FirebaseMLModelDownloader integration tests

### DIFF
--- a/FirebaseMLModelDownloader/Tests/Integration/ModelDownloaderIntegrationTests.swift
+++ b/FirebaseMLModelDownloader/Tests/Integration/ModelDownloaderIntegrationTests.swift
@@ -59,7 +59,11 @@
       FirebaseConfiguration.shared.setLoggerLevel(.debug)
     }
 
-    override func setUp() {
+    override func setUpWithError() throws {
+      try super.setUpWithError()
+      try XCTSkipIf(
+        true, "Skipping integration test due to backend deprecation and rate limiting."
+      )
       do {
         try ModelFileManager.emptyModelsDirectory()
       } catch {


### PR DESCRIPTION
Disabled `FirebaseMLModelDownloader` integration tests to prevent CI failures due to backend rate limits (`resourceExhausted`).
These tests are being removed soon anyway as the SDK is deprecated. We skip all tests inside `ModelDownloaderIntegrationTests` by overriding `setUpWithError() throws` and executing `try XCTSkipIf(true)`.

---
*PR created automatically by Jules for task [3482348680207691816](https://jules.google.com/task/3482348680207691816) started by @ncooke3*