### PR TITLE
ci(auth): add app extension build check

### DIFF
--- a/.github/workflows/_spm.yml
+++ b/.github/workflows/_spm.yml
@@ -69,6 +69,12 @@ on:
         required: false
         default: "{}"
 
+      # Extra flags to pass to scripts/build.sh xcodebuild invocation.
+      extra_flags:
+        type: string
+        required: false
+        default: ""
+
     outputs:
       cache_key:
         description: "The cache key for the Swift package resolution."
@@ -184,6 +190,7 @@ jobs:
         FIREBASE_IS_NIGHTLY_TESTING: ${{ inputs.is_nightly && '1' || '' }}
         TARGET: ${{ inputs.target }}
         PLATFORM: ${{ matrix.platform }}
+        EXTRA_FLAGS: ${{ inputs.extra_flags }}
       with:
         timeout_minutes: 15
         max_attempts: 3
@@ -192,7 +199,8 @@ jobs:
           ./scripts/build.sh \
             "$TARGET" \
             "$PLATFORM" \
-            ${{ (contains(inputs.buildonly_platforms, matrix.platform) || contains(inputs.buildonly_platforms, 'all')) && 'spmbuildonly' || 'spm' }}
+            ${{ (contains(inputs.buildonly_platforms, matrix.platform) || contains(inputs.buildonly_platforms, 'all')) && 'spmbuildonly' || 'spm' }} \
+            $EXTRA_FLAGS
     - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       if: ${{ failure() }}
       with:

--- a/.github/workflows/sdk.auth.yml
+++ b/.github/workflows/sdk.auth.yml
@@ -35,6 +35,14 @@ jobs:
       target: AuthUnit
       buildonly_platforms: macOS
 
+  spm_app_extension:
+    uses: ./.github/workflows/_spm.yml
+    with:
+      target: FirebaseAuth
+      platforms: iOS
+      buildonly_platforms: iOS
+      extra_flags: APPLICATION_EXTENSION_API_ONLY=YES
+
   catalyst:
     uses: ./.github/workflows/_catalyst.yml
     with:


### PR DESCRIPTION
Repros:
```
  Error: 'shared' is unavailable in application extensions for iOS: Use view controller based solutions where appropriate instead.
              let appObj = (self.application as? UIApplication) ?? UIApplication.shared
                                                                                 ^~~~~~
```
#no-changelog