### PR TITLE
Update podspec version for all GoogleUtilities in FirebasePerformance.podspec

### DIFF
--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -63,9 +63,9 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
   s.dependency 'FirebaseRemoteConfig', '~> 12.19.0'
   s.dependency 'FirebaseSessions', '~> 12.19.0'
   s.dependency 'GoogleDataTransport', '~> 10.1'
-  s.dependency 'GoogleUtilities/Environment', '~> 8.1'
-  s.dependency 'GoogleUtilities/MethodSwizzler', '~> 8.1.3'
-  s.dependency 'GoogleUtilities/UserDefaults', '~> 8.1'
+  s.dependency 'GoogleUtilities/Environment', '>= 8.1.3', '< 9.0'
+  s.dependency 'GoogleUtilities/MethodSwizzler', '>= 8.1.3', '< 9.0'
+  s.dependency 'GoogleUtilities/UserDefaults', '>= 8.1.3', '< 9.0'
   s.dependency 'nanopb', '~> 3.30910.0'
 
   s.test_spec 'unit' do |unit_tests|


### PR DESCRIPTION
Followup for https://github.com/firebase/firebase-ios-sdk/pull/16553.

Update all relevant `GoogleUtilities` podspec versions since the earlier approach was an optimistic minor which would've prevented minor version updates. (@paulb777 ++).