### PR TITLE
fix(auth): restore app extension build broken by UIApplication.shared

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- [fixed] Fixed a build error in app extensions introduced in 12.18.0, where
+  `AuthNotificationManager` referenced `UIApplication.shared` directly. (#16583)
 - [fixed] Fixed a persistent crash when interacting with App Check under some
   Swift toolchains (like the Flutter SDK) by avoiding a compiler bug in Swift
   concurrency thunk generation. (#16549)

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
@@ -22,9 +22,18 @@
   protocol AuthNotificationApplication: Sendable {
     var delegate: UIApplicationDelegate? { get }
     var applicationState: UIApplication.State { get }
+
+    /// The `UIApplication` to pass to `UIApplicationDelegate` callbacks.
+    ///
+    /// The delegate signature requires a concrete `UIApplication`, which a test double
+    /// cannot be. Vending it through the protocol keeps `UIApplication.shared` - which
+    /// is unavailable in app extensions - out of this module.
+    var applicationForDelegate: UIApplication { get }
   }
 
-  extension UIApplication: AuthNotificationApplication {}
+  extension UIApplication: AuthNotificationApplication {
+    var applicationForDelegate: UIApplication { self }
+  }
 
   class AuthNotificationManager: @unchecked Sendable {
     /// The key to locate payload data in the remote notification.
@@ -130,7 +139,7 @@
              delegate
              .responds(to: #selector(UIApplicationDelegate
                  .application(_:didReceiveRemoteNotification:fetchCompletionHandler:))) {
-            let appObj = (self.application as? UIApplication) ?? UIApplication.shared
+            let appObj = self.application.applicationForDelegate
             delegate.application?(appObj,
                                   didReceiveRemoteNotification: proberNotification) { _ in
             }

--- a/FirebaseAuth/Tests/Unit/AuthNotificationManagerTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthNotificationManagerTests.swift
@@ -143,6 +143,10 @@
     private class FakeApplication: AuthNotificationApplication, @unchecked Sendable {
       weak var delegate: UIApplicationDelegate?
       var applicationState: UIApplication.State = .active
+      // `FakeForwardingDelegate` ignores this argument, but the delegate signature
+      // requires a concrete `UIApplication`. Test targets are not built for app
+      // extensions, so `shared` is available here where it is not in the SDK.
+      var applicationForDelegate: UIApplication { .shared }
     }
 
     private class FakeForwardingDelegate: NSObject, UIApplicationDelegate {

--- a/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
@@ -1019,6 +1019,9 @@
       @unchecked Sendable {
       weak var delegate: UIApplicationDelegate?
       var applicationState: UIApplication.State = .active
+      // Test targets are not built for app extensions, so `shared` is available
+      // here where it is not in the SDK. See `AuthNotificationApplication`.
+      var applicationForDelegate: UIApplication { .shared }
       @MainActor func registerForRemoteNotifications() {}
     }
 


### PR DESCRIPTION
Fixes #16583.

## The problem

#16449 added an `AuthNotificationApplication` protocol so `AuthNotificationManager` could be unit tested with a fake. `UIApplicationDelegate.application(_:didReceiveRemoteNotification:fetchCompletionHandler:)` takes a concrete `UIApplication`, so the call site gained a downcast with a fallback:

```swift
let appObj = (self.application as? UIApplication) ?? UIApplication.shared
```

`UIApplication.shared` is `NS_EXTENSION_UNAVAILABLE_IOS`, so since 12.18.0 FirebaseAuth does not compile for targets built with `-application-extension`:

```
AuthNotificationManager.swift:133:80: error: 'shared' is unavailable in application extensions for iOS
```

## The fix

Vend the `UIApplication` the delegate callback needs through the protocol. The production conformance is `UIApplication` itself, so it returns `self`; the two test fakes return `UIApplication.shared` from the test target, which is not built for app extensions. That takes `UIApplication.shared` out of the SDK module entirely rather than hiding it behind a runtime lookup.

Behaviour is unchanged. In production `self.application` is always a real `UIApplication` — `AuthNotificationManager` is constructed only in `Auth.protectedDataInitialization()`, after its `GULAppEnvironmentUtil.isAppExtension()` early return — and the fake delegates in the tests ignore the argument.

## Alternative considered

The narrower change would be the reflection idiom already used at `Auth.swift:1704`, `AuthDefaultUIDelegate.swift:34` and `TOTPSecret.swift:64`, which would keep the diff inside one file. I went with the protocol because those three sites genuinely need the shared application at runtime in an app, whereas this one never does. Happy to switch if you would prefer the smaller change.

## Verification

```
xcodebuild build -scheme FirebaseAuth -destination 'generic/platform=iOS' \
  APPLICATION_EXTENSION_API_ONLY=YES CODE_SIGNING_ALLOWED=NO
```

| tree | result |
|---|---|
| `main` (168647efd) | `error: 'shared' is unavailable in application extensions for iOS` |
| this branch | `** BUILD SUCCEEDED **` |
| `12.17.0` tag (control) | `** BUILD SUCCEEDED **` |

`AuthUnit` passes on iOS Simulator, Xcode 26.6. SwiftFormat 0.55.5, the `Mintfile` pin, reports no formatting changes needed.

## Notes, not part of this change

- Nothing in the repo builds any product with `APPLICATION_EXTENSION_API_ONLY = YES`, which is how this reached a release. Under CocoaPods a consumer's extension target surfaced it as a build error, but SwiftPM builds each package product once without `-application-extension` (swiftlang/swift-package-manager#4402), so SwiftPM consumers link the unsafe call into their `.appex` with no diagnostic. With 12.19.0 the last CocoaPods release, that error path goes away. Glad to open a separate PR adding an extension-safe build to CI if that would be useful.
- #16449 also left the `/// A class represents a credential that proves the identity of the app.` doc comment and the `@preconcurrency` attribute attached to the new protocol rather than to `AuthNotificationManager`. Both look accidental and `@preconcurrency` is behaviour-affecting, so I left them for you rather than fold an unrelated change in here.
