### PR TITLE
feat(ai): add ModelResource and endpoint config

### DIFF
--- a/Sources/GeminiAPIClient/EndpointConfiguration.swift
+++ b/Sources/GeminiAPIClient/EndpointConfiguration.swift
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Defines the network endpoint configuration for Gemini API requests.
+package struct EndpointConfiguration: Sendable, Hashable, Equatable {
+  /// The URI scheme (e.g., `"https"` or `"http"`).
+  let scheme: String
+
+  /// The host name of the endpoint (e.g., `"generativelanguage.googleapis.com"`).
+  let host: String
+
+  /// An optional port number (e.g., for local emulators or custom proxies).
+  let port: Int?
+
+  /// The API version path component (e.g., `"v1beta"` or `"v1beta1"`).
+  let apiVersion: String
+
+  /// Initializes a new endpoint configuration.
+  ///
+  /// - Parameters:
+  ///   - scheme: The URI scheme. Defaults to `"https"`.
+  ///   - host: The host name of the target service.
+  ///   - port: An optional port number. Defaults to `nil`.
+  ///   - apiVersion: The target API version path component.
+  package init(
+    scheme: String = "https",
+    host: String,
+    port: Int? = nil,
+    apiVersion: String
+  ) {
+    self.scheme = scheme
+    self.host = host
+    self.port = port
+    self.apiVersion = apiVersion
+  }
+}

--- a/Sources/GeminiAPIClient/GeminiAPIClient.swift
+++ b/Sources/GeminiAPIClient/GeminiAPIClient.swift
@@ -24,36 +24,35 @@ package import GeminiAPIDataModels
 /// A client for communicating with Google Gemini backend endpoints.
 @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 package struct GeminiAPIClient: Sendable {
-  /// The resource path of the target model (e.g., `"v1beta/models/gemini-3.5-flash-lite"`
-  /// or `"v1beta1/projects/p/locations/l/publishers/google/models/gemini-3.5-flash-lite"`).
-  let modelResourcePath: String
+  /// The model resource configuration specifying identifiers for URL routing and payloads.
+  let modelResource: ModelResource
 
-  /// The base URL of the Gemini API endpoint.
-  let baseURL: URL
+  /// The network endpoint configuration defining scheme, host, port, and API version.
+  let endpointConfiguration: EndpointConfiguration
 
   /// An optional async provider for dynamic headers (such as API keys or Bearer tokens).
-  let headerProvider: (@Sendable () async throws -> [String: String])?
+  let headerProvider: HeaderProvider?
 
   private let httpClient: HTTPStreamingClient
 
-  /// Initializes a new Gemini API client with a model resource path and target base URL.
+  /// Initializes a new Gemini API client with a model resource and target endpoint configuration.
   ///
   /// - Parameters:
-  ///   - modelResourcePath: The resource path of the target model (e.g.,
-  ///     `"v1beta/models/gemini-3.5-flash-lite"`).
-  ///   - baseURL: The base URL of the Gemini API endpoint.
+  ///   - modelResource: The model resource configuration.
+  ///   - endpointConfiguration: The network endpoint configuration.
   ///   - headerProvider: An optional async provider for dynamic headers (such as API keys or Bearer
   ///     tokens).
   ///   - sessionConfiguration: The `URLSessionConfiguration` to use. Defaults to `.ephemeral`.
   package init(
-    modelResourcePath: String,
-    baseURL: URL,
-    headerProvider: (@Sendable () async throws -> [String: String])? = nil,
+    modelResource: ModelResource,
+    endpointConfiguration: EndpointConfiguration,
+    headerProvider: HeaderProvider? = nil,
     sessionConfiguration: URLSessionConfiguration = .ephemeral
   ) {
-    assert(!modelResourcePath.isEmpty, "modelResourcePath must not be empty.")
-    self.modelResourcePath = modelResourcePath
-    self.baseURL = baseURL
+    assert(
+      !modelResource.urlResourceName.isEmpty, "modelResource.urlResourceName must not be empty.")
+    self.modelResource = modelResource
+    self.endpointConfiguration = endpointConfiguration
     self.headerProvider = headerProvider
     self.httpClient = HTTPStreamingClient(configuration: sessionConfiguration)
   }
@@ -106,27 +105,42 @@ package struct GeminiAPIClient: Sendable {
     return try JSONDecoder().decode(CountTokensResponse.self, from: bodyData)
   }
 
+  /// Assembles the complete request URL for the configured model resource and endpoint.
+  ///
+  /// - Parameters:
+  ///   - action: The RPC action to invoke (e.g., `"streamGenerateContent"`).
+  ///   - queryItems: An optional array of query items to append to the URL.
+  /// - Returns: The resolved `URL`.
+  /// - Throws: `URLError(.badURL)` if the components do not form a valid URL.
+  func makeRequestURL(
+    action: String,
+    queryItems: [URLQueryItem]? = nil
+  ) throws -> URL {
+    var components = URLComponents()
+    components.scheme = endpointConfiguration.scheme
+    components.host = endpointConfiguration.host
+    components.port = endpointConfiguration.port
+
+    let slashSet = CharacterSet(charactersIn: "/")
+    let sanitizedVersion = endpointConfiguration.apiVersion.trimmingCharacters(in: slashSet)
+    let sanitizedResourcePath = modelResource.urlResourceName.trimmingCharacters(in: slashSet)
+
+    components.path = "/\(sanitizedVersion)/\(sanitizedResourcePath):\(action)"
+    if let queryItems, !queryItems.isEmpty {
+      components.queryItems = queryItems
+    }
+    guard let url = components.url else {
+      throw URLError(.badURL)
+    }
+    return url
+  }
+
   private func makeURLRequest<Body: Encodable>(
     action: String,
     queryItems: [URLQueryItem]? = nil,
     body: Body
   ) async throws -> URLRequest {
-    guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
-      throw URLError(.badURL)
-    }
-
-    let sanitizedResourcePath = modelResourcePath.drop { $0 == "/" }
-    let basePath =
-      components.path.hasSuffix("/")
-      ? String(components.path.dropLast())
-      : components.path
-    components.path = "\(basePath)/\(sanitizedResourcePath):\(action)"
-    if let queryItems {
-      components.queryItems = (components.queryItems ?? []) + queryItems
-    }
-    guard let requestURL = components.url else {
-      throw URLError(.badURL)
-    }
+    let requestURL = try makeRequestURL(action: action, queryItems: queryItems)
 
     var urlRequest = URLRequest(url: requestURL)
     urlRequest.httpMethod = "POST"

--- a/Sources/GeminiAPIClient/HeaderProvider.swift
+++ b/Sources/GeminiAPIClient/HeaderProvider.swift
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// A thread-safe, hashable wrapper around an asynchronous header provider closure.
+///
+/// Because closures cannot conform to `Equatable` or `Hashable`, each `HeaderProvider`
+/// generates a unique identifier upon initialization. This allows it to be used in hashable
+/// configuration types such as `Executor.Configuration`.
+package struct HeaderProvider: Sendable {
+  private let id = UUID()
+  private let headerProvider: @Sendable () async throws -> [String: String]
+
+  /// Creates a new header provider wrapping the specified async closure.
+  ///
+  /// - Parameter headerProvider: An async closure that supplies dynamic HTTP headers.
+  package init(_ headerProvider: @Sendable @escaping () async throws -> [String: String]) {
+    self.headerProvider = headerProvider
+  }
+
+  /// Invokes the underlying closure to produce HTTP headers.
+  ///
+  /// - Returns: A dictionary of HTTP header fields and values.
+  /// - Throws: Any error thrown by the underlying header provider closure.
+  package func callAsFunction() async throws -> [String: String] {
+    try await headerProvider()
+  }
+}
+
+// MARK: - Equatable
+
+extension HeaderProvider: Equatable {
+  /// Indicates whether two header providers are identical instances.
+  ///
+  /// - Parameters:
+  ///   - lhs: A header provider to compare.
+  ///   - rhs: Another header provider to compare.
+  /// - Returns: `true` if both instances share the same identifier, otherwise `false`.
+  package static func == (lhs: HeaderProvider, rhs: HeaderProvider) -> Bool {
+    lhs.id == rhs.id
+  }
+}
+
+// MARK: - Hashable
+
+extension HeaderProvider: Hashable {
+  /// Hashes the essential components of this value into the given hasher.
+  ///
+  /// - Parameter hasher: The hasher to use when combining the components of this instance.
+  package func hash(into hasher: inout Hasher) {
+    hasher.combine(id)
+  }
+}

--- a/Sources/GeminiAPIClient/ModelResource.swift
+++ b/Sources/GeminiAPIClient/ModelResource.swift
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Defines the various string representations of a model required for API routing and payloads.
+///
+/// Since Gemini APIs use Resource-Oriented Design, a single model requires different string
+/// formats depending on whether it is being placed in a URL path or serialized into a JSON body.
+package struct ModelResource: Sendable, Hashable, Equatable {
+  /// The raw, unqualified identifier for the model.
+  ///
+  /// - Note: While the format is consistent (e.g., `gemini-3.8-flash`), the specific models
+  ///   available and their exact identifiers may differ between backend environments.
+  let modelID: String
+
+  /// The fully qualified resource name used when constructing HTTP request URLs.
+  ///
+  /// The format depends on the target backend and whether the request is routed directly
+  /// or through Firebase AI Logic.
+  ///
+  /// ### Gemini Developer API
+  /// - **Direct:** `models/{modelID}`
+  /// - **Firebase AI Logic:** `projects/{projectID}/models/{modelID}`
+  ///
+  /// ### Gemini Enterprise Agent Platform
+  /// The format is identical for both direct and Firebase AI Logic requests:
+  /// - `projects/{projectID}/locations/{locationID}/publishers/google/models/{modelID}`
+  let urlResourceName: String
+
+  /// The canonical resource name used when serializing nested JSON payloads.
+  ///
+  /// Unlike the URL path, the JSON payload format must always use the canonical name
+  /// expected by the downstream service, regardless of whether the request is routed directly or
+  /// through Firebase AI Logic.
+  ///
+  /// ### Formats
+  /// - **Gemini Developer API:** `models/{modelID}`
+  /// - **Gemini Enterprise Agent Platform:** `publishers/google/models/{modelID}`
+  let payloadResourceName: String
+
+  /// Creates a new model resource configuration.
+  ///
+  /// - Parameters:
+  ///   - modelID: The raw, unqualified identifier for the model (e.g., `gemini-3.8-flash`).
+  ///   - urlResourceName: The fully qualified resource name to be used in HTTP request URL paths.
+  ///   - payloadResourceName: The canonical resource name to be serialized into request payloads.
+  package init(modelID: String, urlResourceName: String, payloadResourceName: String) {
+    self.modelID = modelID
+    self.urlResourceName = urlResourceName
+    self.payloadResourceName = payloadResourceName
+  }
+}

--- a/Tests/GeminiAPIClientTests/EndpointConfigurationTests.swift
+++ b/Tests/GeminiAPIClientTests/EndpointConfigurationTests.swift
@@ -1,0 +1,153 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+
+@testable import GeminiAPIClient
+
+@Suite("EndpointConfiguration Tests")
+struct EndpointConfigurationTests {
+  private static let host = "generativelanguage.googleapis.com"
+  private static let apiVersion = "v1beta"
+  private static let modelResource = ModelResource(
+    modelID: "gemini-3.8-flash",
+    urlResourceName: "models/gemini-3.8-flash",
+    payloadResourceName: "models/gemini-3.8-flash"
+  )
+
+  @Test
+  func defaultInitialization() {
+    let endpoint = EndpointConfiguration(
+      host: Self.host,
+      apiVersion: Self.apiVersion
+    )
+
+    #expect(endpoint.scheme == "https")
+    #expect(endpoint.host == Self.host)
+    #expect(endpoint.port == nil)
+    #expect(endpoint.apiVersion == Self.apiVersion)
+  }
+
+  @Test
+  func customSchemeAndPortInitialization() {
+    let scheme = "http"
+    let host = "localhost"
+    let port = 8080
+    let endpoint = EndpointConfiguration(
+      scheme: scheme,
+      host: host,
+      port: port,
+      apiVersion: Self.apiVersion
+    )
+
+    #expect(endpoint.scheme == scheme)
+    #expect(endpoint.host == host)
+    #expect(endpoint.port == port)
+    #expect(endpoint.apiVersion == Self.apiVersion)
+  }
+
+  @Test
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+  func urlAssemblyStandard() throws {
+    let endpoint = EndpointConfiguration(
+      host: Self.host,
+      apiVersion: Self.apiVersion
+    )
+    let client = GeminiAPIClient(
+      modelResource: Self.modelResource,
+      endpointConfiguration: endpoint
+    )
+    let action = "streamGenerateContent"
+
+    let url = try client.makeRequestURL(
+      action: action,
+      queryItems: [URLQueryItem(name: "alt", value: "sse")]
+    )
+
+    let expectedPath = "\(Self.modelResource.urlResourceName):\(action)"
+    let expectedURL = "https://\(Self.host)/\(Self.apiVersion)/\(expectedPath)?alt=sse"
+    #expect(url.absoluteString == expectedURL)
+  }
+
+  @Test
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+  func urlAssemblySanitizesSlashes() throws {
+    let endpoint = EndpointConfiguration(
+      host: Self.host,
+      apiVersion: "/\(Self.apiVersion)/"
+    )
+    let modelResource = ModelResource(
+      modelID: "gemini-3.8-flash",
+      urlResourceName: "/\(Self.modelResource.urlResourceName)/",
+      payloadResourceName: "models/gemini-3.8-flash"
+    )
+    let client = GeminiAPIClient(
+      modelResource: modelResource,
+      endpointConfiguration: endpoint
+    )
+    let action = "countTokens"
+
+    let url = try client.makeRequestURL(action: action)
+
+    let expectedPath = "\(Self.modelResource.urlResourceName):\(action)"
+    let expectedURL = "https://\(Self.host)/\(Self.apiVersion)/\(expectedPath)"
+    #expect(url.absoluteString == expectedURL)
+  }
+
+  @Test
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+  func urlAssemblyWithCustomPort() throws {
+    let scheme = "http"
+    let host = "localhost"
+    let port = 8080
+    let endpoint = EndpointConfiguration(
+      scheme: scheme,
+      host: host,
+      port: port,
+      apiVersion: Self.apiVersion
+    )
+    let client = GeminiAPIClient(
+      modelResource: Self.modelResource,
+      endpointConfiguration: endpoint
+    )
+    let action = "streamGenerateContent"
+
+    let url = try client.makeRequestURL(action: action)
+
+    let expectedPath = "\(Self.modelResource.urlResourceName):\(action)"
+    let expectedURL = "\(scheme)://\(host):\(port)/\(Self.apiVersion)/\(expectedPath)"
+    #expect(url.absoluteString == expectedURL)
+  }
+
+  @Test
+  func equalityAndHashing() {
+    let endpoint1 = EndpointConfiguration(
+      host: Self.host,
+      apiVersion: Self.apiVersion
+    )
+    let endpoint2 = EndpointConfiguration(
+      host: Self.host,
+      apiVersion: Self.apiVersion
+    )
+    let endpoint3 = EndpointConfiguration(
+      host: "firebasevertexai.googleapis.com",
+      apiVersion: Self.apiVersion
+    )
+
+    #expect(endpoint1 == endpoint2)
+    #expect(endpoint1 != endpoint3)
+    #expect(endpoint1.hashValue == endpoint2.hashValue)
+  }
+}

--- a/Tests/GeminiAPIClientTests/GeminiAPIClientIntegrationTests.swift
+++ b/Tests/GeminiAPIClientTests/GeminiAPIClientIntegrationTests.swift
@@ -25,8 +25,15 @@ import Testing
 
 @Suite("GeminiAPIClient Integration Tests")
 struct GeminiAPIClientIntegrationTests {
-  private static let defaultBaseURL = URL(string: "https://generativelanguage.googleapis.com")!
-  private static let defaultModelResourcePath = "v1beta/models/gemini-3.5-flash-lite"
+  private static let defaultEndpointConfiguration = EndpointConfiguration(
+    host: "generativelanguage.googleapis.com",
+    apiVersion: "v1beta"
+  )
+  private static let defaultModelResource = ModelResource(
+    modelID: "gemini-3.5-flash-lite",
+    urlResourceName: "models/gemini-3.5-flash-lite",
+    payloadResourceName: "models/gemini-3.5-flash-lite"
+  )
 
   @Test(.requireAPIKey)
   @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
@@ -120,7 +127,12 @@ struct GeminiAPIClientIntegrationTests {
   @Test(.requireAPIKey)
   @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func streamGenerateContentInvalidModelNameThrows() async throws {
-    let client = makeClient(modelResourcePath: "v1beta/models/non-existent-model-name-xyz-123")
+    let invalidResource = ModelResource(
+      modelID: "non-existent-model-name-xyz-123",
+      urlResourceName: "models/non-existent-model-name-xyz-123",
+      payloadResourceName: "models/non-existent-model-name-xyz-123"
+    )
+    let client = makeClient(modelResource: invalidResource)
     let request = GenerateContentRequest(
       contents: [
         Content(
@@ -140,8 +152,8 @@ struct GeminiAPIClientIntegrationTests {
   @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func streamGenerateContentWithoutAuthThrows() async throws {
     let client = GeminiAPIClient(
-      modelResourcePath: Self.defaultModelResourcePath,
-      baseURL: Self.defaultBaseURL
+      modelResource: Self.defaultModelResource,
+      endpointConfiguration: Self.defaultEndpointConfiguration
     )
     let request = GenerateContentRequest(
       contents: [
@@ -196,11 +208,19 @@ struct GeminiAPIClientIntegrationTests {
       debugToken: debugToken
     )
     let appCheckToken = try await appCheckClient.exchangeDebugToken()
-    let modelPath = "v1beta/projects/\(projectID)/models/gemini-3.5-flash-lite"
+    let modelResource = ModelResource(
+      modelID: "gemini-3.5-flash-lite",
+      urlResourceName: "projects/\(projectID)/models/gemini-3.5-flash-lite",
+      payloadResourceName: "models/gemini-3.5-flash-lite"
+    )
+    let endpointConfiguration = EndpointConfiguration(
+      host: "firebasevertexai.googleapis.com",
+      apiVersion: "v1beta"
+    )
     let client = GeminiAPIClient(
-      modelResourcePath: modelPath,
-      baseURL: URL(string: "https://firebasevertexai.googleapis.com")!,
-      headerProvider: {
+      modelResource: modelResource,
+      endpointConfiguration: endpointConfiguration,
+      headerProvider: HeaderProvider {
         [
           "x-goog-api-key": apiKey,
           "x-firebase-appcheck": appCheckToken,
@@ -244,8 +264,8 @@ struct GeminiAPIClientIntegrationTests {
 
   @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   private func makeClient(
-    modelResourcePath: String = defaultModelResourcePath,
-    baseURL: URL = defaultBaseURL,
+    modelResource: ModelResource = defaultModelResource,
+    endpointConfiguration: EndpointConfiguration = defaultEndpointConfiguration,
     configuration: URLSessionConfiguration = .ephemeral
   ) -> GeminiAPIClient {
     let headerProvider: (@Sendable () async throws -> [String: String])?
@@ -258,9 +278,9 @@ struct GeminiAPIClientIntegrationTests {
     }
 
     return GeminiAPIClient(
-      modelResourcePath: modelResourcePath,
-      baseURL: baseURL,
-      headerProvider: headerProvider,
+      modelResource: modelResource,
+      endpointConfiguration: endpointConfiguration,
+      headerProvider: headerProvider.map { HeaderProvider($0) },
       sessionConfiguration: configuration
     )
   }

--- a/Tests/GeminiAPIClientTests/GeminiAPIClientTests.swift
+++ b/Tests/GeminiAPIClientTests/GeminiAPIClientTests.swift
@@ -25,13 +25,21 @@ import Testing
 
 @Suite("GeminiAPIClient Tests")
 struct GeminiAPIClientTests {
-  private static let baseURLString = "https://generativelanguage.googleapis.com"
-  private static let defaultModelResourcePath = "v1beta/models/gemini-3.5-flash-lite"
+  private static let defaultHost = "generativelanguage.googleapis.com"
+  private static let defaultAPIVersion = "v1beta"
+  private static let defaultModelResource = ModelResource(
+    modelID: "gemini-3.5-flash-lite",
+    urlResourceName: "models/gemini-3.5-flash-lite",
+    payloadResourceName: "models/gemini-3.5-flash-lite"
+  )
 
   private let testID = UUID().uuidString
 
-  private var testBaseURL: URL {
-    URL(string: "\(Self.baseURLString)/\(testID)")!
+  private var testEndpointConfiguration: EndpointConfiguration {
+    EndpointConfiguration(
+      host: Self.defaultHost,
+      apiVersion: "\(Self.defaultAPIVersion)/\(testID)"
+    )
   }
 
   @Test
@@ -775,10 +783,24 @@ struct GeminiAPIClientTests {
   @Test
   @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func streamGenerateContentAgentPlatformResourcePath() async throws {
-    let agentPlatformPath =
-      "v1beta1/projects/my-project/locations/global/publishers/google/models/gemini-3.5-flash-lite"
-    let client = makeClient(modelResourcePath: agentPlatformPath)
-    let expectedURL = try makeExpectedURL(modelResourcePath: agentPlatformPath)
+    let agentPlatformResource = ModelResource(
+      modelID: "gemini-3.5-flash-lite",
+      urlResourceName:
+        "projects/my-project/locations/global/publishers/google/models/gemini-3.5-flash-lite",
+      payloadResourceName: "publishers/google/models/gemini-3.5-flash-lite"
+    )
+    let agentPlatformEndpoint = EndpointConfiguration(
+      host: "generativelanguage.googleapis.com",
+      apiVersion: "v1beta1/\(testID)"
+    )
+    let client = makeClient(
+      modelResource: agentPlatformResource,
+      endpointConfiguration: agentPlatformEndpoint
+    )
+    let expectedURL = try makeExpectedURL(
+      modelResource: agentPlatformResource,
+      endpointConfiguration: agentPlatformEndpoint
+    )
     let httpResponse = try makeResponse(
       url: expectedURL,
       headerFields: ["Content-Type": "text/event-stream"]
@@ -812,9 +834,23 @@ struct GeminiAPIClientTests {
   @Test
   @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func streamGenerateContentFirebaseProxyResourcePath() async throws {
-    let firebaseProxyPath = "v1beta/projects/my-firebase-project/models/gemini-3.5-flash-lite"
-    let client = makeClient(modelResourcePath: firebaseProxyPath)
-    let expectedURL = try makeExpectedURL(modelResourcePath: firebaseProxyPath)
+    let firebaseResource = ModelResource(
+      modelID: "gemini-3.5-flash-lite",
+      urlResourceName: "projects/my-firebase-project/models/gemini-3.5-flash-lite",
+      payloadResourceName: "models/gemini-3.5-flash-lite"
+    )
+    let firebaseEndpoint = EndpointConfiguration(
+      host: "firebasevertexai.googleapis.com",
+      apiVersion: "v1beta/\(testID)"
+    )
+    let client = makeClient(
+      modelResource: firebaseResource,
+      endpointConfiguration: firebaseEndpoint
+    )
+    let expectedURL = try makeExpectedURL(
+      modelResource: firebaseResource,
+      endpointConfiguration: firebaseEndpoint
+    )
     let httpResponse = try makeResponse(
       url: expectedURL,
       headerFields: ["Content-Type": "text/event-stream"]
@@ -848,11 +884,25 @@ struct GeminiAPIClientTests {
   @Test
   @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   func countTokensAgentPlatformResourcePath() async throws {
-    let agentPlatformPath =
-      "v1beta1/projects/my-project/locations/global/publishers/google/models/gemini-3.5-flash-lite"
-    let client = makeClient(modelResourcePath: agentPlatformPath)
+    let agentPlatformResource = ModelResource(
+      modelID: "gemini-3.5-flash-lite",
+      urlResourceName:
+        "projects/my-project/locations/global/publishers/google/models/gemini-3.5-flash-lite",
+      payloadResourceName: "publishers/google/models/gemini-3.5-flash-lite"
+    )
+    let agentPlatformEndpoint = EndpointConfiguration(
+      host: "generativelanguage.googleapis.com",
+      apiVersion: "v1beta1/\(testID)"
+    )
+    let client = makeClient(
+      modelResource: agentPlatformResource,
+      endpointConfiguration: agentPlatformEndpoint
+    )
     let expectedURL = try makeExpectedURL(
-      modelResourcePath: agentPlatformPath, action: "countTokens", query: nil
+      modelResource: agentPlatformResource,
+      endpointConfiguration: agentPlatformEndpoint,
+      action: "countTokens",
+      query: nil
     )
     let httpResponse = try makeResponse(
       url: expectedURL,
@@ -898,16 +948,16 @@ struct GeminiAPIClientTests {
 
   @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   private func makeClient(
-    modelResourcePath: String = defaultModelResourcePath,
-    baseURL: URL? = nil,
+    modelResource: ModelResource = defaultModelResource,
+    endpointConfiguration: EndpointConfiguration? = nil,
     headerProvider: (@Sendable () async throws -> [String: String])? = nil
   ) -> GeminiAPIClient {
     let configuration = URLSessionConfiguration.ephemeral
     configuration.protocolClasses = [MockHTTPURLProtocol.self]
     return GeminiAPIClient(
-      modelResourcePath: modelResourcePath,
-      baseURL: baseURL ?? testBaseURL,
-      headerProvider: headerProvider,
+      modelResource: modelResource,
+      endpointConfiguration: endpointConfiguration ?? testEndpointConfiguration,
+      headerProvider: headerProvider.map { HeaderProvider($0) },
       sessionConfiguration: configuration
     )
   }
@@ -921,15 +971,28 @@ struct GeminiAPIClientTests {
     try HTTPURLResponse.mock(url: url, statusCode: statusCode, headerFields: headerFields)
   }
 
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
   private func makeExpectedURL(
-    modelResourcePath: String = defaultModelResourcePath,
+    modelResource: ModelResource = defaultModelResource,
+    endpointConfiguration: EndpointConfiguration? = nil,
     action: String = "streamGenerateContent",
     query: String? = "alt=sse"
   ) throws -> URL {
-    var urlString = "\(testBaseURL.absoluteString)/\(modelResourcePath):\(action)"
+    let client = makeClient(
+      modelResource: modelResource,
+      endpointConfiguration: endpointConfiguration
+    )
+    let queryItems: [URLQueryItem]?
     if let query {
-      urlString += "?\(query)"
+      let parts = query.split(separator: "=", maxSplits: 1)
+      if parts.count == 2 {
+        queryItems = [URLQueryItem(name: String(parts[0]), value: String(parts[1]))]
+      } else {
+        queryItems = [URLQueryItem(name: query, value: nil)]
+      }
+    } else {
+      queryItems = nil
     }
-    return try #require(URL(string: urlString))
+    return try client.makeRequestURL(action: action, queryItems: queryItems)
   }
 }

--- a/Tests/GeminiAPIClientTests/HeaderProviderTests.swift
+++ b/Tests/GeminiAPIClientTests/HeaderProviderTests.swift
@@ -1,0 +1,71 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+
+@testable import GeminiAPIClient
+
+@Suite("HeaderProvider Tests")
+struct HeaderProviderTests {
+  @Test
+  func callsUnderlyingClosure() async throws {
+    let expectedHeaders = [
+      "x-goog-api-key": "test-key-123",
+      "x-custom-header": "custom-value",
+    ]
+    let provider = HeaderProvider {
+      expectedHeaders
+    }
+
+    let headers = try await provider()
+
+    #expect(headers == expectedHeaders)
+  }
+
+  @Test
+  func propagatesErrorFromClosure() async {
+    struct TestError: Error, Equatable {}
+    let provider = HeaderProvider {
+      throw TestError()
+    }
+
+    await #expect(throws: TestError.self) {
+      _ = try await provider()
+    }
+  }
+
+  @Test
+  func equalityAndHashing() {
+    let provider1 = HeaderProvider { ["key": "val1"] }
+    let provider2 = HeaderProvider { ["key": "val1"] }
+    let provider1Copy = provider1
+
+    #expect(provider1 == provider1Copy)
+    #expect(provider1.hashValue == provider1Copy.hashValue)
+    #expect(provider1 != provider2)
+  }
+
+  @Test
+  func storageInCollections() {
+    let provider1 = HeaderProvider { ["key": "val1"] }
+    let provider2 = HeaderProvider { ["key": "val2"] }
+
+    let set: Set<HeaderProvider> = [provider1, provider2, provider1]
+
+    #expect(set.count == 2)
+    #expect(set.contains(provider1))
+    #expect(set.contains(provider2))
+  }
+}

--- a/Tests/SharedTestUtilities/MockHTTPURLProtocol.swift
+++ b/Tests/SharedTestUtilities/MockHTTPURLProtocol.swift
@@ -93,3 +93,29 @@ package final class MockHTTPURLProtocol: URLProtocol {
     client?.urlProtocol(self, didFailWithError: URLError(.cancelled))
   }
 }
+
+extension URLRequest {
+  /// The body data of the request, reading from either `httpBody` or `httpBodyStream`.
+  ///
+  /// When `URLSession` processes a `URLRequest`, its internal transmission pipeline converts
+  /// `request.httpBody` into an input stream (`request.httpBodyStream`) and sets `request.httpBody`
+  /// to `nil` before delivering the request to a `URLProtocol`.
+  ///
+  /// This test helper enables `MockHTTPURLProtocol` handlers to inspect the intercepted JSON
+  /// payload by reading directly from `httpBody` when present, or by draining `httpBodyStream`
+  /// if `URLSession` has already transformed it.
+  package var httpBodyData: Data? {
+    if let httpBody { return httpBody }
+    guard let stream = httpBodyStream else { return nil }
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 1024)
+    while stream.hasBytesAvailable {
+      let readCount = stream.read(&buffer, maxLength: buffer.count)
+      if readCount <= 0 { break }
+      data.append(contentsOf: buffer[..<readCount])
+    }
+    return data
+  }
+}


### PR DESCRIPTION
- Introduce `ModelResource` to encapsulate model IDs and resource name routing.
- Introduce `EndpointConfiguration` to configure network endpoint scheme, host, port, and API version.
- Introduce `HeaderProvider` to wrap async dynamic HTTP header closures with hashable identity.
- Update `GeminiAPIClient` to use `ModelResource`, `EndpointConfiguration`, and `HeaderProvider`, and add `makeRequestURL(action:queryItems:)`.
- Add `httpBodyData` test helper to `MockHTTPURLProtocol` for stream-drain support in URLProtocol-intercepted requests.
- Add unit tests for `ModelResource`, `EndpointConfiguration`, and `HeaderProvider`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>