### PR TITLE
fix(database): refresh server time offset after clock changes

### DIFF
--- a/FirebaseDatabase/CHANGELOG.md
+++ b/FirebaseDatabase/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Reconnect after significant system clock changes so that
+  `.info/serverTimeOffset` is refreshed. (#363)
+
 # 12.17.0
 - [fixed] Fixed an issue where surrogate pair replacement ranges were incorrect
   in push ID generation. (#16415)

--- a/FirebaseDatabase/Sources/Constants/FConstants.h
+++ b/FirebaseDatabase/Sources/Constants/FConstants.h
@@ -143,6 +143,7 @@ FOUNDATION_EXPORT NSString *const kFQPIndex;
 FOUNDATION_EXPORT NSString *const kFInterruptReasonServerKill;
 FOUNDATION_EXPORT NSString *const kFInterruptReasonWaitingForOpen;
 FOUNDATION_EXPORT NSString *const kFInterruptReasonRepoInterrupt;
+FOUNDATION_EXPORT NSString *const kFInterruptReasonSystemClockChange;
 FOUNDATION_EXPORT NSString *const kFInterruptReasonAuthExpired;
 
 #pragma mark -

--- a/FirebaseDatabase/Sources/Constants/FConstants.m
+++ b/FirebaseDatabase/Sources/Constants/FConstants.m
@@ -136,6 +136,7 @@ NSString *const kFQPIndex = @"i";
 NSString *const kFInterruptReasonServerKill = @"server_kill";
 NSString *const kFInterruptReasonWaitingForOpen = @"waiting_for_open";
 NSString *const kFInterruptReasonRepoInterrupt = @"repo_interrupt";
+NSString *const kFInterruptReasonSystemClockChange = @"system_clock_change";
 
 #pragma mark -
 #pragma mark Payload constants

--- a/FirebaseDatabase/Sources/Core/FPersistentConnection.m
+++ b/FirebaseDatabase/Sources/Core/FPersistentConnection.m
@@ -581,6 +581,13 @@ static void reachabilityCallback(SCNetworkReachabilityRef ref,
     });
 }
 
+- (void)systemClockDidChange:(NSNotification *)notification {
+    dispatch_async(self.dispatchQueue, ^{
+      [self interruptForReason:kFInterruptReasonSystemClockChange];
+      [self resumeForReason:kFInterruptReasonSystemClockChange];
+    });
+}
+
 - (void)setupNotifications {
 #if TARGET_OS_WATCH
     __weak FPersistentConnection *weakSelf = self;
@@ -599,6 +606,15 @@ static void reachabilityCallback(SCNetworkReachabilityRef ref,
             addObserver:self
                selector:@selector(enteringForeground)
                    name:*foregroundConstant
+                 object:nil];
+    }
+    NSString *const *significantTimeChangeConstant = (NSString *const *)dlsym(
+        RTLD_DEFAULT, "UIApplicationSignificantTimeChangeNotification");
+    if (significantTimeChangeConstant) {
+        [[NSNotificationCenter defaultCenter]
+            addObserver:self
+               selector:@selector(systemClockDidChange:)
+                   name:*significantTimeChangeConstant
                  object:nil];
     }
     // An empty address is interpreted a generic internet access

--- a/FirebaseDatabase/Sources/Core/FPersistentConnection.m
+++ b/FirebaseDatabase/Sources/Core/FPersistentConnection.m
@@ -613,15 +613,6 @@ static void reachabilityCallback(SCNetworkReachabilityRef ref,
                    name:*foregroundConstant
                  object:nil];
     }
-    NSString *const *significantTimeChangeConstant = (NSString *const *)dlsym(
-        RTLD_DEFAULT, "UIApplicationSignificantTimeChangeNotification");
-    if (significantTimeChangeConstant) {
-        [[NSNotificationCenter defaultCenter]
-            addObserver:self
-               selector:@selector(systemClockDidChange:)
-                   name:*significantTimeChangeConstant
-                 object:nil];
-    }
     // An empty address is interpreted a generic internet access
     struct sockaddr_in zeroAddress;
     bzero(&zeroAddress, sizeof(zeroAddress));

--- a/FirebaseDatabase/Sources/Core/FPersistentConnection.m
+++ b/FirebaseDatabase/Sources/Core/FPersistentConnection.m
@@ -589,6 +589,11 @@ static void reachabilityCallback(SCNetworkReachabilityRef ref,
 }
 
 - (void)setupNotifications {
+    [[NSNotificationCenter defaultCenter]
+        addObserver:self
+           selector:@selector(systemClockDidChange:)
+               name:NSSystemClockDidChangeNotification
+             object:nil];
 #if TARGET_OS_WATCH
     __weak FPersistentConnection *weakSelf = self;
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];

--- a/FirebaseDatabase/Tests/Unit/FPersistentConnectionTests.m
+++ b/FirebaseDatabase/Tests/Unit/FPersistentConnectionTests.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Google
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseDatabase/Tests/Unit/FPersistentConnectionTests.m
+++ b/FirebaseDatabase/Tests/Unit/FPersistentConnectionTests.m
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import <dlfcn.h>
+
+#import "FirebaseDatabase/Sources/Api/FIRDatabaseConfig.h"
+#import "FirebaseDatabase/Sources/Constants/FConstants.h"
+#import "FirebaseDatabase/Sources/Core/FPersistentConnection.h"
+#import "FirebaseDatabase/Sources/Core/FRepoInfo.h"
+#import "FirebaseDatabase/Tests/Helpers/FTestHelpers.h"
+
+@interface FPersistentConnectionTestDouble : FPersistentConnection
+
+@property(nonatomic, strong) NSMutableArray<NSString *> *interruptedReasons;
+@property(nonatomic, strong) NSMutableArray<NSString *> *resumedReasons;
+
+@end
+
+@implementation FPersistentConnectionTestDouble
+
+- (void)interruptForReason:(NSString *)reason {
+  [self.interruptedReasons addObject:reason];
+}
+
+- (void)resumeForReason:(NSString *)reason {
+  [self.resumedReasons addObject:reason];
+}
+
+@end
+
+@interface FPersistentConnection (Testing)
+
+- (void)systemClockDidChange:(NSNotification *)notification;
+
+@end
+
+@interface FPersistentConnectionTests : XCTestCase
+
+@property(nonatomic, strong) FPersistentConnectionTestDouble *connection;
+@property(nonatomic, strong) dispatch_queue_t connectionQueue;
+
+@end
+
+@implementation FPersistentConnectionTests
+
+- (void)setUp {
+  [super setUp];
+  self.connectionQueue = dispatch_queue_create(
+      "com.google.firebase.database.PersistentConnectionTests", DISPATCH_QUEUE_SERIAL);
+  FRepoInfo *repoInfo = [[FRepoInfo alloc] initWithHost:@"example.firebaseio.com"
+                                               isSecure:YES
+                                          withNamespace:@"example"];
+  self.connection =
+      [[FPersistentConnectionTestDouble alloc] initWithRepoInfo:repoInfo
+                                                  dispatchQueue:self.connectionQueue
+                                                         config:[FTestHelpers defaultConfig]];
+  self.connection.interruptedReasons = [NSMutableArray array];
+  self.connection.resumedReasons = [NSMutableArray array];
+}
+
+- (void)testSystemClockChangeRestartsConnection {
+  [self.connection systemClockDidChange:nil];
+  [self waitForConnectionQueue];
+
+  [self assertConnectionRestartedForSystemClockChange];
+}
+
+- (void)testSignificantTimeChangeNotificationRestartsConnection {
+  NSString *const *significantTimeChangeConstant =
+      (NSString *const *)dlsym(RTLD_DEFAULT, "UIApplicationSignificantTimeChangeNotification");
+  if (!significantTimeChangeConstant) {
+    return;
+  }
+
+  [[NSNotificationCenter defaultCenter] postNotificationName:*significantTimeChangeConstant
+                                                      object:nil];
+  [self waitForConnectionQueue];
+
+  [self assertConnectionRestartedForSystemClockChange];
+}
+
+- (void)waitForConnectionQueue {
+  dispatch_sync(self.connectionQueue, ^{
+                });
+}
+
+- (void)assertConnectionRestartedForSystemClockChange {
+  XCTAssertEqualObjects(self.connection.interruptedReasons,
+                        (@[ kFInterruptReasonSystemClockChange ]));
+  XCTAssertEqualObjects(self.connection.resumedReasons, (@[ kFInterruptReasonSystemClockChange ]));
+}
+
+@end

--- a/FirebaseDatabase/Tests/Unit/FPersistentConnectionTests.m
+++ b/FirebaseDatabase/Tests/Unit/FPersistentConnectionTests.m
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-#import <TargetConditionals.h>
 #import <XCTest/XCTest.h>
-#import <dlfcn.h>
 
 #import "FirebaseDatabase/Sources/Api/FIRDatabaseConfig.h"
 #import "FirebaseDatabase/Sources/Constants/FConstants.h"
@@ -78,24 +76,6 @@
   [self waitForConnectionQueue];
 
   [self assertConnectionRestartedForSystemClockChange];
-}
-
-- (void)testSignificantTimeChangeNotificationRestartsConnection {
-#if TARGET_OS_WATCH
-  return;
-#else
-  NSString *const *significantTimeChangeConstant =
-      (NSString *const *)dlsym(RTLD_DEFAULT, "UIApplicationSignificantTimeChangeNotification");
-  if (!significantTimeChangeConstant) {
-    return;
-  }
-
-  [[NSNotificationCenter defaultCenter] postNotificationName:*significantTimeChangeConstant
-                                                      object:nil];
-  [self waitForConnectionQueue];
-
-  [self assertConnectionRestartedForSystemClockChange];
-#endif  // TARGET_OS_WATCH
 }
 
 - (void)testSystemClockDidChangeNotificationRestartsConnection {

--- a/FirebaseDatabase/Tests/Unit/FPersistentConnectionTests.m
+++ b/FirebaseDatabase/Tests/Unit/FPersistentConnectionTests.m
@@ -93,6 +93,14 @@
   [self assertConnectionRestartedForSystemClockChange];
 }
 
+- (void)testSystemClockDidChangeNotificationRestartsConnection {
+  [[NSNotificationCenter defaultCenter] postNotificationName:NSSystemClockDidChangeNotification
+                                                      object:nil];
+  [self waitForConnectionQueue];
+
+  [self assertConnectionRestartedForSystemClockChange];
+}
+
 - (void)waitForConnectionQueue {
   dispatch_sync(self.connectionQueue, ^{
                 });

--- a/FirebaseDatabase/Tests/Unit/FPersistentConnectionTests.m
+++ b/FirebaseDatabase/Tests/Unit/FPersistentConnectionTests.m
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
 #import <XCTest/XCTest.h>
 #import <dlfcn.h>
 
@@ -80,6 +81,9 @@
 }
 
 - (void)testSignificantTimeChangeNotificationRestartsConnection {
+#if TARGET_OS_WATCH
+  return;
+#else
   NSString *const *significantTimeChangeConstant =
       (NSString *const *)dlsym(RTLD_DEFAULT, "UIApplicationSignificantTimeChangeNotification");
   if (!significantTimeChangeConstant) {
@@ -91,6 +95,7 @@
   [self waitForConnectionQueue];
 
   [self assertConnectionRestartedForSystemClockChange];
+#endif  // TARGET_OS_WATCH
 }
 
 - (void)testSystemClockDidChangeNotificationRestartsConnection {


### PR DESCRIPTION
### Discussion

Fixes #363.

Realtime Database currently keeps the original `.info/serverTimeOffset` when the system clock changes. This change observes `UIApplicationSignificantTimeChangeNotification` and restarts the persistent connection with a dedicated interrupt reason, causing the server time offset to be refreshed without disturbing other interrupt reasons.

### Testing

- Added a unit test for the system clock change handler.
- Added a unit test that posts the runtime-resolved significant-time-change notification and verifies connection restart.
- iOS Simulator focused tests: 2 tests, 0 failures.
- macOS focused tests: 2 tests, 0 failures.
- macOS full `DatabaseUnit`: 429 tests, 0 failures.
- `swift build --disable-sandbox --target DatabaseUnit`
- `PATH="/opt/homebrew/opt/clang-format/bin:/opt/homebrew/bin:$PATH" ./.agents/skills/style_and_commit/scripts/pre_commit.sh`
- `git diff --check`

### API Changes

No public API changes.