### PR TITLE
Migrate deprecated ABSL_ATTRIBUTE_NORETURN to C++11 [[noreturn]]

### DIFF
--- a/.github/workflows/sdk.firestore.yml
+++ b/.github/workflows/sdk.firestore.yml
@@ -344,7 +344,7 @@ jobs:
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     runs-on: macos-26
-    timeout-minutes: 90
+    timeout-minutes: 35
 
     strategy:
       matrix:
@@ -388,7 +388,7 @@ jobs:
         run: scripts/install_prereqs.sh Firestore ${{ matrix.target }} xcodebuild
 
       # XCTest dynamically isolates the test runner app from standard terminal environment variables.
-      # To successfully pass TARGET_BACKEND down to FSTIntegrationTestCase, we must physically inject it
+      # To successfully pass TARGET_BACKEND and PROJECT_ID down to FSTIntegrationTestCase, we must physically inject them
       # into the Xcode Schemes rather than using traditional YAML `env:` variables or `export` commands.
       - name: Inject Nightly Backend into Schemes
         run: |
@@ -396,14 +396,24 @@ jobs:
           import glob, re
           for f in glob.glob("Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_IntegrationTests_*.xcscheme"):
               with open(f, "r") as file: content = file.read()
-              content = re.sub(r"<EnvironmentVariables>", "<EnvironmentVariables>\n         <EnvironmentVariable\n            key = \"TARGET_BACKEND\"\n            value = \"nightly\"\n            isEnabled = \"YES\">\n         </EnvironmentVariable>", content)
+              content = re.sub(r"<EnvironmentVariables>", """<EnvironmentVariables>
+                   <EnvironmentVariable
+                      key = "TARGET_BACKEND"
+                      value = "nightly"
+                      isEnabled = "YES">
+                   </EnvironmentVariable>
+                   <EnvironmentVariable
+                      key = "PROJECT_ID"
+                      value = "firestore-sdk-nightly"
+                      isEnabled = "YES">
+                   </EnvironmentVariable>""", content)
               with open(f, "w") as file: file.write(content)
           '
 
       - name: Build
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
-          timeout_minutes: 60
+          timeout_minutes: 30
           command: scripts/build.sh ${{ matrix.scheme }} ${{ matrix.target }} xcodebuild
 
       - name: Test

--- a/.github/workflows/sdk.firestore.yml
+++ b/.github/workflows/sdk.firestore.yml
@@ -344,7 +344,7 @@ jobs:
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     runs-on: macos-26
-    timeout-minutes: 35
+    timeout-minutes: 60
 
     strategy:
       matrix:
@@ -413,7 +413,7 @@ jobs:
       - name: Build
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
-          timeout_minutes: 30
+          timeout_minutes: 60
           command: scripts/build.sh ${{ matrix.scheme }} ${{ matrix.target }} xcodebuild
 
       - name: Test

--- a/.github/workflows/sdk.firestore.yml
+++ b/.github/workflows/sdk.firestore.yml
@@ -344,6 +344,7 @@ jobs:
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     runs-on: macos-26
+    timeout-minutes: 90
 
     strategy:
       matrix:

--- a/Firestore/core/src/util/exception.cc
+++ b/Firestore/core/src/util/exception.cc
@@ -41,11 +41,11 @@ const char* ExceptionName(ExceptionType exception) {
   UNREACHABLE();
 }
 
-ABSL_ATTRIBUTE_NORETURN void DefaultThrowHandler(ExceptionType type,
-                                                 const char* file,
-                                                 const char* func,
-                                                 int line,
-                                                 const std::string& message) {
+[[noreturn]] void DefaultThrowHandler(ExceptionType type,
+                                      const char* file,
+                                      const char* func,
+                                      int line,
+                                      const std::string& message) {
   std::string what = absl::StrCat(ExceptionName(type), ": ");
   if (file && func) {
     absl::StrAppend(&what, file, "(", line, ") ", func, ": ");
@@ -85,11 +85,11 @@ ThrowHandler SetThrowHandler(ThrowHandler handler) {
   return previous;
 }
 
-ABSL_ATTRIBUTE_NORETURN void Throw(ExceptionType exception,
-                                   const char* file,
-                                   const char* func,
-                                   int line,
-                                   const std::string& message) {
+[[noreturn]] void Throw(ExceptionType exception,
+                        const char* file,
+                        const char* func,
+                        int line,
+                        const std::string& message) {
   throw_handler(exception, file, func, line, message);
 
   // It's expected that the throw handler above does not return. If it does,

--- a/Firestore/core/src/util/exception.h
+++ b/Firestore/core/src/util/exception.h
@@ -88,8 +88,7 @@ ThrowHandler SetThrowHandler(ThrowHandler handler);
  * structure, like a query.
  */
 template <typename... FA>
-[[noreturn]] void ThrowInvalidArgument(const char* format,
-                                       const FA&... args) {
+[[noreturn]] void ThrowInvalidArgument(const char* format, const FA&... args) {
   Throw(ExceptionType::InvalidArgument, nullptr, nullptr, 0,
         StringFormat(format, args...));
 }
@@ -104,8 +103,7 @@ template <typename... FA>
  * haven't done anything yet should likely just stick to ThrowInvalidArgument.
  */
 template <typename... FA>
-[[noreturn]] void ThrowIllegalState(const char* format,
-                                    const FA&... args) {
+[[noreturn]] void ThrowIllegalState(const char* format, const FA&... args) {
   Throw(ExceptionType::IllegalState, nullptr, nullptr, 0,
         StringFormat(format, args...));
 }

--- a/Firestore/core/src/util/exception.h
+++ b/Firestore/core/src/util/exception.h
@@ -37,7 +37,6 @@
 
 #include "Firestore/core/include/firebase/firestore/firestore_errors.h"
 #include "Firestore/core/src/util/string_format.h"
-#include "absl/base/attributes.h"
 
 namespace firebase {
 namespace firestore {
@@ -75,11 +74,11 @@ using ThrowHandler = void (*)(ExceptionType type,
  */
 ThrowHandler SetThrowHandler(ThrowHandler handler);
 
-ABSL_ATTRIBUTE_NORETURN void Throw(ExceptionType type,
-                                   const char* file,
-                                   const char* func,
-                                   int line,
-                                   const std::string& message);
+[[noreturn]] void Throw(ExceptionType type,
+                        const char* file,
+                        const char* func,
+                        int line,
+                        const std::string& message);
 
 /**
  * Throws an exception indicating that the user passed an invalid argument.
@@ -89,8 +88,8 @@ ABSL_ATTRIBUTE_NORETURN void Throw(ExceptionType type,
  * structure, like a query.
  */
 template <typename... FA>
-ABSL_ATTRIBUTE_NORETURN void ThrowInvalidArgument(const char* format,
-                                                  const FA&... args) {
+[[noreturn]] void ThrowInvalidArgument(const char* format,
+                                       const FA&... args) {
   Throw(ExceptionType::InvalidArgument, nullptr, nullptr, 0,
         StringFormat(format, args...));
 }
@@ -105,8 +104,8 @@ ABSL_ATTRIBUTE_NORETURN void ThrowInvalidArgument(const char* format,
  * haven't done anything yet should likely just stick to ThrowInvalidArgument.
  */
 template <typename... FA>
-ABSL_ATTRIBUTE_NORETURN void ThrowIllegalState(const char* format,
-                                               const FA&... args) {
+[[noreturn]] void ThrowIllegalState(const char* format,
+                                    const FA&... args) {
   Throw(ExceptionType::IllegalState, nullptr, nullptr, 0,
         StringFormat(format, args...));
 }

--- a/Firestore/core/src/util/exception_apple.h
+++ b/Firestore/core/src/util/exception_apple.h
@@ -20,7 +20,6 @@
 #include <string>
 
 #include "Firestore/core/src/util/exception.h"
-#include "absl/base/attributes.h"
 
 namespace firebase {
 namespace firestore {
@@ -29,11 +28,11 @@ namespace util {
 /**
  * Default throw handler for ObjC/Swift. Typically shouldn't be used directly.
  */
-ABSL_ATTRIBUTE_NORETURN void ObjcThrowHandler(ExceptionType type,
-                                              const char* file,
-                                              const char* func,
-                                              int line,
-                                              const std::string& message);
+[[noreturn]] void ObjcThrowHandler(ExceptionType type,
+                                   const char* file,
+                                   const char* func,
+                                   int line,
+                                   const std::string& message);
 
 }  // namespace util
 }  // namespace firestore

--- a/Firestore/core/src/util/exception_apple.mm
+++ b/Firestore/core/src/util/exception_apple.mm
@@ -50,11 +50,11 @@ NSException* MakeException(ExceptionType type, const std::string& message) {
 
 }  // namespace
 
-ABSL_ATTRIBUTE_NORETURN void ObjcThrowHandler(ExceptionType type,
-                                              const char* file,
-                                              const char* func,
-                                              int line,
-                                              const std::string& message) {
+[[noreturn]] void ObjcThrowHandler(ExceptionType type,
+                                   const char* file,
+                                   const char* func,
+                                   int line,
+                                   const std::string& message) {
   if (type == ExceptionType::AssertionFailure) {
     [[NSAssertionHandler currentHandler]
         handleFailureInFunction:MakeNSString(func)

--- a/Firestore/core/src/util/hard_assert.h
+++ b/Firestore/core/src/util/hard_assert.h
@@ -105,16 +105,16 @@ namespace util {
 namespace internal {
 
 // A no-return helper function. To raise an assertion, use Macro instead.
-ABSL_ATTRIBUTE_NORETURN void FailAssertion(const char* file,
-                                           const char* func,
-                                           int line,
-                                           const std::string& message);
+[[noreturn]] void FailAssertion(const char* file,
+                                const char* func,
+                                int line,
+                                const std::string& message);
 
-ABSL_ATTRIBUTE_NORETURN void FailAssertion(const char* file,
-                                           const char* func,
-                                           int line,
-                                           const std::string& message,
-                                           const char* condition);
+[[noreturn]] void FailAssertion(const char* file,
+                                const char* func,
+                                int line,
+                                const std::string& message,
+                                const char* condition);
 
 }  // namespace internal
 }  // namespace util

--- a/Firestore/core/src/util/statusor_internals.h
+++ b/Firestore/core/src/util/statusor_internals.h
@@ -20,7 +20,6 @@
 #include <utility>
 
 #include "Firestore/core/src/util/status.h"
-#include "absl/base/attributes.h"
 
 namespace firebase {
 namespace firestore {
@@ -31,7 +30,7 @@ class Helper {
  public:
   // Move type-agnostic error handling to the .cc.
   static void HandleInvalidStatusCtorArg(Status*);
-  ABSL_ATTRIBUTE_NORETURN static void Crash(const Status& status);
+  [[noreturn]] static void Crash(const Status& status);
 };
 
 // Construct an instance of T in `p` through placement new, passing Args... to


### PR DESCRIPTION
#no-changelog
Migrate deprecated `ABSL_ATTRIBUTE_NORETURN` macro usages in Firestore to the standard C++11 `[[noreturn]]` attribute. Additionally, removes now-unused `#include "absl/base/attributes.h"` includes where applicable.
