### PR TITLE
fix(ml): missing import causing build error

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fixed an issue with a transitive import in the logger, which could cause
+  a build error in explicit module mode. (#16563)
+
 # 12.18.0
 - [removed] Removed deprecated Imagen methods and types due to Imagen models being shut down in
   August 2026. As a replacement, you can [migrate your apps to use Gemini Image models (the

--- a/FirebaseAI/Sources/AILog.swift
+++ b/FirebaseAI/Sources/AILog.swift
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import FirebaseCore
+internal import FirebaseCoreExtension
 import Foundation
 import os.log
-
-internal import FirebaseCoreExtension
 
 enum AILog {
   /// Log message codes for the Firebase AI SDK

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 - [fixed] Fixed an issue on iOS 15+ where users were randomly logged out during
   prewarming while the device was locked. (#16498)
+- [fixed] Fixed an issue with a transitive import in the logger, which could cause
+  a build error in explicit module mode. (#16563)
 
 # 12.18.0
 - [fixed] Fixed a bug in `PhoneAuthProvider` where the test mode logic would

--- a/FirebaseAuth/Sources/Swift/Utilities/AuthLog.swift
+++ b/FirebaseAuth/Sources/Swift/Utilities/AuthLog.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import FirebaseCore
 import FirebaseCoreExtension
 import Foundation
 

--- a/FirebaseMLModelDownloader/CHANGELOG.md
+++ b/FirebaseMLModelDownloader/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [fixed] Fixed an issue with a transitive import in the device logger, which could cause
-  a build error in explicit module mode.
+  a build error in explicit module mode. (#16563)
 
 # 12.17.0
 - [deprecated] Firebase ML is deprecated and will be shut down on June 15, 2027.

--- a/FirebaseMLModelDownloader/CHANGELOG.md
+++ b/FirebaseMLModelDownloader/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fixed an issue with a transitive import in the device logger, which could cause
+  a build error in explicit module mode.
+
 # 12.17.0
 - [deprecated] Firebase ML is deprecated and will be shut down on June 15, 2027.
   To host custom models, you must migrate to another solution. You can use Cloud

--- a/FirebaseMLModelDownloader/Sources/DeviceLogger.swift
+++ b/FirebaseMLModelDownloader/Sources/DeviceLogger.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 
+import FirebaseCore
 internal import FirebaseCoreExtension
 
 /// Enum of log messages.

--- a/FirebaseSessions/Sources/FirebaseSessions.swift
+++ b/FirebaseSessions/Sources/FirebaseSessions.swift
@@ -15,6 +15,7 @@
 import Foundation
 
 // Avoids exposing internal FirebaseCore APIs to Swift users.
+internal import FirebaseCore
 internal import FirebaseCoreExtension
 internal import FirebaseInstallations
 internal import GoogleDataTransport

--- a/FirebaseSessions/Sources/Logger.swift
+++ b/FirebaseSessions/Sources/Logger.swift
@@ -15,6 +15,7 @@
 
 import Foundation
 
+internal import FirebaseCore
 internal import FirebaseCoreExtension
 
 ///


### PR DESCRIPTION
Per [b/553008134](https://buganizer.corp.google.com/issues/553008134),

This fixes an issue where `DeviceLogger.swift` could cause a build error when building with [explicitly built modules](https://developer.apple.com/documentation/xcode/building-your-project-with-explicit-module-dependencies).

More specifically, `FirebaseMLDowwnloader` has a `DeviceLogger.swift` file which uses the `FirebaseLoggerLevel` from `FirebaseCore`, but it only has an import for the extension library (`FirebaseCoreExtension`).

Basically, it's relying on the extension library to transitivity import `FirebaseCore`. In most cases, this is true, and doesn't cause an issue. But in certain environments (eg; explicit module mode), this can cause an error during build time:
```swift
error: cannot find type 'FirebaseLoggerLevel' in scope
  static func logEvent(level: FirebaseLoggerLevel, message: String,
```

Instead, `DeviceLogger.swift` should explicitly import `FirebaseCore`; which this PR fixes.


This issue is also present across a couple other locations (auth, sessions, and ai logic), which this PR fixes as well.