### PR TITLE
fix: resolve missing registration token callbacks at app launch. (#16596)

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fix an issue where `messaging:didReceiveRegistrationToken:` was no
+  longer called at app launch when a token was cached. (#16581)
+
 # 12.19.0
 - [fixed] Fix an issue where cached FCM registration tokens were falsely
   invalidated due to locale changes when

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,8 +1,6 @@
-# Unreleased
+# 12.19.0
 - [fixed] Fix an issue where `messaging:didReceiveRegistrationToken:` was no
   longer called at app launch when a token was cached. (#16581)
-
-# 12.19.0
 - [fixed] Fix an issue where cached FCM registration tokens were falsely
   invalidated due to locale changes when
   `FirebaseMessagingInstallationIdEnabled` was set to `YES`. (#16572)

--- a/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
+++ b/FirebaseMessaging/Sources/Token/FIRMessagingTokenManager.m
@@ -85,8 +85,7 @@
                                           scope:kFIRMessagingDefaultTokenScope];
   if (cachedTokenInfo.token.length > 0 &&
       [cachedTokenInfo.tokenType isEqualToString:expectedTokenType]) {
-    _defaultFCMToken = [cachedTokenInfo.token copy];
-    return _defaultFCMToken;
+    return cachedTokenInfo.token;
   } else {
     [self tokenWithAuthorizedEntity:self.fcmSenderID
                               scope:kFIRMessagingDefaultTokenScope

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTest.m
@@ -665,6 +665,99 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
   [self waitForExpectationsWithTimeout:30.0 handler:nil];
 }
 
+- (void)testAppStartNotifiesDelegateWhenCachedV4TokenExists {
+  // FirebaseMessaging.isInstallationIdEnabled should return NO.
+  OCMStub([self.mockMessaging isInstallationIdEnabled]).andReturn(NO);
+
+  id mockOptions = OCMClassMock([FIROptions class]);
+  OCMStub([mockOptions GCMSenderID]).andReturn(@"123456789123");
+  OCMStub([(FIRApp *)self.mockFirebaseApp options]).andReturn(mockOptions);
+
+  FIRMessagingTokenInfo *cachedTokenInfo =
+      [[FIRMessagingTokenInfo alloc] initWithAuthorizedEntity:@"123456789123"
+                                                        scope:kFIRMessagingDefaultTokenScope
+                                                        token:@"fake-cached-v4-token"
+                                                   appVersion:@"1.0"
+                                                firebaseAppID:@"app-id"
+                                                    tokenType:@"V4"];
+  OCMStub([self.mockTokenManager
+              cachedTokenInfoWithAuthorizedEntity:@"123456789123"
+                                            scope:kFIRMessagingDefaultTokenScope])
+      .andReturn(cachedTokenInfo);
+
+  // Setup installations ID.
+  id installationIDArg = [OCMArg invokeBlockWithArgs:@"fake-iid", [NSNull null], nil];
+  OCMStub([(FIRInstallations *)self.testUtil.mockInstallations
+      installationIDWithCompletion:installationIDArg]);
+
+  // Setup message delegate.
+  id mockDelegate = OCMProtocolMock(@protocol(FIRMessagingDelegate));
+  self.messaging.delegate = mockDelegate;
+
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Delegate received registration token on app start."];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  OCMStub([mockDelegate messaging:OCMOCK_ANY didReceiveRegistrationToken:OCMOCK_ANY])
+      .andDo(^(NSInvocation *invocation) {
+        __unsafe_unretained NSString *token;
+        [invocation getArgument:&token atIndex:3];
+        XCTAssertEqualObjects(token, @"fake-cached-v4-token");
+        [expectation fulfill];
+      });
+#pragma clang diagnostic pop
+
+  // Configure messaging to simulate app start with cached token.
+  [self.messaging configureMessagingWithOptions:mockOptions];
+
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
+- (void)testAppStartNotifiesDelegateWhenCachedFidExists {
+  // FirebaseMessaging.isInstallationIdEnabled should return YES.
+  OCMStub([self.mockMessaging isInstallationIdEnabled]).andReturn(YES);
+
+  id mockOptions = OCMClassMock([FIROptions class]);
+  OCMStub([mockOptions GCMSenderID]).andReturn(@"123456789123");
+  OCMStub([(FIRApp *)self.mockFirebaseApp options]).andReturn(mockOptions);
+
+  FIRMessagingTokenInfo *cachedTokenInfo =
+      [[FIRMessagingTokenInfo alloc] initWithAuthorizedEntity:@"123456789123"
+                                                        scope:kFIRMessagingDefaultTokenScope
+                                                        token:@"fake-cached-fid"
+                                                   appVersion:@"1.0"
+                                                firebaseAppID:@"app-id"
+                                                    tokenType:@"FID"];
+  OCMStub([self.mockTokenManager
+              cachedTokenInfoWithAuthorizedEntity:@"123456789123"
+                                            scope:kFIRMessagingDefaultTokenScope])
+      .andReturn(cachedTokenInfo);
+
+  // Setup installations ID.
+  id installationIDArg = [OCMArg invokeBlockWithArgs:@"fake-fid", [NSNull null], nil];
+  OCMStub([(FIRInstallations *)self.testUtil.mockInstallations
+      installationIDWithCompletion:installationIDArg]);
+
+  // Setup message delegate.
+  id mockDelegate = OCMProtocolMock(@protocol(FIRMessagingDelegate));
+  self.messaging.delegate = mockDelegate;
+
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Delegate received registration on app start."];
+  OCMStub([mockDelegate messaging:OCMOCK_ANY didReceiveRegistration:OCMOCK_ANY])
+      .andDo(^(NSInvocation *invocation) {
+        __unsafe_unretained NSString *installationId;
+        [invocation getArgument:&installationId atIndex:3];
+        XCTAssertEqualObjects(installationId, @"fake-cached-fid");
+        [expectation fulfill];
+      });
+
+  // Configure messaging to simulate app start with cached FID token.
+  [self.messaging configureMessagingWithOptions:mockOptions];
+
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
 - (void)testSubscribeToTopicWhenInstallationIdEnabled {
   // FirebaseMessaging.isInstallationIdEnabled should return YES.
   OCMStub([self.mockMessaging isInstallationIdEnabled]).andReturn(YES);

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenManagerTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTokenManagerTest.m
@@ -217,6 +217,38 @@
   NSString *token = [_messaging.tokenManager tokenAndRequestIfNotExist];
 
   XCTAssertEqualObjects(token, @"cached-v4-token");
+  // defaultFCMToken should not be set yet so that updateDefaultFCMToken can detect the change.
+  XCTAssertNil([_messaging.tokenManager defaultFCMToken]);
+  OCMVerifyAll(_mockTokenManager);
+}
+
+- (void)testTokenAndRequestIfNotExistReturnsCachedFIDWhenInstallationIdEnabled {
+  OCMStub([_mockMessaging isInstallationIdEnabled]).andReturn(YES);
+
+  _messaging.tokenManager.fcmSenderID = @"123456789123";
+
+  FIRMessagingTokenInfo *cachedTokenInfo =
+      [[FIRMessagingTokenInfo alloc] initWithAuthorizedEntity:@"123456789123"
+                                                        scope:kFIRMessagingDefaultTokenScope
+                                                        token:@"fake-cached-fid"
+                                                   appVersion:@"1.0"
+                                                firebaseAppID:@"app-id"
+                                                    tokenType:@"FID"];
+
+  OCMStub([_mockTokenManager cachedTokenInfoWithAuthorizedEntity:@"123456789123"
+                                                           scope:kFIRMessagingDefaultTokenScope])
+      .andReturn(cachedTokenInfo);
+
+  [[_mockTokenManager reject] tokenWithAuthorizedEntity:OCMOCK_ANY
+                                                  scope:OCMOCK_ANY
+                                                options:OCMOCK_ANY
+                                                handler:OCMOCK_ANY];
+
+  NSString *token = [_messaging.tokenManager tokenAndRequestIfNotExist];
+
+  XCTAssertEqualObjects(token, @"fake-cached-fid");
+  // defaultFCMToken should not be set yet so that updateDefaultFCMToken can detect the change.
+  XCTAssertNil([_messaging.tokenManager defaultFCMToken]);
   OCMVerifyAll(_mockTokenManager);
 }
 


### PR DESCRIPTION
In #16458, we introduced a regression where `_defaultFCMToken` is set prematurely. As a result, the message delegate is not called at app launch.

#16581