### PR TITLE
test: fix ailogic test flake due to xctest aseert retaining instance

### DIFF
--- a/FirebaseAI/Tests/Unit/VertexComponentTests.swift
+++ b/FirebaseAI/Tests/Unit/VertexComponentTests.swift
@@ -247,7 +247,9 @@ class VertexComponentTests: XCTestCase {
         useLimitedUseAppCheckTokens: false
       )
       weakVertex = vertex
-      XCTAssertNotNil(weakVertex)
+      if weakVertex == nil {
+        XCTFail("Weak reference should not be `nil`.")
+      }
     }
     XCTAssertNil(weakApp)
     XCTAssertNil(weakVertex)


### PR DESCRIPTION
`XCTAssert` can retain the instance passed to it, sometimes for longer than the enclosing autorelease pool scope would dictate. 

Without the fix, running the test 100 times consistently yielded flakes. With the fix, the test runs 1k times with no flakes.

#no-changelog