### PR TITLE
BSON numeric transforms

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRNumericTransformTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRNumericTransformTests.mm
@@ -319,6 +319,15 @@ double DOUBLE_EPSILON = 0.000001;
   XCTAssertTrue(std::isnan([snap[@"sum"] doubleValue]));
 }
 
+- (void)expectLocalAndRemoteDecimal128NaN {
+  FIRDocumentSnapshot *snap = [_accumulator awaitLocalEvent];
+  XCTAssertTrue([snap[@"sum"] isKindOfClass:[FIRDecimal128Value class]]);
+  XCTAssertEqualObjects([(FIRDecimal128Value *)snap[@"sum"] value], @"NaN");
+  snap = [_accumulator awaitRemoteEvent];
+  XCTAssertTrue([snap[@"sum"] isKindOfClass:[FIRDecimal128Value class]]);
+  XCTAssertEqualObjects([(FIRDecimal128Value *)snap[@"sum"] value], @"NaN");
+}
+
 - (void)testMinimumWithNaN {
   // If one of the values is NaN, minimum is NaN
   [self writeInitialData:@{@"sum" : @(NAN)}];
@@ -328,6 +337,26 @@ double DOUBLE_EPSILON = 0.000001;
   [self writeInitialData:@{@"sum" : @5}];
   [self updateDocumentRef:_docRef data:@{@"sum" : [FIRFieldValue fieldValueForDoubleMinimum:NAN]}];
   [self expectLocalAndRemoteNaN];
+
+  [self writeInitialData:@{@"sum" : @(NAN)}];
+  [self updateDocumentRef:_docRef data:@{@"sum" : [FIRFieldValue fieldValueForDoubleMinimum:NAN]}];
+  [self expectLocalAndRemoteNaN];
+
+  [self writeInitialData:@{@"sum" : @5.5}];
+  [self updateDocumentRef:_docRef data:@{@"sum" : [FIRFieldValue fieldValueForDoubleMinimum:NAN]}];
+  [self expectLocalAndRemoteNaN];
+
+  [self writeInitialData:@{@"sum" : [[FIRInt32Value alloc] initWithValue:5]}];
+  [self updateDocumentRef:_docRef data:@{@"sum" : [FIRFieldValue fieldValueForDoubleMinimum:NAN]}];
+  [self expectLocalAndRemoteNaN];
+
+  [self writeInitialData:@{@"sum" : [[FIRDecimal128Value alloc] initWithValue:@"10.5"]}];
+  [self updateDocumentRef:_docRef data:@{@"sum" : [FIRFieldValue fieldValueForDoubleMinimum:NAN]}];
+  [self expectLocalAndRemoteNaN];
+
+  [self writeInitialData:@{@"sum" : [[FIRDecimal128Value alloc] initWithValue:@"NaN"]}];
+  [self updateDocumentRef:_docRef data:@{@"sum" : [FIRFieldValue fieldValueForIntegerMinimum:5]}];
+  [self expectLocalAndRemoteDecimal128NaN];
 }
 
 - (void)testMaximumWithNaN {
@@ -339,6 +368,26 @@ double DOUBLE_EPSILON = 0.000001;
   [self writeInitialData:@{@"sum" : @5}];
   [self updateDocumentRef:_docRef data:@{@"sum" : [FIRFieldValue fieldValueForDoubleMaximum:NAN]}];
   [self expectLocalAndRemoteNaN];
+
+  [self writeInitialData:@{@"sum" : @(NAN)}];
+  [self updateDocumentRef:_docRef data:@{@"sum" : [FIRFieldValue fieldValueForDoubleMaximum:NAN]}];
+  [self expectLocalAndRemoteNaN];
+
+  [self writeInitialData:@{@"sum" : @5.5}];
+  [self updateDocumentRef:_docRef data:@{@"sum" : [FIRFieldValue fieldValueForDoubleMaximum:NAN]}];
+  [self expectLocalAndRemoteNaN];
+
+  [self writeInitialData:@{@"sum" : [[FIRInt32Value alloc] initWithValue:5]}];
+  [self updateDocumentRef:_docRef data:@{@"sum" : [FIRFieldValue fieldValueForDoubleMaximum:NAN]}];
+  [self expectLocalAndRemoteNaN];
+
+  [self writeInitialData:@{@"sum" : [[FIRDecimal128Value alloc] initWithValue:@"10.5"]}];
+  [self updateDocumentRef:_docRef data:@{@"sum" : [FIRFieldValue fieldValueForDoubleMaximum:NAN]}];
+  [self expectLocalAndRemoteNaN];
+
+  [self writeInitialData:@{@"sum" : [[FIRDecimal128Value alloc] initWithValue:@"NaN"]}];
+  [self updateDocumentRef:_docRef data:@{@"sum" : [FIRFieldValue fieldValueForIntegerMaximum:5]}];
+  [self expectLocalAndRemoteDecimal128NaN];
 }
 
 - (void)testNumericIncrementWithBsonTypes {

--- a/Firestore/Example/Tests/Integration/API/FIRNumericTransformTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRNumericTransformTests.mm
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#import <FirebaseFirestore/FIRDecimal128Value.h>
+#import <FirebaseFirestore/FIRFieldValue.h>
+#import <FirebaseFirestore/FIRInt32Value.h>
 #import <FirebaseFirestore/FirebaseFirestore.h>
 
 #import <XCTest/XCTest.h>
@@ -336,6 +339,95 @@ double DOUBLE_EPSILON = 0.000001;
   [self writeInitialData:@{@"sum" : @5}];
   [self updateDocumentRef:_docRef data:@{@"sum" : [FIRFieldValue fieldValueForDoubleMaximum:NAN]}];
   [self expectLocalAndRemoteNaN];
+}
+
+- (void)testNumericIncrementWithBsonTypes {
+  [self writeInitialData:@{
+    @"i32" : [[FIRInt32Value alloc] initWithValue:10],
+    @"d128" : [[FIRDecimal128Value alloc] initWithValue:@"15"]
+  }];
+
+  [self updateDocumentRef:_docRef
+                     data:@{
+                       @"i32" : [FIRFieldValue fieldValueForIntegerIncrement:5],
+                       @"d128" : [FIRFieldValue fieldValueForIntegerIncrement:1]
+                     }];
+  FIRDocumentSnapshot *snap = [_accumulator awaitLocalEvent];
+  XCTAssertEqualObjects(@15, snap[@"i32"]);
+  XCTAssertEqualObjects([[FIRDecimal128Value alloc] initWithValue:@"16"], snap[@"d128"]);
+  snap = [_accumulator awaitRemoteEvent];
+  XCTAssertEqualObjects(@15, snap[@"i32"]);
+  XCTAssertEqualObjects([[FIRDecimal128Value alloc] initWithValue:@"16"], snap[@"d128"]);
+}
+
+- (void)testNumericMinimumAndMaximumWithBsonTypes {
+  [self writeInitialData:@{
+    @"min_i32" : [[FIRInt32Value alloc] initWithValue:10],
+    @"min_d128" : [[FIRDecimal128Value alloc] initWithValue:@"10.5"],
+    @"max_i32" : [[FIRInt32Value alloc] initWithValue:10],
+    @"max_d128" : [[FIRDecimal128Value alloc] initWithValue:@"10.5"]
+  }];
+
+  // First pass: larger operand for min (retains base), smaller operand for max (retains base)
+  [self updateDocumentRef:_docRef
+                     data:@{
+                       @"min_i32" : [FIRFieldValue fieldValueForIntegerMinimum:15],
+                       @"min_d128" : [FIRFieldValue fieldValueForDoubleMinimum:15.5],
+                       @"max_i32" : [FIRFieldValue fieldValueForIntegerMaximum:5],
+                       @"max_d128" : [FIRFieldValue fieldValueForDoubleMaximum:5.5]
+                     }];
+  FIRDocumentSnapshot *snap = [_accumulator awaitLocalEvent];
+  XCTAssertEqualObjects([[FIRInt32Value alloc] initWithValue:10], snap[@"min_i32"]);
+  XCTAssertEqualObjects([[FIRDecimal128Value alloc] initWithValue:@"10.5"], snap[@"min_d128"]);
+  XCTAssertEqualObjects([[FIRInt32Value alloc] initWithValue:10], snap[@"max_i32"]);
+  XCTAssertEqualObjects([[FIRDecimal128Value alloc] initWithValue:@"10.5"], snap[@"max_d128"]);
+  snap = [_accumulator awaitRemoteEvent];
+  XCTAssertEqualObjects([[FIRInt32Value alloc] initWithValue:10], snap[@"min_i32"]);
+  XCTAssertEqualObjects([[FIRDecimal128Value alloc] initWithValue:@"10.5"], snap[@"min_d128"]);
+  XCTAssertEqualObjects([[FIRInt32Value alloc] initWithValue:10], snap[@"max_i32"]);
+  XCTAssertEqualObjects([[FIRDecimal128Value alloc] initWithValue:@"10.5"], snap[@"max_d128"]);
+
+  // Second pass: smaller operand for min (replaces base), larger operand for max (replaces base)
+  [self updateDocumentRef:_docRef
+                     data:@{
+                       @"min_i32" : [FIRFieldValue fieldValueForIntegerMinimum:5],
+                       @"min_d128" : [FIRFieldValue fieldValueForDoubleMinimum:5.5],
+                       @"max_i32" : [FIRFieldValue fieldValueForIntegerMaximum:15],
+                       @"max_d128" : [FIRFieldValue fieldValueForDoubleMaximum:15.5]
+                     }];
+  snap = [_accumulator awaitLocalEvent];
+  XCTAssertEqualObjects(@5, snap[@"min_i32"]);
+  XCTAssertEqualWithAccuracy(5.5, [snap[@"min_d128"] doubleValue], DOUBLE_EPSILON);
+  XCTAssertEqualObjects(@15, snap[@"max_i32"]);
+  XCTAssertEqualWithAccuracy(15.5, [snap[@"max_d128"] doubleValue], DOUBLE_EPSILON);
+  snap = [_accumulator awaitRemoteEvent];
+  XCTAssertEqualObjects(@5, snap[@"min_i32"]);
+  XCTAssertEqualWithAccuracy(5.5, [snap[@"min_d128"] doubleValue], DOUBLE_EPSILON);
+  XCTAssertEqualObjects(@15, snap[@"max_i32"]);
+  XCTAssertEqualWithAccuracy(15.5, [snap[@"max_d128"] doubleValue], DOUBLE_EPSILON);
+}
+
+- (void)testNumericTransformsConcurrentMixed {
+  [self writeInitialData:@{
+    @"min_field" : [[FIRInt32Value alloc] initWithValue:10],
+    @"max_field" : [[FIRDecimal128Value alloc] initWithValue:@"10.5"],
+    @"inc_field" : [[FIRDecimal128Value alloc] initWithValue:@"20.5"]
+  }];
+
+  [self updateDocumentRef:_docRef
+                     data:@{
+                       @"min_field" : [FIRFieldValue fieldValueForDoubleMinimum:5.5],
+                       @"max_field" : [FIRFieldValue fieldValueForIntegerMaximum:15],
+                       @"inc_field" : [FIRFieldValue fieldValueForDoubleIncrement:2.5]
+                     }];
+  FIRDocumentSnapshot *snap = [_accumulator awaitLocalEvent];
+  XCTAssertEqualWithAccuracy(5.5, [snap[@"min_field"] doubleValue], DOUBLE_EPSILON);
+  XCTAssertEqualObjects(@15, snap[@"max_field"]);
+  XCTAssertEqualObjects([[FIRDecimal128Value alloc] initWithValue:@"23"], snap[@"inc_field"]);
+  snap = [_accumulator awaitRemoteEvent];
+  XCTAssertEqualWithAccuracy(5.5, [snap[@"min_field"] doubleValue], DOUBLE_EPSILON);
+  XCTAssertEqualObjects(@15, snap[@"max_field"]);
+  XCTAssertEqualObjects([[FIRDecimal128Value alloc] initWithValue:@"23"], snap[@"inc_field"]);
 }
 
 @end

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -66,6 +66,7 @@
 #include "Firestore/core/src/util/comparison.h"
 #include "Firestore/core/src/util/filesystem.h"
 #include "Firestore/core/src/util/hard_assert.h"
+#include "Firestore/core/src/util/json_reader.h"
 #include "Firestore/core/src/util/log.h"
 #include "Firestore/core/src/util/path.h"
 #include "Firestore/core/src/util/status.h"
@@ -117,6 +118,7 @@ using firebase::firestore::testutil::Version;
 using firebase::firestore::util::ByteStreamCpp;
 using firebase::firestore::util::DirectoryIterator;
 using firebase::firestore::util::Executor;
+using firebase::firestore::util::JsonReader;
 using firebase::firestore::util::MakeNSString;
 using firebase::firestore::util::MakeString;
 using firebase::firestore::util::MakeStringPtr;
@@ -584,7 +586,29 @@ NSString *ToTargetIdListString(const ActiveTargetMap &map) {
                 @"'keepInQueue=true' is not supported on iOS and should only be set in "
                 @"multi-client tests");
 
-  MutationResult mutationResult(version, Message<google_firestore_v1_ArrayValue>{});
+  Message<google_firestore_v1_ArrayValue> transformResults;
+  NSArray *resultsSpec = spec[@"transformResults"];
+  if (resultsSpec) {
+    const auto &database_info = [self.driver databaseInfo];
+    BundleSerializer bundle_serializer(remote::Serializer(database_info.database_id()));
+
+    transformResults = Message<google_firestore_v1_ArrayValue>{};
+    transformResults->values_count = static_cast<pb_size_t>(resultsSpec.count);
+    transformResults->values =
+        nanopb::MakeArray<google_firestore_v1_Value>(transformResults->values_count);
+    for (NSUInteger i = 0; i < resultsSpec.count; ++i) {
+      NSData *jsonData = [NSJSONSerialization dataWithJSONObject:resultsSpec[i]
+                                                         options:0
+                                                           error:nil];
+      std::string jsonStr((const char *)jsonData.bytes, jsonData.length);
+      nlohmann::json jsonVal = nlohmann::json::parse(jsonStr);
+      JsonReader reader;
+      Message<google_firestore_v1_Value> val = bundle_serializer.DecodeValue(reader, jsonVal);
+      transformResults->values[i] = *val.release();
+    }
+  }
+
+  MutationResult mutationResult(version, std::move(transformResults));
   std::vector<MutationResult> mutationResults;
   mutationResults.emplace_back(std::move(mutationResult));
   [self.driver receiveWriteAckWithVersion:version mutationResults:std::move(mutationResults)];

--- a/Firestore/Example/Tests/SpecTests/json/write_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/write_spec_test.json
@@ -698,6 +698,504 @@
       }
     ]
   },
+  "Decimal128 increment loses precision locally and recovers on server ack": {
+    "describeName": "Writes:",
+    "itName": "Decimal128 increment loses precision locally and recovers on server ack",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/doc"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/doc",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "sum": {
+                  "__decimal128__": {
+                    "stringValue": "1.000000000000000000000000000000001"
+                  }
+                }
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "sum": {
+                    "__decimal128__": {
+                      "stringValue": "1.000000000000000000000000000000001"
+                    }
+                  }
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/doc"
+            }
+          }
+        ]
+      },
+      {
+        "userPatch": [
+          "collection/doc",
+          {
+            "sum": {
+              "_methodName": "increment",
+              "_operand": 1
+            }
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "createTime": 0,
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "sum": {
+                    "__decimal128__": {
+                      "stringValue": "2"
+                    }
+                  }
+                },
+                "version": 0
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/doc"
+            }
+          }
+        ]
+      },
+      {
+        "writeAck": {
+          "transformResults": [
+            {
+              "mapValue": {
+                "fields": {
+                  "__decimal128__": {
+                    "stringValue": "2.000000000000000000000000000000001"
+                  }
+                }
+              }
+            }
+          ],
+          "version": 2000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/doc"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/doc",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "sum": {
+                  "__decimal128__": {
+                    "stringValue": "2.000000000000000000000000000000001"
+                  }
+                }
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "modified": [
+              {
+                "createTime": 0,
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "sum": {
+                    "__decimal128__": {
+                      "stringValue": "2.000000000000000000000000000000001"
+                    }
+                  }
+                },
+                "version": 2000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/doc"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Decimal128 increment loses precision locally and recovers when watch arrives before server ack": {
+    "describeName": "Writes:",
+    "itName": "Decimal128 increment loses precision locally and recovers when watch arrives before server ack",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useEagerGCForMemory": true
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/doc"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/doc",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "sum": {
+                  "__decimal128__": {
+                    "stringValue": "1.000000000000000000000000000000001"
+                  }
+                }
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "createTime": 0,
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "sum": {
+                    "__decimal128__": {
+                      "stringValue": "1.000000000000000000000000000000001"
+                    }
+                  }
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/doc"
+            }
+          }
+        ]
+      },
+      {
+        "userPatch": [
+          "collection/doc",
+          {
+            "sum": {
+              "_methodName": "increment",
+              "_operand": 1
+            }
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "createTime": 0,
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "sum": {
+                    "__decimal128__": {
+                      "stringValue": "2"
+                    }
+                  }
+                },
+                "version": 0
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/doc"
+            }
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "createTime": 0,
+              "key": "collection/doc",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "sum": {
+                  "__decimal128__": {
+                    "stringValue": "2.000000000000000000000000000000001"
+                  }
+                }
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "writeAck": {
+          "transformResults": [
+            {
+              "mapValue": {
+                "fields": {
+                  "__decimal128__": {
+                    "stringValue": "2.000000000000000000000000000000001"
+                  }
+                }
+              }
+            }
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "modified": [
+              {
+                "createTime": 0,
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "sum": {
+                    "__decimal128__": {
+                      "stringValue": "2.000000000000000000000000000000001"
+                    }
+                  }
+                },
+                "version": 2000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/doc"
+            }
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/doc"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      }
+    ]
+  },
   "Doesn't raise 'hasPendingWrites' for committed write and new listen": {
     "describeName": "Writes:",
     "itName": "Doesn't raise 'hasPendingWrites' for committed write and new listen",

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -99,41 +99,11 @@ NSDateComponents *FSTTestDateComponents(
   return comps;
 }
 
-static id _Nullable PreConvert(id _Nullable input) {
-  if ([input isKindOfClass:[NSDictionary class]]) {
-    NSDictionary *dict = (NSDictionary *)input;
-    if (dict[@"__decimal128__"]) {
-      id val = dict[@"__decimal128__"];
-      if ([val isKindOfClass:[NSDictionary class]]) {
-        NSDictionary *decimalDict = (NSDictionary *)val;
-        if (decimalDict[@"stringValue"]) {
-          return [[FIRDecimal128Value alloc] initWithValue:decimalDict[@"stringValue"]];
-        }
-      } else if ([val isKindOfClass:[NSString class]]) {
-        return [[FIRDecimal128Value alloc] initWithValue:(NSString *)val];
-      }
-    }
-    if (dict[@"__int32__"]) {
-      id val = dict[@"__int32__"];
-      if ([val isKindOfClass:[NSNumber class]]) {
-        return [[FIRInt32Value alloc] initWithValue:[val intValue]];
-      }
-    }
-    if (dict[@"__int__"]) {
-      id val = dict[@"__int__"];
-      if ([val isKindOfClass:[NSNumber class]]) {
-        return [[FIRInt32Value alloc] initWithValue:[val intValue]];
-      }
-    }
-  }
-  return input;
-}
-
 FSTUserDataReader *FSTTestUserDataReader() {
   FSTUserDataReader *reader =
       [[FSTUserDataReader alloc] initWithDatabaseID:DatabaseId("project")
                                        preConverter:^id _Nullable(id _Nullable input) {
-                                         return PreConvert(input);
+                                         return input;
                                        }];
   return reader;
 }

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -16,8 +16,10 @@
 
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
 
+#import <FirebaseFirestore/FIRDecimal128Value.h>
 #import <FirebaseFirestore/FIRFieldValue.h>
 #import <FirebaseFirestore/FIRGeoPoint.h>
+#import <FirebaseFirestore/FIRInt32Value.h>
 
 #include <set>
 #include <utility>
@@ -97,11 +99,41 @@ NSDateComponents *FSTTestDateComponents(
   return comps;
 }
 
+static id _Nullable PreConvert(id _Nullable input) {
+  if ([input isKindOfClass:[NSDictionary class]]) {
+    NSDictionary *dict = (NSDictionary *)input;
+    if (dict[@"__decimal128__"]) {
+      id val = dict[@"__decimal128__"];
+      if ([val isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *decimalDict = (NSDictionary *)val;
+        if (decimalDict[@"stringValue"]) {
+          return [[FIRDecimal128Value alloc] initWithValue:decimalDict[@"stringValue"]];
+        }
+      } else if ([val isKindOfClass:[NSString class]]) {
+        return [[FIRDecimal128Value alloc] initWithValue:(NSString *)val];
+      }
+    }
+    if (dict[@"__int32__"]) {
+      id val = dict[@"__int32__"];
+      if ([val isKindOfClass:[NSNumber class]]) {
+        return [[FIRInt32Value alloc] initWithValue:[val intValue]];
+      }
+    }
+    if (dict[@"__int__"]) {
+      id val = dict[@"__int__"];
+      if ([val isKindOfClass:[NSNumber class]]) {
+        return [[FIRInt32Value alloc] initWithValue:[val intValue]];
+      }
+    }
+  }
+  return input;
+}
+
 FSTUserDataReader *FSTTestUserDataReader() {
   FSTUserDataReader *reader =
       [[FSTUserDataReader alloc] initWithDatabaseID:DatabaseId("project")
                                        preConverter:^id _Nullable(id _Nullable input) {
-                                         return input;
+                                         return PreConvert(input);
                                        }];
   return reader;
 }
@@ -144,6 +176,31 @@ PatchMutation FSTTestPatchMutation(NSString *path,
     if ([value isEqual:kDeleteSentinel]) {
       const FieldPath fieldPath = Field(MakeString(key));
       mutableValues[key] = [FIRFieldValue fieldValueForDelete];
+    } else if ([value isKindOfClass:[NSDictionary class]]) {
+      NSDictionary *dict = (NSDictionary *)value;
+      NSString *methodName = dict[@"_methodName"] ?: dict[@"methodName"];
+      if ([methodName isEqualToString:@"increment"]) {
+        id operand = dict[@"_operand"] ?: dict[@"operand"];
+        if ([operand isKindOfClass:[NSNumber class]]) {
+          mutableValues[key] = [FIRFieldValue fieldValueForDoubleIncrement:[operand doubleValue]];
+        } else if ([operand isKindOfClass:[NSString class]]) {
+          mutableValues[key] = [FIRFieldValue fieldValueForDoubleIncrement:[operand doubleValue]];
+        }
+      } else if ([methodName isEqualToString:@"minimum"]) {
+        id operand = dict[@"_operand"] ?: dict[@"operand"];
+        if ([operand isKindOfClass:[NSNumber class]]) {
+          mutableValues[key] = [FIRFieldValue fieldValueForDoubleMinimum:[operand doubleValue]];
+        } else if ([operand isKindOfClass:[NSString class]]) {
+          mutableValues[key] = [FIRFieldValue fieldValueForDoubleMinimum:[operand doubleValue]];
+        }
+      } else if ([methodName isEqualToString:@"maximum"]) {
+        id operand = dict[@"_operand"] ?: dict[@"operand"];
+        if ([operand isKindOfClass:[NSNumber class]]) {
+          mutableValues[key] = [FIRFieldValue fieldValueForDoubleMaximum:[operand doubleValue]];
+        } else if ([operand isKindOfClass:[NSString class]]) {
+          mutableValues[key] = [FIRFieldValue fieldValueForDoubleMaximum:[operand doubleValue]];
+        }
+      }
     }
   }];
 

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -227,10 +227,6 @@ class FakeAuthCredentialsProvider : public EmptyAuthCredentialsProvider {
   // SSL certs.
   NSString *project = [[NSProcessInfo processInfo] environment][@"PROJECT_ID"];
   NSString *targetBackend = [[NSProcessInfo processInfo] environment][@"TARGET_BACKEND"];
-  // Forcing use of nightly.Add commentMore actions
-  // TODO(types/ehsann): remove this before merging into main.
-  targetBackend = @"nightly";
-  project = @"firestore-sdk-nightly";
   NSString *host;
   if (targetBackend) {
     if ([targetBackend isEqualToString:@"emulator"]) {

--- a/Firestore/core/src/bundle/bundle_serializer.h
+++ b/Firestore/core/src/bundle/bundle_serializer.h
@@ -58,6 +58,9 @@ class BundleSerializer {
   BundleDocument DecodeDocument(util::JsonReader& reader,
                                 const nlohmann::json& document) const;
 
+  nanopb::Message<google_firestore_v1_Value> DecodeValue(
+      util::JsonReader& reader, const nlohmann::json& value) const;
+
  private:
   BundledQuery DecodeBundledQuery(util::JsonReader& reader,
                                   const nlohmann::json& query) const;
@@ -67,8 +70,6 @@ class BundleSerializer {
                                  const nlohmann::json& filter) const;
   std::vector<core::Filter> DecodeCompositeFilter(
       util::JsonReader& reader, const nlohmann::json& filter) const;
-  nanopb::Message<google_firestore_v1_Value> DecodeValue(
-      util::JsonReader& reader, const nlohmann::json& value) const;
 
   core::Bound DecodeStartAtBound(util::JsonReader& reader,
                                  const nlohmann::json& query) const;

--- a/Firestore/core/src/model/transform_operation.cc
+++ b/Firestore/core/src/model/transform_operation.cc
@@ -641,6 +641,12 @@ NumericMinimumTransform::Rep::ApplyToLocalView(
   if (!IsNumber(previous_value)) {
     return DeepClone(*operand_);
   }
+  if (IsNaNValue(*previous_value)) {
+    return DeepClone(*previous_value);
+  }
+  if (IsNaNValue(*operand_)) {
+    return DeepClone(*operand_);
+  }
   util::ComparisonResult cmp = CompareNumbers(*operand_, *previous_value);
   if (cmp == util::ComparisonResult::Ascending) {
     return DeepClone(*operand_);
@@ -653,6 +659,12 @@ NumericMaximumTransform::Rep::ApplyToLocalView(
     const absl::optional<google_firestore_v1_Value>& previous_value,
     const Timestamp& /* local_write_time */) const {
   if (!IsNumber(previous_value)) {
+    return DeepClone(*operand_);
+  }
+  if (IsNaNValue(*previous_value)) {
+    return DeepClone(*previous_value);
+  }
+  if (IsNaNValue(*operand_)) {
     return DeepClone(*operand_);
   }
   util::ComparisonResult cmp = CompareNumbers(*operand_, *previous_value);

--- a/Firestore/core/src/model/transform_operation.cc
+++ b/Firestore/core/src/model/transform_operation.cc
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <ostream>
@@ -29,6 +30,7 @@
 #include "Firestore/core/src/nanopb/nanopb_util.h"
 #include "Firestore/core/src/util/comparison.h"
 #include "Firestore/core/src/util/hard_assert.h"
+#include "Firestore/core/src/util/quadruple.h"
 #include "Firestore/core/src/util/to_string.h"
 #include "absl/algorithm/container.h"
 #include "absl/strings/str_cat.h"
@@ -297,6 +299,89 @@ Message<google_firestore_v1_Value> ArrayTransform::Rep::Apply(
 static_assert(sizeof(TransformOperation) == sizeof(NumericTransform),
               "No additional members allowed (everything must go in Rep)");
 
+namespace {
+
+/**
+ * Implements saturating integer addition. Overflows are resolved to
+ * INT64_MAX/INT64_MIN.
+ */
+int64_t SafeIncrement(int64_t x, int64_t y) {
+  if (x > 0 && y > INT64_MAX - x) {
+    return INT64_MAX;
+  }
+
+  if (x < 0 && y < INT64_MIN - x) {
+    return INT64_MIN;
+  }
+
+  return x + y;
+}
+
+/**
+ * Implements saturating 32-bit integer addition. Overflows are resolved to
+ * INT32_MAX/INT32_MIN.
+ */
+int32_t SafeIncrementInt32(int32_t x, int32_t y) {
+  if (x > 0 && y > INT32_MAX - x) {
+    return INT32_MAX;
+  }
+
+  if (x < 0 && y < INT32_MIN - x) {
+    return INT32_MIN;
+  }
+
+  return x + y;
+}
+
+Message<google_firestore_v1_Value> MakeInt32Value(int32_t val) {
+  Message<google_firestore_v1_Value> result;
+  result->which_value_type = google_firestore_v1_Value_map_value_tag;
+  result->map_value.fields_count = 1;
+  result->map_value.fields =
+      nanopb::MakeArray<google_firestore_v1_MapValue_FieldsEntry>(1);
+  result->map_value.fields[0].key =
+      nanopb::MakeBytesArray(kRawInt32TypeFieldValue);
+  result->map_value.fields[0].value.which_value_type =
+      google_firestore_v1_Value_integer_value_tag;
+  result->map_value.fields[0].value.integer_value = val;
+  return result;
+}
+
+Message<google_firestore_v1_Value> MakeDecimal128Value(const std::string& str) {
+  Message<google_firestore_v1_Value> result;
+  result->which_value_type = google_firestore_v1_Value_map_value_tag;
+  result->map_value.fields_count = 1;
+  result->map_value.fields =
+      nanopb::MakeArray<google_firestore_v1_MapValue_FieldsEntry>(1);
+  result->map_value.fields[0].key =
+      nanopb::MakeBytesArray(kRawDecimal128TypeFieldValue);
+  result->map_value.fields[0].value.which_value_type =
+      google_firestore_v1_Value_string_value_tag;
+  result->map_value.fields[0].value.string_value = nanopb::MakeBytesArray(str);
+  return result;
+}
+
+double ValueAsDouble(const google_firestore_v1_Value& value) {
+  if (IsDouble(value)) {
+    return value.double_value;
+  } else if (IsInteger(value)) {
+    return static_cast<double>(value.integer_value);
+  } else if (IsInt32Value(value)) {
+    return static_cast<double>(value.map_value.fields[0].value.integer_value);
+  } else if (IsDecimal128Value(value)) {
+    util::Quadruple q;
+    std::string str =
+        nanopb::MakeString(value.map_value.fields[0].value.string_value);
+    HARD_ASSERT(q.Parse(str), "Failed to parse Decimal128 string: %s", str);
+    return static_cast<double>(q);
+  } else {
+    HARD_FAIL("Expected value to be of numeric type, but was %s (type %s)",
+              CanonicalId(value), GetTypeOrder(value));
+  }
+}
+
+}  // namespace
+
 class NumericTransform::Rep : public TransformOperation::Rep {
  public:
   explicit Rep(Message<google_firestore_v1_Value> operand)
@@ -315,15 +400,7 @@ class NumericTransform::Rep : public TransformOperation::Rep {
   }
 
   double OperandAsDouble() const {
-    if (IsDouble(*operand_)) {
-      return operand_->double_value;
-    } else if (IsInteger(*operand_)) {
-      return static_cast<double>(operand_->integer_value);
-    } else {
-      HARD_FAIL(
-          "Expected 'operand' to be of numeric type, but was %s (type %s)",
-          CanonicalId(*operand_), GetTypeOrder(*operand_));
-    }
+    return ValueAsDouble(*operand_);
   }
 
   bool Equals(const TransformOperation::Rep& other) const override {
@@ -478,48 +555,82 @@ NumericMaximumTransform::NumericMaximumTransform(const TransformOperation& op)
               op.type());
 }
 
-namespace {
-
-/**
- * Implements saturating integer addition. Overflows are resolved to
- * LONG_MAX/LONG_MIN.
- */
-int64_t SafeIncrement(int64_t x, int64_t y) {
-  if (x > 0 && y > LONG_MAX - x) {
-    return LONG_MAX;
-  }
-
-  if (x < 0 && y < LONG_MIN - x) {
-    return LONG_MIN;
-  }
-
-  return x + y;
-}
-
-}  // namespace
-
 Message<google_firestore_v1_Value>
 NumericIncrementTransform::Rep::ApplyToLocalView(
     const absl::optional<google_firestore_v1_Value>& previous_value,
     const Timestamp& /* local_write_time */) const {
   auto base_value = ComputeBaseValue(previous_value);
-  Message<google_firestore_v1_Value> result;
+  HARD_ASSERT(base_value.has_value() && IsNumber(**base_value),
+              "'base_value' is not of numeric type");
 
-  // Return an integer value only if the previous value and the operand is an
-  // integer.
-  if (IsInteger(**base_value) && IsInteger(*operand_)) {
-    result->which_value_type = google_firestore_v1_Value_integer_value_tag;
-    result->integer_value =
-        SafeIncrement((*base_value)->integer_value, operand_->integer_value);
-  } else if (IsInteger(**base_value)) {
-    result->which_value_type = google_firestore_v1_Value_double_value_tag;
-    result->double_value = (*base_value)->integer_value + OperandAsDouble();
-  } else {
-    HARD_ASSERT(IsDouble(**base_value), "'base_value' is not of numeric type");
-    result->which_value_type = google_firestore_v1_Value_double_value_tag;
-    result->double_value = (*base_value)->double_value + OperandAsDouble();
+  // If either base_value or operand is Decimal128, the result is Decimal128.
+  if (IsDecimal128Value(**base_value) || IsDecimal128Value(*operand_)) {
+    // Local evaluation is an IEEE 754 64-bit double approximation for latency
+    // compensation before server acknowledgment.
+    double sum = ValueAsDouble(**base_value) + OperandAsDouble();
+    std::string sum_str;
+    if (std::isnan(sum)) {
+      sum_str = "NaN";
+    } else if (std::isinf(sum)) {
+      sum_str = sum < 0 ? "-Infinity" : "Infinity";
+    } else {
+      sum_str = absl::StrCat(sum);
+    }
+    return MakeDecimal128Value(sum_str);
   }
 
+  // If base_value is Int32:
+  if (IsInt32Value(**base_value)) {
+    int32_t base_int32 = static_cast<int32_t>(
+        (*base_value)->map_value.fields[0].value.integer_value);
+    if (IsDouble(*operand_)) {
+      Message<google_firestore_v1_Value> result;
+      result->which_value_type = google_firestore_v1_Value_double_value_tag;
+      result->double_value =
+          static_cast<double>(base_int32) + operand_->double_value;
+      return result;
+    } else if (IsInteger(*operand_)) {
+      Message<google_firestore_v1_Value> result;
+      result->which_value_type = google_firestore_v1_Value_integer_value_tag;
+      result->integer_value =
+          SafeIncrement(base_int32, operand_->integer_value);
+      return result;
+    } else {
+      int32_t operand_int32 = static_cast<int32_t>(
+          operand_->map_value.fields[0].value.integer_value);
+      return MakeInt32Value(SafeIncrementInt32(base_int32, operand_int32));
+    }
+  }
+
+  // If base_value is Integer:
+  if (IsInteger(**base_value)) {
+    int64_t base_int64 = (*base_value)->integer_value;
+    if (IsInteger(*operand_)) {
+      Message<google_firestore_v1_Value> result;
+      result->which_value_type = google_firestore_v1_Value_integer_value_tag;
+      result->integer_value =
+          SafeIncrement(base_int64, operand_->integer_value);
+      return result;
+    } else if (IsInt32Value(*operand_)) {
+      int32_t operand_int32 = static_cast<int32_t>(
+          operand_->map_value.fields[0].value.integer_value);
+      Message<google_firestore_v1_Value> result;
+      result->which_value_type = google_firestore_v1_Value_integer_value_tag;
+      result->integer_value = SafeIncrement(base_int64, operand_int32);
+      return result;
+    } else {
+      Message<google_firestore_v1_Value> result;
+      result->which_value_type = google_firestore_v1_Value_double_value_tag;
+      result->double_value =
+          static_cast<double>(base_int64) + operand_->double_value;
+      return result;
+    }
+  }
+
+  HARD_ASSERT(IsDouble(**base_value), "'base_value' is not of numeric type");
+  Message<google_firestore_v1_Value> result;
+  result->which_value_type = google_firestore_v1_Value_double_value_tag;
+  result->double_value = (*base_value)->double_value + OperandAsDouble();
   return result;
 }
 
@@ -530,37 +641,11 @@ NumericMinimumTransform::Rep::ApplyToLocalView(
   if (!IsNumber(previous_value)) {
     return DeepClone(*operand_);
   }
-
-  auto base_value = *previous_value;
-  Message<google_firestore_v1_Value> result;
-
-  // Return an integer value only if both the previous value and the operand are
-  // integers.
-  if (IsInteger(base_value) && IsInteger(*operand_)) {
-    result->which_value_type = google_firestore_v1_Value_integer_value_tag;
-    result->integer_value =
-        std::min(base_value.integer_value, operand_->integer_value);
-    return result;
-  }
-
-  double prev_double = IsInteger(base_value)
-                           ? static_cast<double>(base_value.integer_value)
-                           : base_value.double_value;
-  double oper_double = OperandAsDouble();
-
-  if (std::isnan(prev_double)) {
-    return DeepClone(base_value);
-  }
-  if (std::isnan(oper_double)) {
+  util::ComparisonResult cmp = CompareNumbers(*operand_, *previous_value);
+  if (cmp == util::ComparisonResult::Ascending) {
     return DeepClone(*operand_);
   }
-
-  if (prev_double == oper_double) {
-    return DeepClone(base_value);
-  }
-
-  bool choose_previous = prev_double < oper_double;
-  return choose_previous ? DeepClone(base_value) : DeepClone(*operand_);
+  return DeepClone(*previous_value);
 }
 
 Message<google_firestore_v1_Value>
@@ -570,37 +655,11 @@ NumericMaximumTransform::Rep::ApplyToLocalView(
   if (!IsNumber(previous_value)) {
     return DeepClone(*operand_);
   }
-
-  auto base_value = *previous_value;
-  Message<google_firestore_v1_Value> result;
-
-  // Return an integer value only if both the previous value and the operand are
-  // integers.
-  if (IsInteger(base_value) && IsInteger(*operand_)) {
-    result->which_value_type = google_firestore_v1_Value_integer_value_tag;
-    result->integer_value =
-        std::max(base_value.integer_value, operand_->integer_value);
-    return result;
-  }
-
-  double prev_double = IsInteger(base_value)
-                           ? static_cast<double>(base_value.integer_value)
-                           : base_value.double_value;
-  double oper_double = OperandAsDouble();
-
-  if (std::isnan(prev_double)) {
-    return DeepClone(base_value);
-  }
-  if (std::isnan(oper_double)) {
+  util::ComparisonResult cmp = CompareNumbers(*operand_, *previous_value);
+  if (cmp == util::ComparisonResult::Descending) {
     return DeepClone(*operand_);
   }
-
-  if (prev_double == oper_double) {
-    return DeepClone(base_value);
-  }
-
-  bool choose_previous = prev_double > oper_double;
-  return choose_previous ? DeepClone(base_value) : DeepClone(*operand_);
+  return DeepClone(*previous_value);
 }
 
 }  // namespace model

--- a/Firestore/core/src/model/value_util.cc
+++ b/Firestore/core/src/model/value_util.cc
@@ -1513,8 +1513,14 @@ google_firestore_v1_Value ZeroIntegerValue() {
 }
 
 bool IsNaNValue(const google_firestore_v1_Value& value) {
-  return value.which_value_type == google_firestore_v1_Value_double_value_tag &&
-         std::isnan(value.double_value);
+  if (value.which_value_type == google_firestore_v1_Value_double_value_tag &&
+      std::isnan(value.double_value)) {
+    return true;
+  }
+  if (IsDecimal128Value(value)) {
+    return ConvertNumericValueToQuadruple(value).is_nan();
+  }
+  return false;
 }
 
 google_firestore_v1_Value MinBoolean() {

--- a/Firestore/core/src/model/value_util.cc
+++ b/Firestore/core/src/model/value_util.cc
@@ -269,7 +269,10 @@ Quadruple ConvertNumericValueToQuadruple(
     return Quadruple(value.map_value.fields[0].value.integer_value);
   } else if (IsDecimal128Value(value)) {
     Quadruple result;
-    result.Parse(
+    bool success = result.Parse(
+        nanopb::MakeString(value.map_value.fields[0].value.string_value));
+    HARD_ASSERT(
+        success, "Failed to parse Decimal128 value: %s",
         nanopb::MakeString(value.map_value.fields[0].value.string_value));
     return result;
   }

--- a/Firestore/core/src/model/value_util.h
+++ b/Firestore/core/src/model/value_util.h
@@ -171,6 +171,8 @@ void SortFields(google_firestore_v1_ArrayValue& value);
 
 util::ComparisonResult Compare(const google_firestore_v1_Value& left,
                                const google_firestore_v1_Value& right);
+util::ComparisonResult CompareNumbers(const google_firestore_v1_Value& left,
+                                      const google_firestore_v1_Value& right);
 util::ComparisonResult LowerBoundCompare(const google_firestore_v1_Value& left,
                                          bool left_inclusive,
                                          const google_firestore_v1_Value& right,
@@ -429,9 +431,12 @@ inline bool IsDouble(const absl::optional<google_firestore_v1_Value>& value) {
          value->which_value_type == google_firestore_v1_Value_double_value_tag;
 }
 
-/** Returns true if `value` is either a INTEGER_VALUE or a DOUBLE_VALUE. */
+/** Returns true if `value` is a numeric type (INTEGER, DOUBLE, INT32, or
+ * DECIMAL128). */
 inline bool IsNumber(const absl::optional<google_firestore_v1_Value>& value) {
-  return IsInteger(value) || IsDouble(value);
+  return IsInteger(value) || IsDouble(value) ||
+         (value.has_value() &&
+          (IsInt32Value(*value) || IsDecimal128Value(*value)));
 }
 
 /** Returns true if `value` is an ARRAY_VALUE. */

--- a/Firestore/core/src/model/value_util.h
+++ b/Firestore/core/src/model/value_util.h
@@ -340,7 +340,8 @@ absl::optional<pb_size_t> IndexOfKey(
  */
 google_firestore_v1_Value NaNValue();
 
-/** Returns `true` if `value` is `NaN` (either IEEE 754 double or BSON Decimal128Value NaN) in its Protobuf representation . */
+/** Returns `true` if `value` is `NaN` (either IEEE 754 double or BSON
+ * Decimal128Value NaN) in its Protobuf representation . */
 bool IsNaNValue(const google_firestore_v1_Value& value);
 
 google_firestore_v1_Value TrueValue();

--- a/Firestore/core/src/model/value_util.h
+++ b/Firestore/core/src/model/value_util.h
@@ -340,7 +340,7 @@ absl::optional<pb_size_t> IndexOfKey(
  */
 google_firestore_v1_Value NaNValue();
 
-/** Returns `true` if `value` is `NaN` in its Protobuf representation. */
+/** Returns `true` if `value` is `NaN` (either IEEE 754 double or BSON Decimal128Value NaN) in its Protobuf representation . */
 bool IsNaNValue(const google_firestore_v1_Value& value);
 
 google_firestore_v1_Value TrueValue();

--- a/Firestore/core/src/remote/serializer.cc
+++ b/Firestore/core/src/remote/serializer.cc
@@ -578,7 +578,7 @@ Serializer::EncodeFieldTransform(const FieldTransform& field_transform) const {
           google_firestore_v1_DocumentTransform_FieldTransform_increment_tag;
       const auto& increment = static_cast<const NumericIncrementTransform&>(
           field_transform.transformation());
-      proto.increment = increment.operand();
+      proto.increment = *DeepClone(increment.operand()).release();
       return proto;
     }
 
@@ -587,7 +587,7 @@ Serializer::EncodeFieldTransform(const FieldTransform& field_transform) const {
           google_firestore_v1_DocumentTransform_FieldTransform_minimum_tag;
       const auto& minimum = static_cast<const NumericMinimumTransform&>(
           field_transform.transformation());
-      proto.minimum = minimum.operand();
+      proto.minimum = *DeepClone(minimum.operand()).release();
       return proto;
     }
 
@@ -596,7 +596,7 @@ Serializer::EncodeFieldTransform(const FieldTransform& field_transform) const {
           google_firestore_v1_DocumentTransform_FieldTransform_maximum_tag;
       const auto& maximum = static_cast<const NumericMaximumTransform&>(
           field_transform.transformation());
-      proto.maximum = maximum.operand();
+      proto.maximum = *DeepClone(maximum.operand()).release();
       return proto;
     }
   }
@@ -642,9 +642,11 @@ FieldTransform Serializer::DecodeFieldTransform(
     }
 
     case google_firestore_v1_DocumentTransform_FieldTransform_increment_tag: {
-      return FieldTransform(
+      FieldTransform field_transform(
           std::move(field),
           NumericIncrementTransform(MakeMessage(proto.increment)));
+      proto.increment = {};
+      return field_transform;
     }
 
     case google_firestore_v1_DocumentTransform_FieldTransform_minimum_tag: {

--- a/Firestore/core/test/unit/model/mutation_test.cc
+++ b/Firestore/core/test/unit/model/mutation_test.cc
@@ -16,6 +16,7 @@
 
 #include "Firestore/core/src/model/mutation.h"
 
+#include <type_traits>
 #include <utility>
 
 #include "Firestore/core/src/model/delete_mutation.h"
@@ -35,10 +36,12 @@ namespace {
 
 using nanopb::Message;
 using testutil::Array;
+using testutil::Decimal128;
 using testutil::DeletedDoc;
 using testutil::DeleteMutation;
 using testutil::Doc;
 using testutil::Field;
+using testutil::Int32;
 using testutil::Key;
 using testutil::Map;
 using testutil::MergeMutation;
@@ -290,19 +293,43 @@ void TransformBaseDoc(Message<google_firestore_v1_Value> base_data,
  * (This is defined in this way to reuse all the overload disambiguation that's
  * already built into `Value`.)
  */
-template <typename T>
-auto Increment(T value) -> decltype(NumericIncrementTransform(Value(value))) {
-  return NumericIncrementTransform(Value(value));
+template <typename T,
+          typename = typename std::enable_if<!std::is_same<
+              typename std::decay<T>::type,
+              nanopb::Message<google_firestore_v1_Value>>::value>::type>
+NumericIncrementTransform Increment(T&& value) {
+  return NumericIncrementTransform(Value(std::forward<T>(value)));
 }
 
-template <typename T>
-auto Minimum(T value) -> decltype(NumericMinimumTransform(Value(value))) {
-  return NumericMinimumTransform(Value(value));
+inline NumericIncrementTransform Increment(
+    nanopb::Message<google_firestore_v1_Value> value) {
+  return NumericIncrementTransform(std::move(value));
 }
 
-template <typename T>
-auto Maximum(T value) -> decltype(NumericMaximumTransform(Value(value))) {
-  return NumericMaximumTransform(Value(value));
+template <typename T,
+          typename = typename std::enable_if<!std::is_same<
+              typename std::decay<T>::type,
+              nanopb::Message<google_firestore_v1_Value>>::value>::type>
+NumericMinimumTransform Minimum(T&& value) {
+  return NumericMinimumTransform(Value(std::forward<T>(value)));
+}
+
+inline NumericMinimumTransform Minimum(
+    nanopb::Message<google_firestore_v1_Value> value) {
+  return NumericMinimumTransform(std::move(value));
+}
+
+template <typename T,
+          typename = typename std::enable_if<!std::is_same<
+              typename std::decay<T>::type,
+              nanopb::Message<google_firestore_v1_Value>>::value>::type>
+NumericMaximumTransform Maximum(T&& value) {
+  return NumericMaximumTransform(Value(std::forward<T>(value)));
+}
+
+inline NumericMaximumTransform Maximum(
+    nanopb::Message<google_firestore_v1_Value> value) {
+  return NumericMaximumTransform(std::move(value));
 }
 
 template <typename... Args>
@@ -399,6 +426,93 @@ TEST(MutationTest, AppliesIncrementWithoutUnderflow) {
   };
   auto expected =
       Map("a", LONG_MIN, "b", LONG_MIN, "c", LONG_MIN, "d", LONG_MIN);
+  TransformBaseDoc(std::move(base_data), transforms, std::move(expected));
+}
+
+TEST(MutationTest, AppliesIncrementWithoutOverflowOnInt32) {
+  auto base_data = Map("a", Int32(INT32_MAX - 1), "b", Int32(INT32_MAX - 1),
+                       "c", Int32(INT32_MAX), "d", Int32(INT32_MAX));
+  TransformPairs transforms = {
+      {"a", Increment(Int32(1))},
+      {"b", Increment(Int32(INT32_MAX))},
+      {"c", Increment(Int32(1))},
+      {"d", Increment(Int32(INT32_MAX))},
+  };
+  auto expected = Map("a", Int32(INT32_MAX), "b", Int32(INT32_MAX), "c",
+                      Int32(INT32_MAX), "d", Int32(INT32_MAX));
+  TransformBaseDoc(std::move(base_data), transforms, std::move(expected));
+}
+
+TEST(MutationTest, AppliesIncrementWithoutUnderflowOnInt32) {
+  auto base_data = Map("a", Int32(INT32_MIN + 1), "b", Int32(INT32_MIN + 1),
+                       "c", Int32(INT32_MIN), "d", Int32(INT32_MIN));
+  TransformPairs transforms = {
+      {"a", Increment(Int32(-1))},
+      {"b", Increment(Int32(INT32_MIN))},
+      {"c", Increment(Int32(-1))},
+      {"d", Increment(Int32(INT32_MIN))},
+  };
+  auto expected = Map("a", Int32(INT32_MIN), "b", Int32(INT32_MIN), "c",
+                      Int32(INT32_MIN), "d", Int32(INT32_MIN));
+  TransformBaseDoc(std::move(base_data), transforms, std::move(expected));
+}
+
+TEST(MutationTest, AppliesMixedInt32AndInt64IncrementBoundaries) {
+  auto base_data =
+      Map("int64_max_plus_int32", INT64_MAX, "int64_max_plus_int64", INT64_MAX,
+          "int64_min_plus_int32", INT64_MIN, "int64_min_plus_int64", INT64_MIN,
+          "int32_max_plus_int64", Int32(INT32_MAX), "int32_min_plus_int64",
+          Int32(INT32_MIN));
+  TransformPairs transforms = {
+      {"int64_max_plus_int32", Increment(Int32(10))},
+      {"int64_max_plus_int64", Increment(INT64_MAX)},
+      {"int64_min_plus_int32", Increment(Int32(-10))},
+      {"int64_min_plus_int64", Increment(INT64_MIN)},
+      {"int32_max_plus_int64", Increment(1L)},
+      {"int32_min_plus_int64", Increment(-1L)},
+  };
+  auto expected =
+      Map("int64_max_plus_int32", INT64_MAX, "int64_max_plus_int64", INT64_MAX,
+          "int64_min_plus_int32", INT64_MIN, "int64_min_plus_int64", INT64_MIN,
+          "int32_max_plus_int64", static_cast<int64_t>(INT32_MAX) + 1,
+          "int32_min_plus_int64", static_cast<int64_t>(INT32_MIN) - 1);
+  TransformBaseDoc(std::move(base_data), transforms, std::move(expected));
+}
+
+TEST(MutationTest, AppliesIncrementTransformToDocumentWithBsonTypes) {
+  auto base_data = Map(
+      "int32_plus_int32", Int32(10), "int32_plus_int64", Int32(10),
+      "int32_plus_double", Int32(10), "int64_plus_int32", 10L,
+      "double_plus_int32", 10.5, "decimal128_plus_int32", Decimal128("10.5"),
+      "decimal128_plus_int64", Decimal128("10.5"), "decimal128_plus_double",
+      Decimal128("10.5"), "decimal128_plus_decimal128", Decimal128("10.5"),
+      "int32_plus_decimal128", Int32(10), "int64_plus_decimal128", 10L,
+      "double_plus_decimal128", 10.5);
+
+  TransformPairs transforms = {
+      {"int32_plus_int32", Increment(Int32(5))},
+      {"int32_plus_int64", Increment(5L)},
+      {"int32_plus_double", Increment(1.5)},
+      {"int64_plus_int32", Increment(Int32(5))},
+      {"double_plus_int32", Increment(Int32(5))},
+      {"decimal128_plus_int32", Increment(Int32(5))},
+      {"decimal128_plus_int64", Increment(5L)},
+      {"decimal128_plus_double", Increment(5.5)},
+      {"decimal128_plus_decimal128", Increment(Decimal128("5.5"))},
+      {"int32_plus_decimal128", Increment(Decimal128("5.5"))},
+      {"int64_plus_decimal128", Increment(Decimal128("5.5"))},
+      {"double_plus_decimal128", Increment(Decimal128("5.5"))},
+  };
+
+  auto expected = Map(
+      "int32_plus_int32", Int32(15), "int32_plus_int64", 15L,
+      "int32_plus_double", 11.5, "int64_plus_int32", 15L, "double_plus_int32",
+      15.5, "decimal128_plus_int32", Decimal128("15.5"),
+      "decimal128_plus_int64", Decimal128("15.5"), "decimal128_plus_double",
+      Decimal128("16"), "decimal128_plus_decimal128", Decimal128("16"),
+      "int32_plus_decimal128", Decimal128("15.5"), "int64_plus_decimal128",
+      Decimal128("15.5"), "double_plus_decimal128", Decimal128("16"));
+
   TransformBaseDoc(std::move(base_data), transforms, std::move(expected));
 }
 
@@ -882,33 +996,89 @@ TEST(MutationTest, OverlayByCombinationsAndPermutations_Increments) {
 }
 
 TEST(MutationTest, AppliesMinimumTransformToDocument) {
-  auto base_data =
-      Map("longMinLong", 5, "longMinDouble", 5, "doubleMinLong", 5.5,
-          "doubleMinDouble", 5.5, "longMinNan", 5, "doubleMinNan", 5.5);
+  auto base_data = Map("longMinLong", 5, "longMinDouble", 5, "doubleMinLong",
+                       5.5, "doubleMinDouble", 5.5, "longMinNan", 5,
+                       "doubleMinNan", 5.5, "smaller", Int32(10), "larger",
+                       Int32(10), "equal_preserves_base_type", Int32(10),
+                       "cross_type", Decimal128("10.5"), "nan_ordering", 5L);
   TransformPairs transforms = {
-      {"longMinLong", Minimum(2)},   {"longMinDouble", Minimum(2.2)},
-      {"doubleMinLong", Minimum(2)}, {"doubleMinDouble", Minimum(2.2)},
-      {"longMinNan", Minimum(NAN)},  {"doubleMinNan", Minimum(NAN)},
+      {"longMinLong", Minimum(2)},
+      {"longMinDouble", Minimum(2.2)},
+      {"doubleMinLong", Minimum(2)},
+      {"doubleMinDouble", Minimum(2.2)},
+      {"longMinNan", Minimum(NAN)},
+      {"doubleMinNan", Minimum(NAN)},
+      {"smaller", Minimum(Int32(5))},
+      {"larger", Minimum(Int32(15))},
+      {"equal_preserves_base_type", Minimum(10L)},
+      {"cross_type", Minimum(Int32(5))},
+      {"missing_field", Minimum(Decimal128("42"))},
+      {"nan_ordering", Minimum(NAN)},
   };
   auto expected =
       Map("longMinLong", 2L, "longMinDouble", 2.2, "doubleMinLong", 2L,
-          "doubleMinDouble", 2.2, "longMinNan", NAN, "doubleMinNan", NAN);
+          "doubleMinDouble", 2.2, "longMinNan", NAN, "doubleMinNan", NAN,
+          "smaller", Int32(5), "larger", Int32(10), "equal_preserves_base_type",
+          Int32(10), "cross_type", Int32(5), "missing_field", Decimal128("42"),
+          "nan_ordering", NAN);
   TransformBaseDoc(std::move(base_data), transforms, std::move(expected));
 }
 
 TEST(MutationTest, AppliesMaximumTransformToDocument) {
-  auto base_data =
-      Map("longMaxLong", 5, "longMaxDouble", 5, "doubleMaxLong", 5.5,
-          "doubleMaxDouble", 5.5, "longMaxNan", 5, "doubleMaxNan", 5.5);
+  auto base_data = Map("longMaxLong", 5, "longMaxDouble", 5, "doubleMaxLong",
+                       5.5, "doubleMaxDouble", 5.5, "longMaxNan", 5,
+                       "doubleMaxNan", 5.5, "smaller", Int32(10), "larger",
+                       Int32(10), "equal_preserves_base_type", Int32(10),
+                       "cross_type", Decimal128("10.5"), "nan_ordering", NAN);
   TransformPairs transforms = {
-      {"longMaxLong", Maximum(8)},   {"longMaxDouble", Maximum(8.8)},
-      {"doubleMaxLong", Maximum(8)}, {"doubleMaxDouble", Maximum(8.8)},
-      {"longMaxNan", Maximum(NAN)},  {"doubleMaxNan", Maximum(NAN)},
+      {"longMaxLong", Maximum(8)},
+      {"longMaxDouble", Maximum(8.8)},
+      {"doubleMaxLong", Maximum(8)},
+      {"doubleMaxDouble", Maximum(8.8)},
+      {"longMaxNan", Maximum(NAN)},
+      {"doubleMaxNan", Maximum(NAN)},
+      {"smaller", Maximum(Int32(5))},
+      {"larger", Maximum(Int32(15))},
+      {"equal_preserves_base_type", Maximum(10L)},
+      {"cross_type", Maximum(Int32(15))},
+      {"missing_field", Maximum(Decimal128("42"))},
+      {"nan_ordering", Maximum(5L)},
   };
   auto expected =
       Map("longMaxLong", 8L, "longMaxDouble", 8.8, "doubleMaxLong", 8L,
-          "doubleMaxDouble", 8.8, "longMaxNan", NAN, "doubleMaxNan", NAN);
+          "doubleMaxDouble", 8.8, "longMaxNan", 5L, "doubleMaxNan", 5.5,
+          "smaller", Int32(10), "larger", Int32(15),
+          "equal_preserves_base_type", Int32(10), "cross_type", Int32(15),
+          "missing_field", Decimal128("42"), "nan_ordering", 5L);
   TransformBaseDoc(std::move(base_data), transforms, std::move(expected));
+}
+
+TEST(MutationTest, AppliesConsecutiveMixedNumericTransforms) {
+  auto base_data = Map("val", Int32(10));
+  TransformPairs transforms = {
+      {"val", Minimum(15L)},    // retains Int32(10)
+      {"val", Minimum(5L)},     // selects 5L
+      {"val", Maximum(20L)},    // selects 20L
+      {"val", Increment(10L)},  // 20 + 10 = 30L
+  };
+  auto expected = Map("val", 30L);
+  TransformBaseDoc(std::move(base_data), transforms, std::move(expected));
+}
+
+TEST(MutationTest, AppliesServerAckedMinimumAndMaximumTransforms) {
+  MutableDocument doc =
+      Doc("collection/key", 0, Map("min_val", 10L, "max_val", 10L));
+
+  Mutation transform =
+      SetMutation("collection/key", Map(),
+                  {{"min_val", Minimum(5L)}, {"max_val", Maximum(20L)}});
+
+  model::MutationResult mutation_result(Version(1), Array(5L, 20L));
+
+  transform.ApplyToRemoteDocument(doc, std::move(mutation_result));
+
+  EXPECT_EQ(doc, Doc("collection/key", 1, Map("min_val", 5L, "max_val", 20L))
+                     .SetHasCommittedMutations());
 }
 
 TEST(MutationTest, AppliesMinimumTransformToUnexpectedType) {

--- a/Firestore/core/test/unit/model/mutation_test.cc
+++ b/Firestore/core/test/unit/model/mutation_test.cc
@@ -1046,10 +1046,10 @@ TEST(MutationTest, AppliesMaximumTransformToDocument) {
   };
   auto expected =
       Map("longMaxLong", 8L, "longMaxDouble", 8.8, "doubleMaxLong", 8L,
-          "doubleMaxDouble", 8.8, "longMaxNan", 5L, "doubleMaxNan", 5.5,
+          "doubleMaxDouble", 8.8, "longMaxNan", NAN, "doubleMaxNan", NAN,
           "smaller", Int32(10), "larger", Int32(15),
           "equal_preserves_base_type", Int32(10), "cross_type", Int32(15),
-          "missing_field", Decimal128("42"), "nan_ordering", 5L);
+          "missing_field", Decimal128("42"), "nan_ordering", NAN);
   TransformBaseDoc(std::move(base_data), transforms, std::move(expected));
 }
 

--- a/Firestore/core/test/unit/model/transform_operation_test.cc
+++ b/Firestore/core/test/unit/model/transform_operation_test.cc
@@ -23,6 +23,8 @@ namespace firebase {
 namespace firestore {
 namespace model {
 
+using testutil::Decimal128;
+using testutil::Int32;
 using testutil::Value;
 
 using Type = TransformOperation::Type;
@@ -37,28 +39,85 @@ TEST(TransformOperationsTest, ServerTimestamp) {
   EXPECT_NE(transform, other);
 }
 
-TEST(TransformOperationsTest, Minimum) {
-  NumericMinimumTransform transform(Value(1));
-  EXPECT_EQ(Type::Minimum, transform.type());
+TEST(TransformOperationsTest, NumericIncrement) {
+  NumericIncrementTransform transform(Value(1));
+  EXPECT_EQ(Type::Increment, transform.type());
+  EXPECT_EQ(transform.operand(), *Value(1));
 
-  NumericMinimumTransform another(Value(1));
-  NumericMinimumTransform different(Value(2));
-  NumericIncrementTransform other(Value(1));
-  EXPECT_EQ(transform, another);
-  EXPECT_NE(transform, different);
-  EXPECT_NE(transform, other);
+  NumericIncrementTransform dup(Value(1));
+  NumericIncrementTransform other_val(Value(2));
+  NumericIncrementTransform int32_transform(Int32(1));
+  NumericIncrementTransform d128_transform(Decimal128("1.0"));
+
+  EXPECT_EQ(transform, dup);
+  EXPECT_NE(transform, other_val);
+  EXPECT_NE(transform, int32_transform);
+  EXPECT_NE(transform, d128_transform);
+  EXPECT_NE(transform, ServerTimestampTransform());
+
+  EXPECT_EQ(transform.Hash(), dup.Hash());
+  EXPECT_FALSE(transform.ToString().empty());
+
+  TransformOperation op = transform;
+  NumericIncrementTransform recovered(op);
+  EXPECT_EQ(recovered, transform);
+  EXPECT_EQ(recovered.operand(), *Value(1));
 }
 
-TEST(TransformOperationsTest, Maximum) {
-  NumericMaximumTransform transform(Value(1));
-  EXPECT_EQ(Type::Maximum, transform.type());
+TEST(TransformOperationsTest, NumericMinimum) {
+  NumericMinimumTransform transform(Value(5));
+  EXPECT_EQ(Type::Minimum, transform.type());
+  EXPECT_EQ(transform.operand(), *Value(5));
 
-  NumericMaximumTransform another(Value(1));
-  NumericMaximumTransform different(Value(2));
-  NumericMinimumTransform other(Value(1));
-  EXPECT_EQ(transform, another);
-  EXPECT_NE(transform, different);
-  EXPECT_NE(transform, other);
+  NumericMinimumTransform dup(Value(5));
+  NumericMinimumTransform other_val(Value(10));
+  NumericMinimumTransform int32_transform(Int32(5));
+  NumericMinimumTransform d128_transform(Decimal128("5.0"));
+  NumericIncrementTransform inc_transform(Value(5));
+
+  EXPECT_EQ(transform, dup);
+  EXPECT_NE(transform, other_val);
+  EXPECT_NE(transform, int32_transform);
+  EXPECT_NE(transform, d128_transform);
+  EXPECT_NE(transform, inc_transform);
+  EXPECT_NE(transform, ServerTimestampTransform());
+
+  EXPECT_EQ(transform.Hash(), dup.Hash());
+  EXPECT_FALSE(transform.ToString().empty());
+
+  TransformOperation op = transform;
+  NumericMinimumTransform recovered(op);
+  EXPECT_EQ(recovered, transform);
+  EXPECT_EQ(recovered.operand(), *Value(5));
+}
+
+TEST(TransformOperationsTest, NumericMaximum) {
+  NumericMaximumTransform transform(Value(10));
+  EXPECT_EQ(Type::Maximum, transform.type());
+  EXPECT_EQ(transform.operand(), *Value(10));
+
+  NumericMaximumTransform dup(Value(10));
+  NumericMaximumTransform other_val(Value(20));
+  NumericMaximumTransform int32_transform(Int32(10));
+  NumericMaximumTransform d128_transform(Decimal128("10.0"));
+  NumericMinimumTransform min_transform(Value(10));
+  NumericIncrementTransform inc_transform(Value(10));
+
+  EXPECT_EQ(transform, dup);
+  EXPECT_NE(transform, other_val);
+  EXPECT_NE(transform, int32_transform);
+  EXPECT_NE(transform, d128_transform);
+  EXPECT_NE(transform, min_transform);
+  EXPECT_NE(transform, inc_transform);
+  EXPECT_NE(transform, ServerTimestampTransform());
+
+  EXPECT_EQ(transform.Hash(), dup.Hash());
+  EXPECT_FALSE(transform.ToString().empty());
+
+  TransformOperation op = transform;
+  NumericMaximumTransform recovered(op);
+  EXPECT_EQ(recovered, transform);
+  EXPECT_EQ(recovered.operand(), *Value(10));
 }
 
 // TODO(mikelehen): Add ArrayTransform test once it no longer depends on

--- a/Firestore/core/test/unit/model/value_util_test.cc
+++ b/Firestore/core/test/unit/model/value_util_test.cc
@@ -287,57 +287,6 @@ TEST_F(ValueUtilTest, Decimal128Comparison) {
             ComparisonResult::Ascending);
 }
 
-TEST(QuadrupleTest, ParseValidAndMalformedStrings) {
-  Quadruple q;
-
-  // Valid inputs
-  EXPECT_TRUE(q.Parse("0"));
-  EXPECT_TRUE(q.Parse("-0"));
-  EXPECT_TRUE(q.Parse("0.0"));
-  EXPECT_TRUE(q.Parse("-0.0"));
-  EXPECT_TRUE(q.Parse("123.456"));
-  EXPECT_TRUE(q.Parse("-123.456"));
-  EXPECT_TRUE(q.Parse("+123.456"));
-  EXPECT_TRUE(q.Parse("1.23e4"));
-  EXPECT_TRUE(q.Parse("1.23e-4"));
-  EXPECT_TRUE(q.Parse("1.23E+4"));
-  EXPECT_TRUE(q.Parse("NaN"));
-  EXPECT_TRUE(q.Parse("Infinity"));
-  EXPECT_TRUE(q.Parse("+Infinity"));
-  EXPECT_TRUE(q.Parse("-Infinity"));
-
-  // Malformed inputs
-  EXPECT_FALSE(q.Parse(""));
-  EXPECT_FALSE(q.Parse(" "));
-  EXPECT_FALSE(q.Parse("abc"));
-  EXPECT_FALSE(q.Parse("123a"));
-  EXPECT_FALSE(q.Parse("1.2.3"));
-  EXPECT_FALSE(q.Parse("+"));
-  EXPECT_FALSE(q.Parse("-"));
-  EXPECT_FALSE(q.Parse("."));
-  EXPECT_FALSE(q.Parse("+."));
-  EXPECT_FALSE(q.Parse("-."));
-  EXPECT_FALSE(q.Parse("++1"));
-  EXPECT_FALSE(q.Parse("--1"));
-  EXPECT_FALSE(q.Parse("+-1"));
-  EXPECT_FALSE(q.Parse("1e"));
-  EXPECT_FALSE(q.Parse("1e+"));
-  EXPECT_FALSE(q.Parse("1e-"));
-  EXPECT_FALSE(q.Parse("1e999999999999"));
-  EXPECT_FALSE(q.Parse("1e12345678901"));
-  EXPECT_FALSE(q.Parse("NaNx"));
-  EXPECT_FALSE(q.Parse("InfinityAndBeyond"));
-
-  // Repeated calls do not leak or corrupt state
-  for (int iter = 0; iter < 1000; ++iter) {
-    EXPECT_TRUE(q.Parse("3.1415926535897932384626433832795028841971"));
-    EXPECT_FALSE(q.Parse("not_a_number_12345_!@#$"));
-    EXPECT_TRUE(q.Parse("-0.0000000000000000000000000000000000000123"));
-    EXPECT_FALSE(q.Parse("1e999999999999999999"));
-    EXPECT_TRUE(q.Parse("1e10"));
-  }
-}
-
 TEST_F(ValueUtilTest, Equality) {
   // Create a matrix that defines an equality group. The outer vector has
   // multiple rows and each row can have an arbitrary number of entries.

--- a/Firestore/core/test/unit/model/value_util_test.cc
+++ b/Firestore/core/test/unit/model/value_util_test.cc
@@ -24,6 +24,7 @@
 #include "Firestore/core/src/remote/serializer.h"
 #include "Firestore/core/src/util/comparison.h"
 #include "Firestore/core/src/util/defer.h"
+#include "Firestore/core/src/util/quadruple.h"
 #include "Firestore/core/test/unit/testutil/equals_tester.h"
 #include "Firestore/core/test/unit/testutil/testutil.h"
 #include "Firestore/core/test/unit/testutil/time_testing.h"
@@ -56,6 +57,7 @@ using testutil::time_point;
 using testutil::Value;
 using testutil::VectorType;
 using util::ComparisonResult;
+using util::Quadruple;
 
 namespace {
 
@@ -283,6 +285,57 @@ TEST_F(ValueUtilTest, Decimal128Comparison) {
             ComparisonResult::Same);
   EXPECT_EQ(Compare(*Decimal128("3.4e-5"), *Value(2.0F)),
             ComparisonResult::Ascending);
+}
+
+TEST(QuadrupleTest, ParseValidAndMalformedStrings) {
+  Quadruple q;
+
+  // Valid inputs
+  EXPECT_TRUE(q.Parse("0"));
+  EXPECT_TRUE(q.Parse("-0"));
+  EXPECT_TRUE(q.Parse("0.0"));
+  EXPECT_TRUE(q.Parse("-0.0"));
+  EXPECT_TRUE(q.Parse("123.456"));
+  EXPECT_TRUE(q.Parse("-123.456"));
+  EXPECT_TRUE(q.Parse("+123.456"));
+  EXPECT_TRUE(q.Parse("1.23e4"));
+  EXPECT_TRUE(q.Parse("1.23e-4"));
+  EXPECT_TRUE(q.Parse("1.23E+4"));
+  EXPECT_TRUE(q.Parse("NaN"));
+  EXPECT_TRUE(q.Parse("Infinity"));
+  EXPECT_TRUE(q.Parse("+Infinity"));
+  EXPECT_TRUE(q.Parse("-Infinity"));
+
+  // Malformed inputs
+  EXPECT_FALSE(q.Parse(""));
+  EXPECT_FALSE(q.Parse(" "));
+  EXPECT_FALSE(q.Parse("abc"));
+  EXPECT_FALSE(q.Parse("123a"));
+  EXPECT_FALSE(q.Parse("1.2.3"));
+  EXPECT_FALSE(q.Parse("+"));
+  EXPECT_FALSE(q.Parse("-"));
+  EXPECT_FALSE(q.Parse("."));
+  EXPECT_FALSE(q.Parse("+."));
+  EXPECT_FALSE(q.Parse("-."));
+  EXPECT_FALSE(q.Parse("++1"));
+  EXPECT_FALSE(q.Parse("--1"));
+  EXPECT_FALSE(q.Parse("+-1"));
+  EXPECT_FALSE(q.Parse("1e"));
+  EXPECT_FALSE(q.Parse("1e+"));
+  EXPECT_FALSE(q.Parse("1e-"));
+  EXPECT_FALSE(q.Parse("1e999999999999"));
+  EXPECT_FALSE(q.Parse("1e12345678901"));
+  EXPECT_FALSE(q.Parse("NaNx"));
+  EXPECT_FALSE(q.Parse("InfinityAndBeyond"));
+
+  // Repeated calls do not leak or corrupt state
+  for (int iter = 0; iter < 1000; ++iter) {
+    EXPECT_TRUE(q.Parse("3.1415926535897932384626433832795028841971"));
+    EXPECT_FALSE(q.Parse("not_a_number_12345_!@#$"));
+    EXPECT_TRUE(q.Parse("-0.0000000000000000000000000000000000000123"));
+    EXPECT_FALSE(q.Parse("1e999999999999999999"));
+    EXPECT_TRUE(q.Parse("1e10"));
+  }
 }
 
 TEST_F(ValueUtilTest, Equality) {

--- a/Firestore/core/test/unit/remote/serializer_test.cc
+++ b/Firestore/core/test/unit/remote/serializer_test.cc
@@ -88,6 +88,9 @@ using model::GetTypeOrder;
 using model::MutableDocument;
 using model::Mutation;
 using model::MutationResult;
+using model::NumericIncrementTransform;
+using model::NumericMaximumTransform;
+using model::NumericMinimumTransform;
 using model::ObjectValue;
 using model::PatchMutation;
 using model::Precondition;
@@ -2135,6 +2138,169 @@ TEST_F(SerializerTest, EncodesArrayTransform) {
   v1::ArrayValue& remove2 = *remove_proto2.mutable_remove_all_from_array();
   *remove2.add_values() = ValueProto(Map("x", 1));
   *patch_proto.add_update_transforms() = std::move(remove_proto2);
+
+  v1::DocumentMask mask;
+  patch_proto.set_allocated_update_mask(mask.New());
+  patch_proto.mutable_current_document()->set_exists(true);
+
+  ExpectRoundTrip(patch_model, patch_proto);
+}
+
+TEST_F(SerializerTest, EncodesNumericIncrementTransform) {
+  std::vector<std::pair<std::string, TransformOperation>> transforms = {
+      {"i64", NumericIncrementTransform(Value(int64_t{42}))},
+      {"dbl", NumericIncrementTransform(Value(42.5))},
+      {"i32", NumericIncrementTransform(Int32(42))},
+      {"d128", NumericIncrementTransform(Decimal128("42.5"))}};
+
+  SetMutation set_model = testutil::SetMutation("docs/1", Map(), transforms);
+
+  v1::Write set_proto;
+  v1::Document& doc = *set_proto.mutable_update();
+  doc.set_name(ResourceName("docs/1"));
+
+  v1::DocumentTransform::FieldTransform inc_proto1;
+  inc_proto1.set_field_path("i64");
+  *inc_proto1.mutable_increment() = ValueProto(int64_t{42});
+  *set_proto.add_update_transforms() = std::move(inc_proto1);
+
+  v1::DocumentTransform::FieldTransform inc_proto2;
+  inc_proto2.set_field_path("dbl");
+  *inc_proto2.mutable_increment() = ValueProto(42.5);
+  *set_proto.add_update_transforms() = std::move(inc_proto2);
+
+  v1::DocumentTransform::FieldTransform inc_proto3;
+  inc_proto3.set_field_path("i32");
+  *inc_proto3.mutable_increment() = ValueProto(Int32(42));
+  *set_proto.add_update_transforms() = std::move(inc_proto3);
+
+  v1::DocumentTransform::FieldTransform inc_proto4;
+  inc_proto4.set_field_path("d128");
+  *inc_proto4.mutable_increment() = ValueProto(Decimal128("42.5"));
+  *set_proto.add_update_transforms() = std::move(inc_proto4);
+
+  ExpectRoundTrip(set_model, set_proto);
+
+  PatchMutation patch_model =
+      testutil::PatchMutation("docs/1", Map(), transforms);
+
+  v1::Write patch_proto;
+  v1::Document& doc2 = *patch_proto.mutable_update();
+  doc2.set_name(ResourceName("docs/1"));
+
+  v1::DocumentTransform::FieldTransform patch_inc_proto1;
+  patch_inc_proto1.set_field_path("i64");
+  *patch_inc_proto1.mutable_increment() = ValueProto(int64_t{42});
+  *patch_proto.add_update_transforms() = std::move(patch_inc_proto1);
+
+  v1::DocumentTransform::FieldTransform patch_inc_proto2;
+  patch_inc_proto2.set_field_path("dbl");
+  *patch_inc_proto2.mutable_increment() = ValueProto(42.5);
+  *patch_proto.add_update_transforms() = std::move(patch_inc_proto2);
+
+  v1::DocumentTransform::FieldTransform patch_inc_proto3;
+  patch_inc_proto3.set_field_path("i32");
+  *patch_inc_proto3.mutable_increment() = ValueProto(Int32(42));
+  *patch_proto.add_update_transforms() = std::move(patch_inc_proto3);
+
+  v1::DocumentTransform::FieldTransform patch_inc_proto4;
+  patch_inc_proto4.set_field_path("d128");
+  *patch_inc_proto4.mutable_increment() = ValueProto(Decimal128("42.5"));
+  *patch_proto.add_update_transforms() = std::move(patch_inc_proto4);
+
+  v1::DocumentMask mask;
+  patch_proto.set_allocated_update_mask(mask.New());
+  patch_proto.mutable_current_document()->set_exists(true);
+
+  ExpectRoundTrip(patch_model, patch_proto);
+}
+
+TEST_F(SerializerTest, EncodesNumericMinimumTransform) {
+  std::vector<std::pair<std::string, TransformOperation>> transforms = {
+      {"i32", NumericMinimumTransform(Int32(42))},
+      {"d128", NumericMinimumTransform(Decimal128("42.5"))}};
+
+  SetMutation set_model = testutil::SetMutation("docs/1", Map(), transforms);
+
+  v1::Write set_proto;
+  v1::Document& doc = *set_proto.mutable_update();
+  doc.set_name(ResourceName("docs/1"));
+
+  v1::DocumentTransform::FieldTransform min_proto1;
+  min_proto1.set_field_path("i32");
+  *min_proto1.mutable_minimum() = ValueProto(Int32(42));
+  *set_proto.add_update_transforms() = std::move(min_proto1);
+
+  v1::DocumentTransform::FieldTransform min_proto2;
+  min_proto2.set_field_path("d128");
+  *min_proto2.mutable_minimum() = ValueProto(Decimal128("42.5"));
+  *set_proto.add_update_transforms() = std::move(min_proto2);
+
+  ExpectRoundTrip(set_model, set_proto);
+
+  PatchMutation patch_model =
+      testutil::PatchMutation("docs/1", Map(), transforms);
+
+  v1::Write patch_proto;
+  v1::Document& doc2 = *patch_proto.mutable_update();
+  doc2.set_name(ResourceName("docs/1"));
+
+  v1::DocumentTransform::FieldTransform patch_min_proto1;
+  patch_min_proto1.set_field_path("i32");
+  *patch_min_proto1.mutable_minimum() = ValueProto(Int32(42));
+  *patch_proto.add_update_transforms() = std::move(patch_min_proto1);
+
+  v1::DocumentTransform::FieldTransform patch_min_proto2;
+  patch_min_proto2.set_field_path("d128");
+  *patch_min_proto2.mutable_minimum() = ValueProto(Decimal128("42.5"));
+  *patch_proto.add_update_transforms() = std::move(patch_min_proto2);
+
+  v1::DocumentMask mask;
+  patch_proto.set_allocated_update_mask(mask.New());
+  patch_proto.mutable_current_document()->set_exists(true);
+
+  ExpectRoundTrip(patch_model, patch_proto);
+}
+
+TEST_F(SerializerTest, EncodesNumericMaximumTransform) {
+  std::vector<std::pair<std::string, TransformOperation>> transforms = {
+      {"i32", NumericMaximumTransform(Int32(42))},
+      {"d128", NumericMaximumTransform(Decimal128("42.5"))}};
+
+  SetMutation set_model = testutil::SetMutation("docs/1", Map(), transforms);
+
+  v1::Write set_proto;
+  v1::Document& doc = *set_proto.mutable_update();
+  doc.set_name(ResourceName("docs/1"));
+
+  v1::DocumentTransform::FieldTransform max_proto1;
+  max_proto1.set_field_path("i32");
+  *max_proto1.mutable_maximum() = ValueProto(Int32(42));
+  *set_proto.add_update_transforms() = std::move(max_proto1);
+
+  v1::DocumentTransform::FieldTransform max_proto2;
+  max_proto2.set_field_path("d128");
+  *max_proto2.mutable_maximum() = ValueProto(Decimal128("42.5"));
+  *set_proto.add_update_transforms() = std::move(max_proto2);
+
+  ExpectRoundTrip(set_model, set_proto);
+
+  PatchMutation patch_model =
+      testutil::PatchMutation("docs/1", Map(), transforms);
+
+  v1::Write patch_proto;
+  v1::Document& doc2 = *patch_proto.mutable_update();
+  doc2.set_name(ResourceName("docs/1"));
+
+  v1::DocumentTransform::FieldTransform patch_max_proto1;
+  patch_max_proto1.set_field_path("i32");
+  *patch_max_proto1.mutable_maximum() = ValueProto(Int32(42));
+  *patch_proto.add_update_transforms() = std::move(patch_max_proto1);
+
+  v1::DocumentTransform::FieldTransform patch_max_proto2;
+  patch_max_proto2.set_field_path("d128");
+  *patch_max_proto2.mutable_maximum() = ValueProto(Decimal128("42.5"));
+  *patch_proto.add_update_transforms() = std::move(patch_max_proto2);
 
   v1::DocumentMask mask;
   patch_proto.set_allocated_update_mask(mask.New());


### PR DESCRIPTION
Adds offline evaluation of numeric transformations (`increment`, `maximum`, `minimum`) on BSON types (`Int32Value` and `Decimal128Value`). 

Notes:
- `Decimal128` increment transforms have precision loss when evaluated locally, which is recovered upon receiving the write acknowledgement from the server. The local increment is only a 64-bit approximation of the increment.
- `minimum` and `maximum` transform implementations updated to use the `CompareNumbers` util which supports BSON numeric types, instead of strictly directly comparing `int` and `double` values.

Spec tests:
- Updated `doWriteAck` to parse `transformResults`
- Configured `PreConvert` in `FSTTestUserDatareader` to parson BSON JSON representations
- Added spec tests for Decimal128 precision loss recovery