### PR TITLE
test(ai): skip stalling image test on visionOS

### DIFF
--- a/FirebaseAI/Tests/Unit/PartsRepresentableTests.swift
+++ b/FirebaseAI/Tests/Unit/PartsRepresentableTests.swift
@@ -136,7 +136,7 @@ final class PartsRepresentableTests: XCTestCase {
     XCTAssertEqual(dataPart, inlineData)
   }
 
-  #if canImport(UIKit)
+  #if canImport(UIKit) && !os(visionOS)
     func testMixedParts_withImage() throws {
       let text = "This is a test"
       let image = try XCTUnwrap(UIImage(systemName: "star"))


### PR DESCRIPTION
Converting a `UIImage` to JPEG data via `jpegData(compressionQuality:)` stalls on visionOS Simulators, causing unit test runs to hit CI timeouts.

Excluded `testMixedParts_withImage` on visionOS, matching the existing `!os(visionOS)` guards in the other `PartsRepresentableTests`.

Note: We should consider switching from `UIImage(systemName: "star")` (vector art from SF Symbols) to a bitmap image in the future, programmatically generated or a tiny image file. Apparently these hang on some simulators during rasterization so avoiding that should fix it, but untested. For now visionOS isn't heavily used and this should only impact the test.

#no-changelog