### PR TITLE
fix(appcheck): build failure with unguarded provider

### DIFF
--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [fixed] Fixed an issue where the Recaptcha provider could cause build
-  errors in binary environments, due to unsupported platforms.
+  errors in binary environments, due to unsupported platforms. (#16564)
 
 # 12.18.0
 - [fixed] Safely disable the reCAPTCHA provider when its Swift dependencies

--- a/FirebaseAppCheck/CHANGELOG.md
+++ b/FirebaseAppCheck/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fixed an issue where the Recaptcha provider could cause build
+  errors in binary environments, due to unsupported platforms.
+
 # 12.18.0
 - [fixed] Safely disable the reCAPTCHA provider when its Swift dependencies
   cannot be resolved to prevent `unknown receiver` build failures that

--- a/FirebaseAppCheck/Sources/RecaptchaProvider/FIRRecaptchaProvider.m
+++ b/FirebaseAppCheck/Sources/RecaptchaProvider/FIRRecaptchaProvider.m
@@ -20,7 +20,11 @@
 #import <AppCheckCore/AppCheckCore.h>
 
 #if SWIFT_PACKAGE
+#if (TARGET_OS_IOS && !TARGET_OS_MACCATALYST) || TARGET_OS_VISION
 @import AppCheckRecaptchaProvider;
+#else
+#define FIR_RECAPTCHA_PROVIDER_SWIFT_AVAILABLE 0
+#endif
 #elif __has_include(<AppCheckCore/AppCheckCore-Swift.h>)
 #import <AppCheckCore/AppCheckCore-Swift.h>
 #elif __has_include("AppCheckCore-Swift.h")

--- a/scripts/check_imports.swift
+++ b/scripts/check_imports.swift
@@ -159,6 +159,9 @@ private func checkFile(_ file: String, logger: ErrorLogger, inRepo repoURL: URL,
           // Non-public header imports should be repo-relative paths. Unqualified imports are
           // allowed in private headers.
           if !isPrivate || importFile.contains("/") {
+            if importFileRaw.hasSuffix("-Swift.h") {
+              continue nextLine
+            }
             for skip in skipImportPatterns {
               if importFileRaw.starts(with: skip) {
                 continue nextLine


### PR DESCRIPTION
Per [b/553016929](https://buganizer.corp.google.com/issues/553016929),

This fixes an issue where app check could cause a build error in certain binary distributions. More specifically, `AppCheckRecaptchaProvider` is only available on iOS and visionOS. But the import in `FIRRecaptchaProvider` is not guarded for these platforms. The only thing it _is_ guarded on is a `SWIFT_PACKAGE=1` environment. In a normal SPM environment, this doesn't cause any issues, as SPM builds every target in the package for all platforms, even if they're unavailable.

Although, the binary distribution for the actual underlying (closed-source) recaptcha sdk is built only for iOS/visionOS. So in binary environments, when targeting other platforms, this can cause errors during build time; as it doesn't build every target for all platforms like SPM does.

To fix this, the import in `FIRRecaptchaProvider` should be guarded on the target being iOS or visionOS, like its usages currently are; which this PR does.

This PR also fixes an issue where `check_imports.swift` was attempting to validate the generated Swift headers (`-Swift.h`), which could cause issues as they're generated dynamically.