### PR TITLE
refactor(ai): consolidate HTTP request headers

### DIFF
--- a/FirebaseAI/Sources/Extensions/Internal/FirebaseInfo+Headers.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/FirebaseInfo+Headers.swift
@@ -48,11 +48,10 @@ extension FirebaseInfo {
       headers["x-ios-bundle-identifier"] = bundleID
     }
 
-    var clientTags = [
+    let clientTags = [
       Constants.languageTag,
       Constants.firebaseVersionTag,
-    ]
-    clientTags.append(contentsOf: additionalClientTags)
+    ] + additionalClientTags
     headers["x-goog-api-client"] = clientTags.joined(separator: " ")
 
     if let appCheck {
@@ -69,7 +68,7 @@ extension FirebaseInfo {
       }
     }
 
-    if let auth, accessToken == nil,
+    if accessToken == nil, let auth,
        let authToken = try await auth.getToken(forcingRefresh: false) {
       headers["Authorization"] = "Firebase \(authToken)"
     }

--- a/FirebaseAI/Sources/Extensions/Internal/FirebaseInfo+Headers.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/FirebaseInfo+Headers.swift
@@ -1,0 +1,122 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FirebaseAppCheckInterop
+import FirebaseAuthInterop
+import FirebaseCore
+import Foundation
+
+extension FirebaseInfo {
+  /// Constructs the standard HTTP headers for Firebase AI API requests.
+  ///
+  /// - Parameters:
+  ///   - errorDomain: Suffix appended to `Constants.baseErrorDomain` if token fetching throws.
+  ///     Defaults to the base type name extracted from the caller's `#fileID`.
+  ///   - additionalClientTags: Additional client tags to append to the `x-goog-api-client` header.
+  /// - Returns: A dictionary of HTTP header field names and values.
+  /// - Throws: An error if App Check or Firebase Auth token retrieval fails.
+  func requestHeaders(errorDomain: String = defaultErrorDomain(for: #fileID),
+                      additionalClientTags: [String] = []) async throws -> [String: String] {
+    var headers: [String: String] = [
+      "Content-Type": "application/json",
+    ]
+
+    #if DEBUG
+      let accessToken = ProcessInfo.processInfo.environment[Constants.gCloudAccessTokenEnvVarKey]
+    #else
+      let accessToken: String? = nil
+    #endif // DEBUG
+
+    if let accessToken {
+      headers["Authorization"] = "Bearer \(accessToken)"
+    } else {
+      headers["x-goog-api-key"] = apiKey
+    }
+
+    if let bundleID = Bundle.main.bundleIdentifier {
+      headers["x-ios-bundle-identifier"] = bundleID
+    }
+
+    var clientTags = [
+      Constants.languageTag,
+      Constants.firebaseVersionTag,
+    ]
+    clientTags.append(contentsOf: additionalClientTags)
+    headers["x-goog-api-client"] = clientTags.joined(separator: " ")
+
+    if let appCheck {
+      let tokenResult = try await appCheck.fetchAppCheckToken(
+        limitedUse: useLimitedUseAppCheckTokens,
+        domain: errorDomain
+      )
+      headers["X-Firebase-AppCheck"] = tokenResult.token
+      if let error = tokenResult.error {
+        AILog.error(
+          code: .appCheckTokenFetchFailed,
+          "Failed to fetch AppCheck token. Error: \(error)"
+        )
+      }
+    }
+
+    if let auth, accessToken == nil,
+       let authToken = try await auth.getToken(forcingRefresh: false) {
+      headers["Authorization"] = "Firebase \(authToken)"
+    }
+
+    if app.isDataCollectionDefaultEnabled {
+      headers["X-Firebase-AppId"] = firebaseAppID
+      if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+        headers["X-Firebase-AppVersion"] = appVersion
+      }
+    }
+
+    return headers
+  }
+
+  /// Applies the standard Firebase AI HTTP headers to a `URLRequest`.
+  ///
+  /// - Parameters:
+  ///   - request: The `URLRequest` to mutate.
+  ///   - errorDomain: Suffix appended to `Constants.baseErrorDomain` if token fetching throws.
+  ///     Defaults to the base type name extracted from the caller's `#fileID`.
+  ///   - additionalClientTags: Additional client tags to append to the `x-goog-api-client` header.
+  /// - Throws: An error if App Check or Firebase Auth token retrieval fails.
+  func applyHeaders(to request: inout URLRequest,
+                    errorDomain: String = defaultErrorDomain(for: #fileID),
+                    additionalClientTags: [String] = []) async throws {
+    let headers = try await requestHeaders(
+      errorDomain: errorDomain,
+      additionalClientTags: additionalClientTags
+    )
+    for (field, value) in headers {
+      request.setValue(value, forHTTPHeaderField: field)
+    }
+  }
+
+  // MARK: - Internal Helpers
+
+  /// Resolves a default error domain suffix from a file identifier (such as `#fileID`).
+  ///
+  /// Extracts the base filename without path or file extension, and strips any category suffix
+  /// (e.g. `GeminiLanguageModel+Firebase.swift` becomes `GeminiLanguageModel`).
+  ///
+  /// - Parameter fileID: The file identifier string, typically from `#fileID`.
+  /// - Returns: The extracted domain string.
+  static func defaultErrorDomain(for fileID: String) -> String {
+    let fileName = fileID.split(separator: "/").last.map(String.init) ?? fileID
+    let baseName = fileName.split(separator: ".").first.map(String.init) ?? fileName
+    let typeName = baseName.split(separator: "+").first.map(String.init) ?? baseName
+    return typeName.isEmpty ? "FirebaseAI" : typeName
+  }
+}

--- a/FirebaseAI/Sources/Extensions/Internal/GeminiLanguageModel+Firebase.swift
+++ b/FirebaseAI/Sources/Extensions/Internal/GeminiLanguageModel+Firebase.swift
@@ -40,51 +40,18 @@
           port: urlComponents.port,
           apiVersion: firebaseAI.apiConfig.version.rawValue
         ),
-        headerProvider: {
-          let firebaseInfo = firebaseAI.firebaseInfo
-          var headers = ["x-goog-api-key": firebaseInfo.apiKey]
-
-          if let bundleID = Bundle.main.bundleIdentifier {
-            headers["x-ios-bundle-identifier"] = bundleID
-          }
-
-          let apiClientHeaders = [
-            Constants.languageTag,
-            Constants.firebaseVersionTag,
-            Constants.foundationModelsRequestTag,
-          ]
-          headers["x-goog-api-client"] = apiClientHeaders.joined(separator: " ")
-
-          if let appCheck = firebaseInfo.appCheck {
-            let tokenResult = try await appCheck.fetchAppCheckToken(
-              limitedUse: firebaseInfo.useLimitedUseAppCheckTokens,
-              domain: "\(Self.self)"
-            )
-            headers["X-Firebase-AppCheck"] = tokenResult.token
-            if let error = tokenResult.error {
-              AILog.error(
-                code: .appCheckTokenFetchFailed,
-                "Failed to fetch AppCheck token. Error: \(error)"
-              )
-            }
-          }
-
-          if let auth = firebaseInfo.auth,
-             let authToken = try await auth.getToken(forcingRefresh: false) {
-            headers["Authorization"] = "Firebase \(authToken)"
-          }
-
-          if firebaseInfo.app.isDataCollectionDefaultEnabled {
-            headers["X-Firebase-AppId"] = firebaseInfo.firebaseAppID
-            if let bundleInfo = Bundle.main.infoDictionary,
-               let appVersion = bundleInfo["CFBundleShortVersionString"] as? String {
-              headers["X-Firebase-AppVersion"] = appVersion
-            }
-          }
-
-          return headers
-        },
+        headerProvider: firebaseAI.headerProvider,
         configuration: .ephemeral
+      )
+    }
+  }
+
+  @available(iOS 27.0, macOS 27.0, watchOS 27.0, visionOS 27.0, *)
+  @available(tvOS, unavailable)
+  private extension FirebaseAI {
+    func headerProvider() async throws -> [String: String] {
+      try await firebaseInfo.requestHeaders(
+        additionalClientTags: [Constants.foundationModelsRequestTag]
       )
     }
   }

--- a/FirebaseAI/Sources/GenerativeAIService.swift
+++ b/FirebaseAI/Sources/GenerativeAIService.swift
@@ -136,10 +136,7 @@ struct GenerativeAIService {
   private func urlRequest<T: GenerativeAIRequest>(request: T) async throws -> URLRequest {
     var urlRequest = try URLRequest(url: request.getURL())
     urlRequest.httpMethod = "POST"
-    var additionalClientTags: [String] = []
-    if TaskLocals.isHybridRequest {
-      additionalClientTags.append("hybrid")
-    }
+    let additionalClientTags = TaskLocals.isHybridRequest ? ["hybrid"] : []
     try await firebaseInfo.applyHeaders(
       to: &urlRequest,
       additionalClientTags: additionalClientTags

--- a/FirebaseAI/Sources/GenerativeAIService.swift
+++ b/FirebaseAI/Sources/GenerativeAIService.swift
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import FirebaseAppCheckInterop
-import FirebaseAuthInterop
-import FirebaseCore
 import Foundation
 import os.log
 
@@ -139,54 +136,14 @@ struct GenerativeAIService {
   private func urlRequest<T: GenerativeAIRequest>(request: T) async throws -> URLRequest {
     var urlRequest = try URLRequest(url: request.getURL())
     urlRequest.httpMethod = "POST"
-    #if DEBUG
-      let accessToken = ProcessInfo.processInfo.environment[Constants.gCloudAccessTokenEnvVarKey]
-    #else
-      let accessToken: String? = nil
-    #endif // DEBUG
-    if let accessToken {
-      urlRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-    } else {
-      urlRequest.setValue(firebaseInfo.apiKey, forHTTPHeaderField: "x-goog-api-key")
-    }
-    if let bundleID = Bundle.main.bundleIdentifier {
-      urlRequest.setValue(bundleID, forHTTPHeaderField: "x-ios-bundle-identifier")
-    }
-    var apiClientHeaders = [Constants.languageTag, Constants.firebaseVersionTag]
+    var additionalClientTags: [String] = []
     if TaskLocals.isHybridRequest {
-      apiClientHeaders.append("hybrid")
+      additionalClientTags.append("hybrid")
     }
-    urlRequest.setValue(
-      apiClientHeaders.joined(separator: " "),
-      forHTTPHeaderField: "x-goog-api-client"
+    try await firebaseInfo.applyHeaders(
+      to: &urlRequest,
+      additionalClientTags: additionalClientTags
     )
-    urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-    if let appCheck = firebaseInfo.appCheck {
-      let tokenResult = try await appCheck.fetchAppCheckToken(
-        limitedUse: firebaseInfo.useLimitedUseAppCheckTokens,
-        domain: "GenerativeAIService"
-      )
-      urlRequest.setValue(tokenResult.token, forHTTPHeaderField: "X-Firebase-AppCheck")
-      if let error = tokenResult.error {
-        AILog.error(
-          code: .appCheckTokenFetchFailed,
-          "Failed to fetch AppCheck token. Error: \(error)"
-        )
-      }
-    }
-
-    if let auth = firebaseInfo.auth, let authToken = try await auth.getToken(forcingRefresh: false),
-       accessToken == nil {
-      urlRequest.setValue("Firebase \(authToken)", forHTTPHeaderField: "Authorization")
-    }
-
-    if firebaseInfo.app.isDataCollectionDefaultEnabled {
-      urlRequest.setValue(firebaseInfo.firebaseAppID, forHTTPHeaderField: "X-Firebase-AppId")
-      if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
-        urlRequest.setValue(appVersion, forHTTPHeaderField: "X-Firebase-AppVersion")
-      }
-    }
 
     let encoder = JSONEncoder()
     urlRequest.httpBody = try encoder.encode(request)

--- a/FirebaseAI/Sources/Types/Internal/Live/LiveSessionService.swift
+++ b/FirebaseAI/Sources/Types/Internal/Live/LiveSessionService.swift
@@ -15,12 +15,6 @@
 import Foundation
 import os.log
 
-// TODO: remove @preconcurrency when we update to Swift 6
-// for context, see
-// https://forums.swift.org/t/why-does-sending-a-sendable-value-risk-causing-data-races/73074
-@preconcurrency import FirebaseAppCheckInterop
-@preconcurrency import FirebaseAuthInterop
-
 /// Facilitates communication with the backend for a ``LiveSession``.
 ///
 /// Using an actor will make it easier to adopt session resumption, as we have an isolated place for
@@ -394,42 +388,7 @@ actor LiveSessionService {
     }
     var urlRequest = URLRequest(url: url)
     urlRequest.timeoutInterval = requestOptions.timeout
-    urlRequest.setValue(firebaseInfo.apiKey, forHTTPHeaderField: "x-goog-api-key")
-    if let bundleID = Bundle.main.bundleIdentifier {
-      urlRequest.setValue(bundleID, forHTTPHeaderField: "x-ios-bundle-identifier")
-    }
-    urlRequest.setValue(
-      "\(Constants.languageTag) \(Constants.firebaseVersionTag)",
-      forHTTPHeaderField: "x-goog-api-client"
-    )
-    urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-    if let appCheck = firebaseInfo.appCheck {
-      let tokenResult = try await appCheck.fetchAppCheckToken(
-        limitedUse: firebaseInfo.useLimitedUseAppCheckTokens,
-        domain: "LiveSessionService"
-      )
-      urlRequest.setValue(tokenResult.token, forHTTPHeaderField: "X-Firebase-AppCheck")
-      if let error = tokenResult.error {
-        AILog.error(
-          code: .appCheckTokenFetchFailed,
-          "Failed to fetch AppCheck token. Error: \(error)"
-        )
-      }
-    }
-
-    if let auth = firebaseInfo.auth, let authToken = try await auth.getToken(
-      forcingRefresh: false
-    ) {
-      urlRequest.setValue("Firebase \(authToken)", forHTTPHeaderField: "Authorization")
-    }
-
-    if firebaseInfo.app.isDataCollectionDefaultEnabled {
-      urlRequest.setValue(firebaseInfo.firebaseAppID, forHTTPHeaderField: "X-Firebase-AppId")
-      if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
-        urlRequest.setValue(appVersion, forHTTPHeaderField: "X-Firebase-AppVersion")
-      }
-    }
+    try await firebaseInfo.applyHeaders(to: &urlRequest)
 
     return AsyncWebSocket(urlSession: urlSession, urlRequest: urlRequest)
   }

--- a/FirebaseAI/Tests/Unit/FirebaseInfoHeadersTests.swift
+++ b/FirebaseAI/Tests/Unit/FirebaseInfoHeadersTests.swift
@@ -1,0 +1,188 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import FirebaseAppCheckInterop
+import FirebaseAuthInterop
+import FirebaseCore
+import Foundation
+import Testing
+
+@testable import FirebaseAILogic
+
+struct FirebaseInfoHeadersTests {
+  @Test
+  func standardHeaders() async throws {
+    let firebaseInfo = makeFirebaseInfo()
+
+    let headers = try await firebaseInfo.requestHeaders()
+
+    #expect(headers["Content-Type"] == "application/json")
+    #expect(headers["x-goog-api-key"] == "API_KEY")
+    #expect(headers["x-ios-bundle-identifier"] == Bundle.main.bundleIdentifier)
+    let clientTags = try #require(headers["x-goog-api-client"]?.components(separatedBy: " "))
+    #expect(clientTags.contains(Constants.languageTag))
+    #expect(clientTags.contains(Constants.firebaseVersionTag))
+    #expect(headers["X-Firebase-AppId"] == "My app ID")
+    let expectedAppVersion =
+      Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    #expect(headers["X-Firebase-AppVersion"] == expectedAppVersion)
+    #expect(headers["Authorization"] == nil)
+    #expect(headers["X-Firebase-AppCheck"] == nil)
+  }
+
+  @Test
+  func appCheckHeaders() async throws {
+    let appCheck = AppCheckInteropFake(token: "test-app-check-token")
+    let firebaseInfo = makeFirebaseInfo(appCheck: appCheck)
+
+    let headers = try await firebaseInfo.requestHeaders()
+
+    #expect(headers["X-Firebase-AppCheck"] == "test-app-check-token")
+  }
+
+  @Test
+  func appCheckLimitedUseHeaders() async throws {
+    let appCheck = AppCheckInteropFake(token: "test-app-check-token")
+    let firebaseInfo = makeFirebaseInfo(
+      appCheck: appCheck,
+      useLimitedUseAppCheckTokens: true
+    )
+
+    let headers = try await firebaseInfo.requestHeaders()
+
+    #expect(headers["X-Firebase-AppCheck"] == "limited_use_test-app-check-token")
+  }
+
+  @Test
+  func appCheckErrorReturnsPlaceholderToken() async throws {
+    let appCheck = AppCheckInteropFake(error: AppCheckErrorFake())
+    let firebaseInfo = makeFirebaseInfo(appCheck: appCheck)
+
+    let headers = try await firebaseInfo.requestHeaders()
+
+    #expect(headers["X-Firebase-AppCheck"] == AppCheckInteropFake.placeholderTokenValue)
+  }
+
+  @Test
+  func authHeaders() async throws {
+    let auth = AuthInteropFake(token: "test-auth-token")
+    let firebaseInfo = makeFirebaseInfo(auth: auth)
+
+    let headers = try await firebaseInfo.requestHeaders()
+
+    #expect(headers["Authorization"] == "Firebase test-auth-token")
+  }
+
+  @Test
+  func additionalClientTags() async throws {
+    let firebaseInfo = makeFirebaseInfo()
+
+    let headers = try await firebaseInfo.requestHeaders(
+      additionalClientTags: ["fma", "hybrid"]
+    )
+
+    let clientTags = try #require(headers["x-goog-api-client"]?.components(separatedBy: " "))
+    #expect(clientTags.contains(Constants.languageTag))
+    #expect(clientTags.contains(Constants.firebaseVersionTag))
+    #expect(clientTags.contains("fma"))
+    #expect(clientTags.contains("hybrid"))
+  }
+
+  @Test
+  func dataCollectionDisabled() async throws {
+    let firebaseInfo = makeFirebaseInfo(privateAppID: true)
+
+    let headers = try await firebaseInfo.requestHeaders()
+
+    #expect(headers["X-Firebase-AppId"] == nil)
+    #expect(headers["X-Firebase-AppVersion"] == nil)
+  }
+
+  @Test
+  func applyHeadersToURLRequest() async throws {
+    let auth = AuthInteropFake(token: "test-auth-token")
+    let appCheck = AppCheckInteropFake(token: "test-app-check-token")
+    let firebaseInfo = makeFirebaseInfo(
+      appCheck: appCheck,
+      auth: auth
+    )
+    let url = try #require(URL(string: "https://firebasevertexai.googleapis.com"))
+    var request = URLRequest(url: url)
+
+    try await firebaseInfo.applyHeaders(to: &request, additionalClientTags: ["custom-tag"])
+
+    #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    #expect(request.value(forHTTPHeaderField: "x-goog-api-key") == "API_KEY")
+    #expect(request.value(forHTTPHeaderField: "Authorization") == "Firebase test-auth-token")
+    #expect(request.value(forHTTPHeaderField: "X-Firebase-AppCheck") == "test-app-check-token")
+    let clientTags = try #require(
+      request.value(forHTTPHeaderField: "x-goog-api-client")?.components(separatedBy: " ")
+    )
+    #expect(clientTags.contains("custom-tag"))
+  }
+
+  @Test
+  func defaultErrorDomainResolution() {
+    #expect(
+      FirebaseInfo.defaultErrorDomain(for: "FirebaseAILogic/GenerativeAIService.swift") ==
+        "GenerativeAIService"
+    )
+    #expect(
+      FirebaseInfo.defaultErrorDomain(for: "FirebaseAILogic/LiveSessionService.swift") ==
+        "LiveSessionService"
+    )
+    #expect(
+      FirebaseInfo.defaultErrorDomain(for: "FirebaseAILogic/GeminiLanguageModel+Firebase.swift") ==
+        "GeminiLanguageModel"
+    )
+    #expect(
+      FirebaseInfo.defaultErrorDomain(for: "SomeFile.swift") == "SomeFile"
+    )
+    #expect(
+      FirebaseInfo.defaultErrorDomain(for: "") == "FirebaseAI"
+    )
+  }
+
+  @Test
+  func explicitErrorDomain() async throws {
+    let appCheck = AppCheckInteropFake(token: "test-token")
+    let firebaseInfo = makeFirebaseInfo(appCheck: appCheck)
+
+    let headers = try await firebaseInfo.requestHeaders(errorDomain: "CustomErrorDomain")
+
+    #expect(headers["X-Firebase-AppCheck"] == "test-token")
+  }
+
+  // MARK: - Private Helpers
+
+  private func makeFirebaseInfo(appCheck: AppCheckInterop? = nil,
+                                auth: AuthInterop? = nil,
+                                privateAppID: Bool = false,
+                                useLimitedUseAppCheckTokens: Bool = false) -> FirebaseInfo {
+    let app = FirebaseApp(
+      instanceWithName: UUID().uuidString,
+      options: FirebaseOptions(googleAppID: "ignore", gcmSenderID: "ignore")
+    )
+    app.isDataCollectionDefaultEnabled = !privateAppID
+    return FirebaseInfo(
+      appCheck: appCheck,
+      auth: auth,
+      projectID: "my-project-id",
+      apiKey: "API_KEY",
+      firebaseAppID: "My app ID",
+      firebaseApp: app,
+      useLimitedUseAppCheckTokens: useLimitedUseAppCheckTokens
+    )
+  }
+}


### PR DESCRIPTION
Consolidated duplicated HTTP request header construction logic across `GenerativeAIService`, `LiveSessionService`, and `GeminiLanguageModel` into a unified `FirebaseInfo` extension.

Previously, each service independently assembled HTTP headers (including API key, App Check tokens, Firebase Auth tokens, bundle identifier, client tags, and data collection fields), duplicating error handling and interop dependencies across multiple files.

Added `requestHeaders` and `applyHeaders` methods to `FirebaseInfo`, unifed error domain resolution via `#fileID`, and added unit tests.

#no-changelog

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>