### PR TITLE
Ignore locale changes for token freshness when `isInstallationIdEnabled` is `YES`

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- [fixed] Fix an issue where cached FCM registration tokens were falsely
+  invalidated due to locale changes when
+  `FirebaseMessagingInstallationIdEnabled` was set to `YES`. (#16572)
 - [fixed] Fix a potential crash when parsing malformed FCM payloads with
   unexpected non-numeric fields. (#16533)
 

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenInfo.m
@@ -124,9 +124,10 @@ static const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7
     return NO;
   }
 
-  // Check whether locale has changed, if yes, token needs to be updated with server for locale
-  // information.
-  if (FIRMessagingHasLocaleChanged()) {
+  // Check whether locale has changed. The new FID registration API does not track or send locale
+  // information (and bypasses the checkin API that persists it in user defaults), so locale
+  // changes only invalidate cached tokens in legacy checkin-based registration.
+  if (!isInstallationIdEnabled && FIRMessagingHasLocaleChanged()) {
     FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTokenInfoLocaleChanged,
                             @"Invalidating cached token due to locale change");
     return NO;

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenInfoTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenInfoTest.m
@@ -21,7 +21,10 @@
 #import <OCMock/OCMock.h>
 #import "FirebaseCore/Extension/FirebaseCoreInternal.h"
 #import "FirebaseMessaging/Sources/FIRMessagingUtilities.h"
+#import "FirebaseMessaging/Sources/FIRMessaging_Private.h"
+#import "FirebaseMessaging/Sources/Public/FirebaseMessaging/FIRMessaging.h"
 #import "FirebaseMessaging/Sources/Token/FIRMessagingAPNSInfo.h"
+#import "FirebaseMessaging/Tests/UnitTests/FIRMessagingTestUtilities.h"
 
 static NSString *const kAuthorizedEntity = @"authorizedEntity";
 static NSString *const kScope = @"scope";
@@ -74,6 +77,7 @@ static BOOL const kAPNSSandbox = NO;
 }
 
 - (void)tearDown {
+  [FIROptions defaultOptions].googleAppID = kFirebaseAppID;
   [self.mockOptions stopMocking];
   [super tearDown];
 }
@@ -148,6 +152,41 @@ static BOOL const kAPNSSandbox = NO;
   [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
+- (void)testTokenFreshnessWithLocaleChangeWhenInstallationIdEnabled {
+  NSUserDefaults *defaults =
+      [[NSUserDefaults alloc] initWithSuiteName:kFIRMessagingDefaultsTestDomain];
+  FIRMessagingTestUtilities *testUtil =
+      [[FIRMessagingTestUtilities alloc] initWithUserDefaults:defaults withRMQManager:NO];
+  OCMStub([testUtil.mockMessaging isInstallationIdEnabled]).andReturn(YES);
+
+  FIRMessagingTokenInfo *fidTokenInfo =
+      [[FIRMessagingTokenInfo alloc] initWithAuthorizedEntity:kAuthorizedEntity
+                                                        scope:kScope
+                                                        token:kToken
+                                                   appVersion:FIRMessagingCurrentAppVersion()
+                                                firebaseAppID:FIRMessagingFirebaseAppID()
+                                                    tokenType:@"FID"];
+  fidTokenInfo.APNSInfo = [[FIRMessagingAPNSInfo alloc] initWithDeviceToken:self.APNSDeviceToken
+                                                                  isSandbox:kAPNSSandbox];
+  fidTokenInfo.cacheTime = [NSDate date];
+
+  // Default should be fresh.
+  XCTAssertTrue([fidTokenInfo isFreshWithIID:kIID]);
+
+  // Set to a different locale than the current locale. Locale change should not affect FID token
+  // freshness.
+  [[NSUserDefaults standardUserDefaults] setObject:@"zh-Hant"
+                                            forKey:kFIRMessagingInstanceIDUserDefaultsKeyLocale];
+  [[NSUserDefaults standardUserDefaults] synchronize];
+  XCTAssertTrue([fidTokenInfo isFreshWithIID:kIID]);
+
+  // Reset locale
+  [[NSUserDefaults standardUserDefaults] setObject:FIRMessagingCurrentLocale()
+                                            forKey:kFIRMessagingInstanceIDUserDefaultsKeyLocale];
+  [[NSUserDefaults standardUserDefaults] synchronize];
+  [testUtil cleanupAfterTest:self];
+}
+
 - (void)testTokenFreshnessWithTokenTimestampChange {
   XCTAssertTrue([self.validTokenInfo isFreshWithIID:kIID]);
   // Set last fetch token time 7 days ago.
@@ -172,6 +211,7 @@ static BOOL const kAPNSSandbox = NO;
   // Change Firebase App ID.
   [FIROptions defaultOptions].googleAppID = @"newFirebaseAppID:ios:abcdefg";
   XCTAssertFalse([self.validTokenInfo isFreshWithIID:kIID]);
+  [FIROptions defaultOptions].googleAppID = kFirebaseAppID;
 }
 
 - (void)testTokenFreshnessWithAppVersionChange {


### PR DESCRIPTION
With the new FID registration API (#16133), we no longer use the legacy checkin flow. So the device locale info is never saved to user defaults or sent to the backend. Because `FIRMessagingTokenInfo` was still checking for locale changes, it always thought the locale had changed, kept invalidating cached FID tokens, and triggered unnecessary re-registrations every time the app subscribed to a topic or retrieved a token.

This PR updates `FIRMessagingTokenInfo` to only run the locale check for legacy registration (`!isInstallationIdEnabled`). 