### PR TITLE
bound compressed encoding index in compact unwind lookup

### DIFF
--- a/Crashlytics/Crashlytics/Unwind/Compact/FIRCLSCompactUnwind.c
+++ b/Crashlytics/Crashlytics/Unwind/Compact/FIRCLSCompactUnwind.c
@@ -274,6 +274,11 @@ bool FIRCLSCompactUnwindLookupSecondLevelCompressed(FIRCLSCompactUnwindContext* 
   } else {
     encodingIndex = encodingIndex - context->unwindHeader.commonEncodingsArrayCount;
 
+    if (encodingIndex >= header->encodingsCount) {
+      FIRCLSSDKLog("Error: compressed encoding index out of range\n");
+      return false;
+    }
+
     compact_unwind_encoding_t* encodings = ptr + header->encodingsPageOffset;
 
     result->encoding = encodings[encodingIndex];


### PR DESCRIPTION
FIRCLSCompactUnwindLookupSecondLevelCompressed reads the encoding index from the high byte of a compressed second-level entry, and the common-encodings branch bounds that index against commonEncodingsArrayCount while the page-local branch indexes encodings[] with no check, so a corrupt or crafted __unwind_info page whose index exceeds the page's encodingsCount reads past the encodings array during crash-time unwinding. Add the encodingsCount bound before the read, matching the check already applied a few lines above.