### PR TITLE
infra: pod publishing should require explicit override

### DIFF
--- a/ReleaseTooling/Sources/FirebaseReleaser/Push.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/Push.swift
@@ -29,6 +29,7 @@ enum Push {
   }
 
   static func publishPodsToTrunk(gitRoot: URL) {
+    fatalError("Pod publishing has ceased. Comment out this line if publishing is needed.")
     push(to: .trunk, gitRoot: gitRoot)
   }
 


### PR DESCRIPTION
Adding a check to prevent accidental trunk pushes. It can be overridden if needed by locally modifying the tooling.

Related: [cl/976421376](http://cl/976421376)