### PR TITLE
chore(ci): add xcode 27 to spm test matrix

### DIFF
--- a/.github/workflows/_spm.yml
+++ b/.github/workflows/_spm.yml
@@ -129,17 +129,19 @@ jobs:
     needs: [spm-package-resolved]
     env:
         FIREBASE_IS_NIGHTLY_TESTING: ${{ inputs.is_nightly && '1' || '' }}
+    continue-on-error: ${{ matrix.os == 'xcode-27' }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15, macos-26]
-        xcode: [Xcode_26.2, Xcode_26.4]
+        os: [macos-15, macos-26, xcode-27]
         platform: [iOS, tvOS, macOS, watchOS, catalyst, visionOS]
-        exclude:
+        include:
           - os: macos-15
-            xcode: Xcode_26.4
-          - os: macos-26
             xcode: Xcode_26.2
+          - os: macos-26
+            xcode: Xcode_26.4
+          - os: xcode-27
+            xcode: Xcode_27.0
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/LanguageModelSession+ModelSession.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if compiler(>=6.2.3) && canImport(FoundationModels)
+#if compiler(>=6.2.3) && canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
   import Foundation
   import FoundationModels
 
@@ -191,4 +191,5 @@
       return options.toFoundationModels()
     }
   }
-#endif // compiler(>=6.2.3) && canImport(FoundationModels)
+#endif // compiler(>=6.2.3) && canImport(FoundationModels) &&
+// IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GenerativeModelSessionHybridTests.swift
@@ -46,11 +46,11 @@
       let content = response.content
       #expect(!content.isEmpty)
       #expect(response.rawContent.isComplete)
-      #if canImport(FoundationModels)
+      #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
         if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
           #expect(response.rawContent.kind == .string(content))
         }
-      #endif // canImport(FoundationModels)
+      #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
       #expect(response.rawContent.generationID != nil)
       #expect(response.rawResponse.text == content)
       #expect(response.rawResponse.modelVersion == validModel._modelName)
@@ -151,11 +151,11 @@
       #expect(!content.isEmpty)
       #expect(response.rawContent.isComplete, "The final response was not marked as complete.")
       #expect(response.rawContent.generationID == generationID)
-      #if canImport(FoundationModels)
+      #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
         if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
           #expect(response.rawContent.kind == .string(content))
         }
-      #endif // canImport(FoundationModels)
+      #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
       if let text = response.rawResponse.text {
         #expect(content.hasSuffix(text))
       }
@@ -250,7 +250,7 @@
     /// throw a `ModelManagerError` if the simulator's model version does not match the host macOS
     /// version. A new version of the model was introduced in Xcode/macOS/iOS 26.4.
     func foundationModelsIsAvailable() async -> Bool {
-      #if canImport(FoundationModels)
+      #if canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
         if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) {
           let model = SystemLanguageModel.default
           guard model.isAvailable else {
@@ -269,7 +269,7 @@
             return false
           }
         }
-      #endif // canImport(FoundationModels)
+      #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
 
       return false
     }

--- a/FirebaseAI/Tests/Unit/GenerativeModelSessionTests.swift
+++ b/FirebaseAI/Tests/Unit/GenerativeModelSessionTests.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if compiler(>=6.2.3) && canImport(FoundationModels)
+#if compiler(>=6.2.3) && canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM
   import FoundationModels
   import XCTest
 
@@ -641,4 +641,5 @@
       return self.map { $0.toolRepresentation }
     }
   }
-#endif // compiler(>=6.2.3) && canImport(FoundationModels)
+#endif // compiler(>=6.2.3) && canImport(FoundationModels) &&
+// IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM

--- a/FirebaseAI/Tests/Unit/ResponseStreamTests.swift
+++ b/FirebaseAI/Tests/Unit/ResponseStreamTests.swift
@@ -106,18 +106,26 @@
           // Assert that the error is one of the expected decoding failure types.
           if let genError = error as? GenerativeModelSession.GenerationError,
              case .decodingFailure = genError {
-            // Expected error.
-          } else if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *),
-                    let foundationError = error as? FoundationModels.LanguageModelSession
-                    .GenerationError,
-                    case .decodingFailure = foundationError {
-            // TODO: Remove this else-if after wrapping `FoundationModels.GenerationError` errors
-            //       into equivalent `GenerativeModelSession.GenerationError` values.
-
-            // Expected error.
-          } else {
-            XCTFail("Expected a decoding failure error, but got \(error) instead.")
+            return
           }
+
+          #if compiler(>=6.4)
+            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *),
+               error is FoundationModels.GeneratedContent.ParsingError {
+              return
+            }
+          #endif // compiler(>=6.4)
+
+          if #available(iOS 26.0, macOS 26.0, visionOS 26.0, *),
+             let foundationError = error as? FoundationModels.LanguageModelSession
+             .GenerationError,
+             case .decodingFailure = foundationError {
+            // TODO: Remove this check after wrapping `FoundationModels.GenerationError` errors
+            //       into equivalent `GenerativeModelSession.GenerationError` values.
+            return
+          }
+
+          XCTFail("Expected a decoding failure error, but got \(error) instead.")
         }
       }
     #endif // canImport(FoundationModels) && IS_FOUNDATION_MODELS_SUPPORTED_PLATFORM

--- a/FirebaseAI/Tests/Unit/Types/GenerationOptionsTests.swift
+++ b/FirebaseAI/Tests/Unit/Types/GenerationOptionsTests.swift
@@ -41,8 +41,13 @@
 
         XCTAssertEqual(foundationModelsGenerationOptions.temperature, 0.5)
         XCTAssertEqual(foundationModelsGenerationOptions.maximumResponseTokens, 100)
-        XCTAssertNotNil(foundationModelsGenerationOptions.sampling)
-        XCTAssertEqual(foundationModelsGenerationOptions.sampling, .greedy)
+        #if compiler(>=6.4)
+          XCTAssertNotNil(foundationModelsGenerationOptions.samplingMode)
+          XCTAssertEqual(foundationModelsGenerationOptions.samplingMode, .greedy)
+        #else
+          XCTAssertNotNil(foundationModelsGenerationOptions.sampling)
+          XCTAssertEqual(foundationModelsGenerationOptions.sampling, .greedy)
+        #endif // compiler(>=6.4)
       }
     #endif // canImport(FoundationModels)
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -185,6 +185,14 @@ else
   )
 fi
 
+if [[ "$xcode_major" -ge 27 ]]; then
+  spm_macosx_deployment_target="12.0"
+  spm_watchos_deployment_target="9.0"
+else
+  spm_macosx_deployment_target="10.15"
+  spm_watchos_deployment_target="7.0"
+fi
+
 ios_device_flags=(
   -destination 'generic/platform=iOS'
 )
@@ -795,9 +803,9 @@ case "$product-$platform-$method" in
       -scheme $product \
       "${xcb_flags[@]}" \
       IPHONEOS_DEPLOYMENT_TARGET=15.0 \
-      MACOSX_DEPLOYMENT_TARGET=10.15 \
+      MACOSX_DEPLOYMENT_TARGET="$spm_macosx_deployment_target" \
       TVOS_DEPLOYMENT_TARGET=15.0 \
-      WATCHOS_DEPLOYMENT_TARGET=7.0 \
+      WATCHOS_DEPLOYMENT_TARGET="$spm_watchos_deployment_target" \
       test
     ;;
 

--- a/scripts/setup_simulator.sh
+++ b/scripts/setup_simulator.sh
@@ -64,10 +64,10 @@ get_vision_device() {
       grep -o -E 'com\.apple\.CoreSimulator\.SimRuntime\.[a-zA-Z0-9.-]+' |
       tail -1 || true
   )
-  if [[ "$vision_runtime" =~ xrOS-26|visionOS-26 ]]; then
-    echo "${device_prefix}.Apple-Vision-Pro-4K"
-  else
+  if [[ "$vision_runtime" =~ (xrOS|visionOS)-[12]- ]]; then
     echo "${device_prefix}.Apple-Vision-Pro"
+  else
+    echo "${device_prefix}.Apple-Vision-Pro-4K"
   fi
 }
 


### PR DESCRIPTION
Added the [`xcode-27`](https://github.com/actions/runner-images/blob/95cbee4fc5fdd72447b0b9a5ae2e773148eacc72/images/macos/xcode-27-arm64-Readme.md) preview runner image to the SPM workflow matrix so SDKs can be tested against Xcode 27 ahead of its official release. This runner image is actually macOS 26 but includes Xcode 27.

Previously, `_spm.yml` used a Cartesian product of OS and Xcode versions with manual exclusions. Replace the combinatorial matrix by retaining only `os` and `platform` at the top level, and use `include` to map each runner OS to its corresponding installed Xcode version.

Set `continue-on-error` for `xcode-27` so potential preview instability or beta compiler failures do not block pull request merges.

#no-changelog