### PR TITLE
fix(auth): restore app extension build broken by UIApplication.shared 

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,4 +1,6 @@
 # 12.19.0
+- [fixed] Fixed a build error in app extensions introduced in 12.18.0, where
+  `AuthNotificationManager` referenced `UIApplication.shared` directly. (#16583)
 - [fixed] Fixed a persistent crash when interacting with App Check under some
   Swift toolchains (like the Flutter SDK) by avoiding a compiler bug in Swift
   concurrency thunk generation. (#16549)

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
@@ -16,25 +16,20 @@
   import Foundation
   import UIKit
 
-  /// A class represents a credential that proves the identity of the app.
-  @preconcurrency
-  // Protocol to help with unit tests.
+  /// A protocol representing the application interactions required by AuthNotificationManager.
   protocol AuthNotificationApplication: Sendable {
     var delegate: UIApplicationDelegate? { get }
     var applicationState: UIApplication.State { get }
 
-    /// The `UIApplication` to pass to `UIApplicationDelegate` callbacks.
-    ///
-    /// The delegate signature requires a concrete `UIApplication`, which a test double
-    /// cannot be. Vending it through the protocol keeps `UIApplication.shared` - which
-    /// is unavailable in app extensions - out of this module.
-    var applicationForDelegate: UIApplication { get }
+    /// The `UIApplication` to pass to `UIApplicationDelegate` callbacks, or `nil` if unavailable.
+    var applicationForDelegate: UIApplication? { get }
   }
 
   extension UIApplication: AuthNotificationApplication {
-    var applicationForDelegate: UIApplication { self }
+    var applicationForDelegate: UIApplication? { self }
   }
 
+  @preconcurrency
   class AuthNotificationManager: @unchecked Sendable {
     /// The key to locate payload data in the remote notification.
     private let kNotificationDataKey = "com.google.firebase.auth"
@@ -138,8 +133,8 @@
           if let delegate = self.application.delegate,
              delegate
              .responds(to: #selector(UIApplicationDelegate
-                 .application(_:didReceiveRemoteNotification:fetchCompletionHandler:))) {
-            let appObj = self.application.applicationForDelegate
+                 .application(_:didReceiveRemoteNotification:fetchCompletionHandler:))),
+             let appObj = self.application.applicationForDelegate {
             delegate.application?(appObj,
                                   didReceiveRemoteNotification: proberNotification) { _ in
             }

--- a/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
+++ b/FirebaseAuth/Sources/Swift/SystemService/AuthNotificationManager.swift
@@ -22,9 +22,18 @@
   protocol AuthNotificationApplication: Sendable {
     var delegate: UIApplicationDelegate? { get }
     var applicationState: UIApplication.State { get }
+
+    /// The `UIApplication` to pass to `UIApplicationDelegate` callbacks.
+    ///
+    /// The delegate signature requires a concrete `UIApplication`, which a test double
+    /// cannot be. Vending it through the protocol keeps `UIApplication.shared` - which
+    /// is unavailable in app extensions - out of this module.
+    var applicationForDelegate: UIApplication { get }
   }
 
-  extension UIApplication: AuthNotificationApplication {}
+  extension UIApplication: AuthNotificationApplication {
+    var applicationForDelegate: UIApplication { self }
+  }
 
   class AuthNotificationManager: @unchecked Sendable {
     /// The key to locate payload data in the remote notification.
@@ -130,7 +139,7 @@
              delegate
              .responds(to: #selector(UIApplicationDelegate
                  .application(_:didReceiveRemoteNotification:fetchCompletionHandler:))) {
-            let appObj = (self.application as? UIApplication) ?? UIApplication.shared
+            let appObj = self.application.applicationForDelegate
             delegate.application?(appObj,
                                   didReceiveRemoteNotification: proberNotification) { _ in
             }

--- a/FirebaseAuth/Tests/Unit/AuthNotificationManagerTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthNotificationManagerTests.swift
@@ -143,6 +143,10 @@
     private class FakeApplication: AuthNotificationApplication, @unchecked Sendable {
       weak var delegate: UIApplicationDelegate?
       var applicationState: UIApplication.State = .active
+      // `FakeForwardingDelegate` ignores this argument, but the delegate signature
+      // requires a concrete `UIApplication`. Test targets are not built for app
+      // extensions, so `shared` is available here where it is not in the SDK.
+      var applicationForDelegate: UIApplication { .shared }
     }
 
     private class FakeForwardingDelegate: NSObject, UIApplicationDelegate {

--- a/FirebaseAuth/Tests/Unit/AuthNotificationManagerTests.swift
+++ b/FirebaseAuth/Tests/Unit/AuthNotificationManagerTests.swift
@@ -143,10 +143,7 @@
     private class FakeApplication: AuthNotificationApplication, @unchecked Sendable {
       weak var delegate: UIApplicationDelegate?
       var applicationState: UIApplication.State = .active
-      // `FakeForwardingDelegate` ignores this argument, but the delegate signature
-      // requires a concrete `UIApplication`. Test targets are not built for app
-      // extensions, so `shared` is available here where it is not in the SDK.
-      var applicationForDelegate: UIApplication { .shared }
+      var applicationForDelegate: UIApplication? { nil }
     }
 
     private class FakeForwardingDelegate: NSObject, UIApplicationDelegate {

--- a/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
@@ -1019,9 +1019,7 @@
       @unchecked Sendable {
       weak var delegate: UIApplicationDelegate?
       var applicationState: UIApplication.State = .active
-      // Test targets are not built for app extensions, so `shared` is available
-      // here where it is not in the SDK. See `AuthNotificationApplication`.
-      var applicationForDelegate: UIApplication { .shared }
+      var applicationForDelegate: UIApplication? { nil }
       @MainActor func registerForRemoteNotifications() {}
     }
 

--- a/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
+++ b/FirebaseAuth/Tests/Unit/PhoneAuthProviderTests.swift
@@ -1019,6 +1019,9 @@
       @unchecked Sendable {
       weak var delegate: UIApplicationDelegate?
       var applicationState: UIApplication.State = .active
+      // Test targets are not built for app extensions, so `shared` is available
+      // here where it is not in the SDK. See `AuthNotificationApplication`.
+      var applicationForDelegate: UIApplication { .shared }
       @MainActor func registerForRemoteNotifications() {}
     }
 


### PR DESCRIPTION
See context in https://github.com/firebase/firebase-ios-sdk/pull/16584. Credit to @jeffwall-curlewlabs for the fix!

I addeed app extension testing in https://github.com/firebase/firebase-ios-sdk/pull/16589, which is failing on main. This PR fixes the failure: https://github.com/firebase/firebase-ios-sdk/actions/runs/33680307912/job/100415494661?pr=16594

The `-Swift.h` header fix coming next.

