### PR TITLE
fix undefined 32-bit shift in dwarf LEB128 decoding

### DIFF
--- a/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDataParsing.c
+++ b/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDataParsing.c
@@ -98,7 +98,7 @@ uint64_t FIRCLSParseULEB128AndAdvance(const void** cursor) {
 
     *cursor += 1;
 
-    result |= ((0x7F & byte) << shift);
+    result |= ((uint64_t)(0x7F & byte) << shift);
     if ((0x80 & byte) == 0) {
       break;
     }
@@ -120,7 +120,7 @@ int64_t FIRCLSParseLEB128AndAdvance(const void** cursor) {
 
     *cursor += 1;
 
-    result |= ((0x7F & byte) << shift);
+    result |= ((uint64_t)(0x7F & byte) << shift);
     shift += 7;
 
     /* sign bit of byte is second high order bit (0x40) */
@@ -131,7 +131,7 @@ int64_t FIRCLSParseLEB128AndAdvance(const void** cursor) {
 
   if ((shift < size) && (0x40 & byte)) {
     // sign extend
-    result |= -(1 << shift);
+    result |= -((uint64_t)1 << shift);
   }
 
   return result;

--- a/Crashlytics/UnitTests/FIRCLSDwarfTests.m
+++ b/Crashlytics/UnitTests/FIRCLSDwarfTests.m
@@ -21,6 +21,7 @@
 #include "Crashlytics/Crashlytics/Components/FIRCLSContext.h"
 #include "Crashlytics/Crashlytics/Components/FIRCLSGlobals.h"
 #include "Crashlytics/Crashlytics/Helpers/FIRCLSDefines.h"
+#include "Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDataParsing.h"
 #include "Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDwarfUnwind.h"
 #include "Crashlytics/Crashlytics/Unwind/FIRCLSUnwind_arch.h"
 
@@ -170,6 +171,25 @@
       FIRCLSDwarfUnwindAssignRegisters(&state, &inputRegisters, cfaRegister, &outputRegisters));
 
   XCTAssertEqual(FIRCLSDwarfUnwindGetRegisterValue(&outputRegisters, CLS_DWARF_REG_RETURN), 777);
+}
+
+- (void)testParseULEB128DecodesValueWiderThan28Bits {
+  // ULEB128 of 0xFFFFFFFF needs 5 bytes; the fifth byte lands at shift 28, so
+  // decoding the 0x7F chunk as a 32-bit int shifts past the sign bit.
+  const uint8_t encoded[] = {0xFF, 0xFF, 0xFF, 0xFF, 0x0F};
+  const void* cursor = encoded;
+
+  XCTAssertEqual(FIRCLSParseULEB128AndAdvance(&cursor), 0xFFFFFFFFULL);
+  XCTAssertEqual(cursor, (const void*)(encoded + sizeof(encoded)));
+}
+
+- (void)testParseLEB128DecodesLargeNegativeValue {
+  // SLEB128 of -2^32; the sign-extension and the value chunks both shift past 32.
+  const uint8_t encoded[] = {0x80, 0x80, 0x80, 0x80, 0x70};
+  const void* cursor = encoded;
+
+  XCTAssertEqual(FIRCLSParseLEB128AndAdvance(&cursor), -4294967296LL);
+  XCTAssertEqual(cursor, (const void*)(encoded + sizeof(encoded)));
 }
 
 #endif


### PR DESCRIPTION
Repro: unwind a frame whose __eh_frame CFI record holds a ULEB128/SLEB128 operand that needs five or more bytes (any value at or above 2^28), e.g. an augmentation length or DWARF expression length.
Cause: FIRCLSParseULEB128AndAdvance and FIRCLSParseLEB128AndAdvance accumulate into a uint64_t but shift the masked byte as a 32-bit int, so the shift count climbs to 49 (ULEB) and 56 (the SLEB sign-extension). Shifting an int by its width or more is undefined; on arm64 the count is masked to 5 bits, so a ULEB128 of 0xFFFFFFFF decodes to 0xFFFFFFFFFFFFFFFF and an SLEB128 of -2^32 to -8. That value then feeds pointer/length math on the record.
Fix: widen the shifted operand (and the sign-extension constant) to uint64_t at the three sites. Values below 2^28 decode exactly as before; larger ones now match the spec. Tests in FIRCLSDwarfTests.m cover a 5-byte ULEB128 and a 5-byte negative SLEB128.