### PR TITLE
fix: wording in 12.19 CHANGELOG.md

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -2,8 +2,8 @@
 - [deprecated] Firebase 12.19.0 is the final planned minor release of 12.x and
   the final scheduled release published to CocoaPods. Future major versions
   (13.0.0+) will be distributed exclusively via Swift Package Manager and binary
-  distributions. Existing CocoaPods versions will remain functional and
-  available indefinitely.
+  distributions. Existing CocoaPods releases will remain available as long as
+  CocoaPods ecosystem support continues.
   See https://firebase.google.com/docs/ios/cocoapods-deprecation for details.
 - [fixed] Fixed a race condition where initializing Firebase in a multi-threaded
   environment could temporarily corrupt Foundation's locale and calendar caches,


### PR DESCRIPTION
#no-changelog