### PR TITLE
refactor: feedback for #16541

### DIFF
--- a/FirebaseFunctions/CHANGELOG.md
+++ b/FirebaseFunctions/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
-- [changed] Requests directed to the local emulator over a non-loopback HTTP connection when tokens
-  are present will now explicitly fail with an `unauthenticated` error instead of silently omitting
-  the tokens and proceeding. (#16536)
+- [changed] Requests directed to the local emulator over a non-loopback HTTP connection
+  when tokens are present will now explicitly fail with an `unauthenticated` error
+  instead of silently omitting the tokens and proceeding. (#16536)
+- [added] Added a DEBUG-only `allowInsecureTokenAttachment` property on `Functions` to
+  allow insecure token attachment over HTTP for physical device testing. (#16536)
 
 # 12.17.0
 - [fixed] Resolved a concurrency resource leak in Functions stream cancellation. (#16392)

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -587,11 +587,10 @@ enum FunctionsConstants {
     urlRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
     urlRequest.httpMethod = "POST"
 
-    var shouldAttachTokens = url.isSecureOrLoopback
     #if DEBUG
-      if allowInsecureTokenAttachment {
-        shouldAttachTokens = true
-      }
+      let shouldAttachTokens = url.isSecureOrLoopback || allowInsecureTokenAttachment
+    #else
+      let shouldAttachTokens = url.isSecureOrLoopback
     #endif
     let hasTokens = context.authToken != nil || context.fcmToken != nil || context
       .appCheckToken != nil || context.limitedUseAppCheckToken != nil
@@ -666,11 +665,10 @@ enum FunctionsConstants {
       fetcher.allowedInsecureSchemes = ["http"]
     }
 
-    var shouldAttachTokens = url.isSecureOrLoopback
     #if DEBUG
-      if allowInsecureTokenAttachment {
-        shouldAttachTokens = true
-      }
+      let shouldAttachTokens = url.isSecureOrLoopback || allowInsecureTokenAttachment
+    #else
+      let shouldAttachTokens = url.isSecureOrLoopback
     #endif
     let hasTokens = context.authToken != nil || context.fcmToken != nil || context
       .appCheckToken != nil || context.limitedUseAppCheckToken != nil
@@ -775,6 +773,45 @@ enum FunctionsConstants {
     }
 
     return dataJSON
+  }
+
+  /// Validates whether tokens can safely be attached to the request.
+  /// - Throws: `FunctionsError.unauthenticated` when credentials would be transmitted insecurely
+  /// over HTTP to a non-loopback host.
+  /// - Returns: `true` if tokens should be attached, `false` otherwise.
+  private func shouldAttachTokens(to url: URL,
+                                  context: FunctionsContext,
+                                  logCode: String) throws -> Bool {
+    #if DEBUG
+      let shouldAttach = url.isSecureOrLoopback || allowInsecureTokenAttachment
+    #else
+      let shouldAttach = url.isSecureOrLoopback
+    #endif
+
+    guard shouldAttach else {
+      let hasTokens = context.authToken != nil ||
+        context.fcmToken != nil ||
+        context.appCheckToken != nil ||
+        context.limitedUseAppCheckToken != nil
+
+      if hasTokens && url.scheme?.lowercased() == "http" {
+        FirebaseLogger.log(
+          level: .warning,
+          service: "[FirebaseFunctions]",
+          code: logCode,
+          message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
+        )
+        throw FunctionsError(
+          .unauthenticated,
+          userInfo: [
+            NSLocalizedDescriptionKey: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host.",
+          ]
+        )
+      }
+      return false
+    }
+
+    return true
   }
 }
 

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -586,30 +586,8 @@ enum FunctionsConstants {
     urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
     urlRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
     urlRequest.httpMethod = "POST"
-
-    #if DEBUG
-      let shouldAttachTokens = url.isSecureOrLoopback || allowInsecureTokenAttachment
-    #else
-      let shouldAttachTokens = url.isSecureOrLoopback
-    #endif
-    let hasTokens = context.authToken != nil || context.fcmToken != nil || context
-      .appCheckToken != nil || context.limitedUseAppCheckToken != nil
-
-    guard shouldAttachTokens else {
-      if hasTokens && url.scheme?.lowercased() == "http" {
-        FirebaseLogger.log(
-          level: .warning,
-          service: "[FirebaseFunctions]",
-          code: "I-FUN000001",
-          message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
-        )
-        throw FunctionsError(
-          .unauthenticated,
-          userInfo: [
-            NSLocalizedDescriptionKey: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host.",
-          ]
-        )
-      }
+      
+    guard try shouldAttachTokens(to: url, context: context, logCode: "I-FUN000001") else {
       return urlRequest
     }
 
@@ -665,29 +643,7 @@ enum FunctionsConstants {
       fetcher.allowedInsecureSchemes = ["http"]
     }
 
-    #if DEBUG
-      let shouldAttachTokens = url.isSecureOrLoopback || allowInsecureTokenAttachment
-    #else
-      let shouldAttachTokens = url.isSecureOrLoopback
-    #endif
-    let hasTokens = context.authToken != nil || context.fcmToken != nil || context
-      .appCheckToken != nil || context.limitedUseAppCheckToken != nil
-
-    guard shouldAttachTokens else {
-      if hasTokens && url.scheme?.lowercased() == "http" {
-        FirebaseLogger.log(
-          level: .warning,
-          service: "[FirebaseFunctions]",
-          code: "I-FUN000002",
-          message: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host."
-        )
-        throw FunctionsError(
-          .unauthenticated,
-          userInfo: [
-            NSLocalizedDescriptionKey: "Refusing to send Auth, FCM, and AppCheck tokens over HTTP to non-loopback host.",
-          ]
-        )
-      }
+    guard try shouldAttachTokens(to: url, context: context, logCode: "I-FUN000002") else {
       return fetcher
     }
 
@@ -783,12 +739,12 @@ enum FunctionsConstants {
                                   context: FunctionsContext,
                                   logCode: String) throws -> Bool {
     #if DEBUG
-      let shouldAttach = url.isSecureOrLoopback || allowInsecureTokenAttachment
+      let shouldAttachTokens = url.isSecureOrLoopback || allowInsecureTokenAttachment
     #else
-      let shouldAttach = url.isSecureOrLoopback
+      let shouldAttachTokens = url.isSecureOrLoopback
     #endif
 
-    guard shouldAttach else {
+    guard shouldAttachTokens else {
       let hasTokens = context.authToken != nil ||
         context.fcmToken != nil ||
         context.appCheckToken != nil ||

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -586,7 +586,7 @@ enum FunctionsConstants {
     urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
     urlRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
     urlRequest.httpMethod = "POST"
-      
+
     guard try shouldAttachTokens(to: url, context: context, logCode: "I-FUN000001") else {
       return urlRequest
     }

--- a/FirebaseFunctions/Sources/Functions.swift
+++ b/FirebaseFunctions/Sources/Functions.swift
@@ -75,7 +75,7 @@ enum FunctionsConstants {
     /// connections.
     /// This should only be used for local testing and debugging on physical devices.
     /// To prevent accidental credential leaks, this property is only available in DEBUG builds.
-    @objc open var allowInsecureTokenAttachment: Bool = false
+    @nonobjc public var allowInsecureTokenAttachment: Bool = false
   #endif
 
   /// Creates a Cloud Functions client using the default or returns a pre-existing instance if it

--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -2,8 +2,10 @@
 - [fixed] Fixed an issue where constructing a download URL could fail or produce
   an invalid path if the storage bucket name contained special characters. (#16529)
 - [changed] Requests directed to the local emulator over a non-loopback HTTP connection
-  when token providers are configured will now explicitly fail with an `unauthenticated`
+  when tokens are present will now explicitly fail with an `unauthenticated`
   error instead of silently omitting the tokens and proceeding. (#16536)
+- [added] Added a DEBUG-only `allowInsecureTokenAttachment` property on `Storage` to
+  allow insecure token attachment over HTTP for physical device testing. (#16536)
 
 # 12.17.0
 - [changed] Enforced stricter transport layer security when using the emulator: Auth and AppCheck

--- a/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
+++ b/FirebaseStorage/Sources/Internal/StorageFetcherService.swift
@@ -40,16 +40,18 @@ actor StorageFetcherService {
       fetcherService.allowLocalhostRequest = true
       fetcherService.maxRetryInterval = storage.maxOperationRetryInterval
       fetcherService.testBlock = testBlock
-      var allowInsecureTokenAttachment = false
-      #if DEBUG
-        allowInsecureTokenAttachment = storage.allowInsecureTokenAttachment
-      #endif
       let authorizer = StorageTokenAuthorizer(
         googleAppID: app.options.googleAppID,
         callbackQueue: storage.callbackQueue,
         authProvider: storage.auth,
         appCheck: storage.appCheck,
-        allowInsecureTokenAttachment: allowInsecureTokenAttachment
+        allowInsecureTokenAttachment: { [weak storage] in
+          #if DEBUG
+            return storage?.allowInsecureTokenAttachment ?? false
+          #else
+            return false
+          #endif
+        }
       )
       fetcherService.authorizer = authorizer
       if storage.usesEmulator {

--- a/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
+++ b/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
@@ -66,9 +66,7 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
     if let appCheck {
       fetchTokenGroup.enter()
       appCheck.getToken(forcingRefresh: false) { tokenResult in
-        if let token = tokenResult.token {
-          request?.setValue(token, forHTTPHeaderField: "X-Firebase-AppCheck")
-        }
+        request?.setValue(tokenResult.token, forHTTPHeaderField: "X-Firebase-AppCheck")
 
         if let error = tokenResult.error {
           FirebaseLogger.log(

--- a/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
+++ b/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
@@ -42,11 +42,10 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
     let isHttps = scheme == "https"
     let host = request?.url?.host?.lowercased() ?? ""
     let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]"
-    var shouldAttachTokens = isHttps || isLoopback
     #if DEBUG
-      if allowInsecureTokenAttachment() {
-        shouldAttachTokens = true
-      }
+      let shouldAttachTokens = isHttps || isLoopback || allowInsecureTokenAttachment()
+    #else
+      let shouldAttachTokens = isHttps || isLoopback
     #endif
 
     if let auth {

--- a/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
+++ b/FirebaseStorage/Sources/Internal/StorageTokenAuthorizer.swift
@@ -42,34 +42,12 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
     let isHttps = scheme == "https"
     let host = request?.url?.host?.lowercased() ?? ""
     let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]"
-    var shouldFetchTokens = isHttps || isLoopback
+    var shouldAttachTokens = isHttps || isLoopback
     #if DEBUG
-      if allowInsecureTokenAttachment {
-        shouldFetchTokens = true
+      if allowInsecureTokenAttachment() {
+        shouldAttachTokens = true
       }
     #endif
-    let hasTokenProviders = auth != nil || appCheck != nil
-
-    guard shouldFetchTokens else {
-      if hasTokenProviders && scheme == "http" {
-        FirebaseLogger.log(
-          level: .warning,
-          service: "[FirebaseStorage]",
-          code: "I-STR000002",
-          message: "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host."
-        )
-        tokenError = StorageError
-          .unauthenticated(
-            serverError: [
-              "message": "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host.",
-            ]
-          ) as NSError
-      }
-      fetchTokenGroup.notify(queue: callbackQueue) {
-        handler(tokenError)
-      }
-      return
-    }
 
     if let auth {
       fetchTokenGroup.enter()
@@ -89,7 +67,9 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
     if let appCheck {
       fetchTokenGroup.enter()
       appCheck.getToken(forcingRefresh: false) { tokenResult in
-        request?.setValue(tokenResult.token, forHTTPHeaderField: "X-Firebase-AppCheck")
+        if let token = tokenResult.token {
+          request?.setValue(token, forHTTPHeaderField: "X-Firebase-AppCheck")
+        }
 
         if let error = tokenResult.error {
           FirebaseLogger.log(
@@ -104,6 +84,28 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
     }
 
     fetchTokenGroup.notify(queue: callbackQueue) {
+      let tokensWereAttached = request?.value(forHTTPHeaderField: "Authorization") != nil ||
+        request?.value(forHTTPHeaderField: "X-Firebase-AppCheck") != nil
+
+      if tokensWereAttached && !shouldAttachTokens && scheme == "http" {
+        // Strip tokens so credentials aren't transmitted over cleartext HTTP
+        request?.setValue(nil, forHTTPHeaderField: "Authorization")
+        request?.setValue(nil, forHTTPHeaderField: "X-Firebase-AppCheck")
+
+        FirebaseLogger.log(
+          level: .warning,
+          service: "[FirebaseStorage]",
+          code: "I-STR000002",
+          message: "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host."
+        )
+        tokenError = StorageError
+          .unauthenticated(
+            serverError: [
+              "message": "Refusing to send Auth and AppCheck tokens over HTTP to non-loopback host.",
+            ]
+          ) as NSError
+      }
+
       handler(tokenError)
     }
   }
@@ -139,7 +141,7 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
   private let auth: AuthInterop?
   private let appCheck: AppCheckInterop?
   #if DEBUG
-    private let allowInsecureTokenAttachment: Bool
+    private let allowInsecureTokenAttachment: () -> Bool
   #endif
 
   private let serialAuthArgsQueue = DispatchQueue(label: "com.google.firebasestorage.authorizer")
@@ -148,7 +150,7 @@ class StorageTokenAuthorizer: NSObject, GTMSessionFetcherAuthorizer {
        callbackQueue: DispatchQueue = DispatchQueue.main,
        authProvider: AuthInterop?,
        appCheck: AppCheckInterop?,
-       allowInsecureTokenAttachment: Bool = false) {
+       allowInsecureTokenAttachment: @escaping () -> Bool = { false }) {
     self.googleAppID = googleAppID
     self.callbackQueue = callbackQueue
     auth = authProvider

--- a/FirebaseStorage/Sources/Storage.swift
+++ b/FirebaseStorage/Sources/Storage.swift
@@ -116,7 +116,7 @@ internal import FirebaseCoreExtension
     /// connections.
     /// This should only be used for local testing and debugging on physical devices.
     /// To prevent accidental credential leaks, this property is only available in DEBUG builds.
-    @objc public var allowInsecureTokenAttachment: Bool = false
+    @nonobjc public var allowInsecureTokenAttachment: Bool = false
   #endif
 
   /// Creates a `StorageReference` initialized at the root Firebase Storage location.

--- a/FirebaseStorage/Tests/Unit/StorageAuthorizerTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageAuthorizerTests.swift
@@ -230,6 +230,27 @@ class StorageAuthorizerTests: StorageTestHelpers {
     XCTAssertNil(headers?["X-Firebase-AppCheck"])
   }
 
+  func testInsecureHostSucceedsWhenAuthProviderIsPresentButUserSignedOut() async throws {
+    let unauthenticatedAuthFake = FIRAuthInteropFake(token: nil, userID: nil, error: nil)
+    let insecureRequest = URLRequest(url: URL(string: "http://10.0.0.1/v0/b/bucket/o/object")!)
+    fetcher = GTMSessionFetcher(request: insecureRequest)
+    fetcher?.allowedInsecureSchemes = ["http"]
+    fetcher?.authorizer = StorageTokenAuthorizer(
+      googleAppID: "dummyAppID",
+      callbackQueue: DispatchQueue.main,
+      authProvider: unauthenticatedAuthFake,
+      appCheck: nil
+    )
+
+    setFetcherTestBlock(with: 200) { fetcher in
+      self.checkAuthorizer(fetcher: fetcher, trueFalse: false)
+    }
+    let _ = try await fetcher?.beginFetch()
+    let headers = fetcher!.request?.allHTTPHeaderFields
+    XCTAssertNil(headers?["Authorization"])
+    XCTAssertNil(headers?["X-Firebase-AppCheck"])
+  }
+
   func testLocalhostDoesAttachTokensOverHttp() async throws {
     appCheck?.tokenResult = appCheckTokenSuccess!
     let localRequest = URLRequest(url: URL(string: "http://localhost/v0/b/bucket/o/object")!)
@@ -245,6 +266,34 @@ class StorageAuthorizerTests: StorageTestHelpers {
     setFetcherTestBlock(with: 200) { fetcher in
       self.checkAuthorizer(fetcher: fetcher, trueFalse: true)
     }
+    let _ = try await fetcher?.beginFetch()
+    let headers = fetcher!.request?.allHTTPHeaderFields
+    XCTAssertEqual(headers?["Authorization"], "Firebase \(StorageTestAuthToken)")
+    XCTAssertEqual(headers?["X-Firebase-AppCheck"], appCheckTokenSuccess?.token)
+  }
+
+  func testDynamicAllowInsecureTokenAttachment() async throws {
+    appCheck?.tokenResult = appCheckTokenSuccess!
+    let insecureRequest = URLRequest(url: URL(string: "http://10.0.0.1/v0/b/bucket/o/object")!)
+    fetcher = GTMSessionFetcher(request: insecureRequest)
+    fetcher?.allowedInsecureSchemes = ["http"]
+
+    var allowInsecure = false
+    fetcher?.authorizer = StorageTokenAuthorizer(
+      googleAppID: "dummyAppID",
+      callbackQueue: DispatchQueue.main,
+      authProvider: auth,
+      appCheck: appCheck,
+      allowInsecureTokenAttachment: { allowInsecure }
+    )
+
+    // Update allowInsecure to true after authorizer has been initialized
+    allowInsecure = true
+
+    setFetcherTestBlock(with: 200) { fetcher in
+      self.checkAuthorizer(fetcher: fetcher, trueFalse: true)
+    }
+
     let _ = try await fetcher?.beginFetch()
     let headers = fetcher!.request?.allHTTPHeaderFields
     XCTAssertEqual(headers?["Authorization"], "Firebase \(StorageTestAuthToken)")

--- a/FirebaseStorage/Tests/Unit/StorageAuthorizerTests.swift
+++ b/FirebaseStorage/Tests/Unit/StorageAuthorizerTests.swift
@@ -300,6 +300,49 @@ class StorageAuthorizerTests: StorageTestHelpers {
     XCTAssertEqual(headers?["X-Firebase-AppCheck"], appCheckTokenSuccess?.token)
   }
 
+  func testInsecureHostFailsWhenOnlyAppCheckTokenIsPresent() async throws {
+    appCheck?.tokenResult = appCheckTokenSuccess!
+    let insecureRequest = URLRequest(url: URL(string: "http://10.0.0.1/v0/b/bucket/o/object")!)
+    fetcher = GTMSessionFetcher(request: insecureRequest)
+    fetcher?.allowedInsecureSchemes = ["http"]
+    fetcher?.authorizer = StorageTokenAuthorizer(
+      googleAppID: "dummyAppID",
+      callbackQueue: DispatchQueue.main,
+      authProvider: nil,
+      appCheck: appCheck
+    )
+
+    do {
+      let _ = try await fetcher?.beginFetch()
+      XCTFail("Expected fetch to fail due to insecure AppCheck token attachment")
+    } catch {
+      let nsError = error as NSError
+      XCTAssertEqual(nsError.domain, StorageErrorDomain)
+      XCTAssertEqual(nsError.code, StorageErrorCode.unauthenticated.rawValue)
+    }
+  }
+
+  func testInsecureHostFailsWhenOnlyAuthTokenIsPresent() async throws {
+    let insecureRequest = URLRequest(url: URL(string: "http://10.0.0.1/v0/b/bucket/o/object")!)
+    fetcher = GTMSessionFetcher(request: insecureRequest)
+    fetcher?.allowedInsecureSchemes = ["http"]
+    fetcher?.authorizer = StorageTokenAuthorizer(
+      googleAppID: "dummyAppID",
+      callbackQueue: DispatchQueue.main,
+      authProvider: auth,
+      appCheck: nil
+    )
+
+    do {
+      let _ = try await fetcher?.beginFetch()
+      XCTFail("Expected fetch to fail due to insecure Auth token attachment")
+    } catch {
+      let nsError = error as NSError
+      XCTAssertEqual(nsError.domain, StorageErrorDomain)
+      XCTAssertEqual(nsError.code, StorageErrorCode.unauthenticated.rawValue)
+    }
+  }
+
   // MARK: Helpers
 
   private func setFetcherTestBlock(with statusCode: Int,


### PR DESCRIPTION
## Problem
When testing on a physical iOS device against a local emulator over LAN HTTP (`http://192.168.1.x`):
1. `Functions` and `Storage` silently dropped Auth and AppCheck tokens, causing signed-in requests to execute unauthenticated and corrupt client state.
2. In `Storage`, setting `storage.allowInsecureTokenAttachment = true` after startup was ignored because `GTMSessionFetcherService` cached the property at creation time.
3. In `Storage`, signed-out requests failed with an `unauthenticated` error even when no user was logged in (unlike `Functions`, which allowed signed-out HTTP requests).

## Solution
* Added `#if DEBUG` property `allowInsecureTokenAttachment: Bool` (`@nonobjc public var`) on `Functions` and `Storage` so developers can opt in for local physical device testing.
* Deduplicated `Functions` token validation into a shared `shouldAttachTokens` helper.
* Updated `StorageFetcherService` to pass a weak closure for `allowInsecureTokenAttachment` so flag updates apply to cached fetcher services.
* Updated `StorageTokenAuthorizer` to evaluate security after token resolution. Signed-out requests without tokens now succeed over HTTP in `Storage` (matching `Functions`), while requests with tokens present fail with `.unauthenticated` unless opted in.

## Testing
* Added `testDynamicAllowInsecureTokenAttachment` (verifies flag updates apply to cached fetchers).
* Added `testInsecureHostSucceedsWhenAuthProviderIsPresentButUserSignedOut` (verifies signed-out parity).
* Formatted via `./scripts/style.sh`.