### PR TITLE
feat(ai): add GeminiLanguageModel guided generation support

### DIFF
--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GeminiLanguageModelTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GeminiLanguageModelTests.swift
@@ -42,5 +42,35 @@
       #expect(!text.isEmpty)
       #expect(text == allText)
     }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+    @Generable(description: "Basic profile information about a cat")
+    struct CatProfile {
+      var name: String
+
+      @Guide(description: "The age of the cat", .range(0 ... 20))
+      var age: Int
+
+      @Guide(description: "A one sentence profile about the cat's personality")
+      var profile: String
+    }
+
+    @Test(arguments: InstanceConfig.defaultConfigs)
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+    func testGenerateStructuredCat(_ config: InstanceConfig) async throws {
+      let ai = FirebaseAI.componentInstance(config)
+      let model = ai.geminiLanguageModel(name: ModelNames.gemini3_1_FlashLite)
+      let session = LanguageModelSession(model: model)
+
+      let response = try await session.respond(
+        to: "Generate a cute rescue cat",
+        generating: CatProfile.self
+      )
+
+      let cat = response.content
+      #expect(!cat.name.isEmpty)
+      #expect(cat.age >= 0 && cat.age <= 20)
+      #expect(!cat.profile.isEmpty)
+    }
   }
 #endif // compiler(>=6.4) && canImport(FoundationModels) && canImport(GeminiLanguageModel)

--- a/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiLanguageModel.swift
+++ b/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiLanguageModel.swift
@@ -54,7 +54,8 @@
     /// The capabilities supported by this language model.
     public var capabilities: LanguageModelCapabilities {
       LanguageModelCapabilities([
-        .reasoning
+        .guidedGeneration,
+        .reasoning,
       ])
     }
   }

--- a/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiLanguageModelExecutor.swift
+++ b/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiLanguageModelExecutor.swift
@@ -79,14 +79,7 @@
         model: GeminiLanguageModel,
         streamingInto channel: LanguageModelExecutorGenerationChannel
       ) async throws {
-        let (contents, systemInstruction) = try GeminiTranscriptTranslator.translate(
-          request.transcript
-        )
-        let generateRequest = GenerateContentRequest(
-          model: nil,
-          systemInstruction: systemInstruction,
-          contents: contents
-        )
+        let generateRequest = try GeminiRequestTranslator.translate(request)
 
         let client = GeminiAPIClient(
           modelResource: configuration.modelResource,

--- a/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiRequestTranslator.swift
+++ b/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiRequestTranslator.swift
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(FoundationModels) && compiler(>=6.4)
+  import Foundation
+  import FoundationModels
+
+  import GeminiAPIDataModels
+
+  /// Translates Foundation Models requests into Gemini API data models.
+  @available(iOS 27.0, macOS 27.0, watchOS 27.0, visionOS 27.0, *)
+  @available(tvOS, unavailable)
+  enum GeminiRequestTranslator {
+    /// Translates a `LanguageModelExecutorGenerationRequest` into a `GenerateContentRequest`.
+    ///
+    /// - Parameter request: The generation request from the Foundation Models session.
+    /// - Returns: A `GenerateContentRequest` configured for the Gemini API.
+    /// - Throws: An error if transcript or schema translation fails.
+    static func translate(
+      _ request: LanguageModelExecutorGenerationRequest
+    ) throws -> GenerateContentRequest {
+      let (contents, systemInstruction) = try GeminiTranscriptTranslator.translate(
+        request.transcript
+      )
+      let generationConfig = try translateGenerationConfig(schema: request.schema)
+
+      return GenerateContentRequest(
+        systemInstruction: systemInstruction,
+        contents: contents,
+        generationConfig: generationConfig
+      )
+    }
+
+    /// Translates an optional `GenerationSchema` into a Gemini `GenerationConfig`.
+    ///
+    /// - Parameter schema: An optional generation schema specifying structured output constraints.
+    /// - Returns: A `GenerationConfig` configured with response schema, or `nil` if `schema`
+    ///   is `nil`.
+    /// - Throws: An error if encoding the schema fails or if an unsupported generation guide is
+    ///   detected.
+    static func translateGenerationConfig(
+      schema: GenerationSchema?
+    ) throws -> GenerationConfig? {
+      guard let schema else { return nil }
+
+      let jsonSchema = try schema.toGeminiJSONSchema()
+      let textFormat = TextResponseFormat(
+        mimeType: .applicationJson,
+        schema: .object(jsonSchema)
+      )
+      return GenerationConfig(responseFormat: ResponseFormatConfig(text: textFormat))
+    }
+  }
+#endif  // canImport(FoundationModels) && compiler(>=6.4)

--- a/GeminiLanguageModel/Sources/GeminiLanguageModel/GenerationSchema+Gemini.swift
+++ b/GeminiLanguageModel/Sources/GeminiLanguageModel/GenerationSchema+Gemini.swift
@@ -1,0 +1,88 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(FoundationModels) && compiler(>=6.4)
+  import Foundation
+  import FoundationModels
+  import GeminiAPIDataModels
+  import Synchronization
+
+  @available(iOS 27.0, macOS 27.0, watchOS 27.0, visionOS 27.0, *)
+  @available(tvOS, unavailable)
+  extension GenerationSchema {
+    /// Returns a Gemini-compatible JSON Schema of this `GenerationSchema`.
+    ///
+    /// When encoded to JSON, `FoundationModels.GenerationSchema` uses the Foundation Models
+    /// `x-order` key for property ordering. This method translates `x-order` to Gemini's expected
+    /// `propertyOrdering` key.
+    ///
+    /// - Returns: A `JSONObject` representing the Gemini-compatible JSON Schema.
+    /// - Throws: `LanguageModelError.unsupportedGenerationGuide` if an unsupported regex pattern
+    ///   guide is present, or an error if encoding or decoding fails.
+    func toGeminiJSONSchema() throws -> JSONObject {
+      let hasPatternGuide = Mutex(false)
+      let encoder = JSONEncoder()
+      encoder.keyEncodingStrategy = .custom { keys in
+        guard let lastKey = keys.last else {
+          assertionFailure("Unexpected empty coding path.")
+          return SchemaCodingKey(stringValue: "")
+        }
+        if lastKey.stringValue == "pattern" {
+          hasPatternGuide.withLock { $0 = true }
+        }
+        if lastKey.stringValue == "x-order" {
+          return SchemaCodingKey(stringValue: "propertyOrdering")
+        }
+        return lastKey
+      }
+
+      let generationSchemaData = try encoder.encode(self)
+      if hasPatternGuide.withLock({ $0 }) {
+        throw LanguageModelError.unsupportedGenerationGuide(
+          LanguageModelError.UnsupportedGenerationGuide(
+            schemaName: self.name,
+            debugDescription: "Gemini does not support regular expression pattern guides."
+          )
+        )
+      }
+
+      let jsonSchema = try JSONDecoder().decode(JSONObject.self, from: generationSchemaData)
+
+      return jsonSchema
+    }
+
+    /// Returns a Gemini-compatible JSON Schema of this `GenerationSchema` as a `JSONValue`.
+    ///
+    /// - Returns: A `JSONValue.object` representing the Gemini-compatible JSON Schema.
+    /// - Throws: `LanguageModelError.unsupportedGenerationGuide` if an unsupported regex pattern
+    ///   guide is present, or an error if encoding or decoding fails.
+    func toGeminiJSONValue() throws -> JSONValue {
+      .object(try toGeminiJSONSchema())
+    }
+
+    private struct SchemaCodingKey: CodingKey {
+      let stringValue: String
+      let intValue: Int? = nil
+
+      init(stringValue: String) {
+        self.stringValue = stringValue
+      }
+
+      init?(intValue: Int) {
+        assertionFailure("Unexpected \(Self.self) with integer value: \(intValue)")
+        return nil
+      }
+    }
+  }
+#endif  // canImport(FoundationModels) && compiler(>=6.4)

--- a/GeminiLanguageModel/Sources/GeminiLanguageModel/GenerationSchema+Gemini.swift
+++ b/GeminiLanguageModel/Sources/GeminiLanguageModel/GenerationSchema+Gemini.swift
@@ -38,6 +38,8 @@
           assertionFailure("Unexpected empty coding path.")
           return SchemaCodingKey(stringValue: "")
         }
+        // Regex pattern guides encode with "pattern" as `lastKey` (e.g. `[<property>, "pattern"]`).
+        // Properties named "pattern" encode child keys under `pattern`, so they will not match.
         if lastKey.stringValue == "pattern" {
           hasPatternGuide.withLock { $0 = true }
         }

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GeminiLanguageModelTests.swift
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GeminiLanguageModelTests.swift
@@ -18,6 +18,7 @@
   import GeminiAPIClient
   import GeminiAPIDataModels
   import GeminiTestUtilities
+  import Synchronization
   import Testing
 
   #if canImport(FoundationNetworking)
@@ -28,6 +29,14 @@
 
   @Suite("GeminiLanguageModel Tests", .serialized, .requireFoundationModels)
   struct GeminiLanguageModelTests {
+    @Generable(description: "A city summary")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct CitySummary {
+      var name: String
+      var population: Int
+    }
+
     @Test
     @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
     func modelInitializationAndCapabilities() {
@@ -39,8 +48,54 @@
       #expect(model.executorConfiguration.modelResource == .gemini35FlashLite)
       #expect(model.executorConfiguration.endpointConfiguration == .geminiDeveloperAPI)
       #expect(model.capabilities.contains(.reasoning))
+      #expect(model.capabilities.contains(.guidedGeneration))
       #expect(!model.capabilities.contains(.toolCalling))
-      #expect(!model.capabilities.contains(.guidedGeneration))
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func sessionRespondGuidedGeneration() async throws {
+      defer { MockHTTPURLProtocol.reset() }
+      let model = Self.makeMockModel()
+      let expectedURL = try Self.makeExpectedStreamURL()
+      let httpResponse = try HTTPURLResponse.mock(
+        url: expectedURL,
+        headerFields: ["Content-Type": "text/event-stream"]
+      )
+      let ssePayload = """
+        data: {"candidates": [{"content": {"parts": [{"text": "{\\"name\\": \\"Tokyo\\", \\"population\\": 14000000}"}], "role": "model"}, "finishReason": "STOP", "index": 0}]}
+
+        """
+      let receivedRequest = Mutex<GenerateContentRequest?>(nil)
+      MockHTTPURLProtocol.setHandler(for: expectedURL) { request, proto in
+        if let body = request.httpBodyData,
+          let decoded = try? JSONDecoder().decode(GenerateContentRequest.self, from: body)
+        {
+          receivedRequest.withLock { $0 = decoded }
+        }
+        proto.client?.urlProtocol(proto, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+        proto.client?.urlProtocol(proto, didLoad: Data(ssePayload.utf8))
+        proto.client?.urlProtocolDidFinishLoading(proto)
+      }
+
+      let session = LanguageModelSession(model: model)
+
+      let response = try await session.respond(
+        to: "Tell me about Tokyo",
+        generating: CitySummary.self
+      )
+
+      #expect(response.content.name == "Tokyo")
+      #expect(response.content.population == 14_000_000)
+      let capturedRequest = try #require(receivedRequest.withLock { $0 })
+      let textFormat = try #require(capturedRequest.generationConfig?.responseFormat?.text)
+      #expect(textFormat.mimeType == .applicationJson)
+      guard case .object(let schemaObject) = textFormat.schema else {
+        Issue.record("Expected schema to be a JSON object.")
+        return
+      }
+      #expect(schemaObject["x-order"] == nil)
+      #expect(schemaObject["propertyOrdering"] != nil)
     }
 
     @Test
@@ -88,17 +143,20 @@
         data: {"candidates": [{"content": {"parts": [{"text": "Your name is Alice."}], "role": "model"}, "finishReason": "STOP", "index": 0}]}
 
         """
-      nonisolated(unsafe) var requestCount = 0
-      nonisolated(unsafe) var lastReceivedContents: [Content] = []
+      let requestCount = Mutex<Int>(0)
+      let lastReceivedContents = Mutex<[Content]>([])
       MockHTTPURLProtocol.setHandler(for: expectedURL) { request, proto in
-        requestCount += 1
+        let currentCount = requestCount.withLock { count in
+          count += 1
+          return count
+        }
         if let body = request.httpBodyData,
           let decoded = try? JSONDecoder().decode(GenerateContentRequest.self, from: body)
         {
-          lastReceivedContents = decoded.contents
+          lastReceivedContents.withLock { $0 = decoded.contents }
         }
         proto.client?.urlProtocol(proto, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
-        let payload = requestCount == 1 ? firstPayload : secondPayload
+        let payload = currentCount == 1 ? firstPayload : secondPayload
         proto.client?.urlProtocol(proto, didLoad: Data(payload.utf8))
         proto.client?.urlProtocolDidFinishLoading(proto)
       }
@@ -110,9 +168,10 @@
 
       #expect(firstResponse.content == "Nice to meet you, Alice.")
       #expect(secondResponse.content == "Your name is Alice.")
-      #expect(requestCount == 2)
-      #expect(lastReceivedContents.count == 3)
-      #expect(lastReceivedContents.first?.parts?.first?.data == .text("My name is Alice."))
+      #expect(requestCount.withLock { $0 } == 2)
+      let contents = lastReceivedContents.withLock { $0 }
+      #expect(contents.count == 3)
+      #expect(contents.first?.parts?.first?.data == .text("My name is Alice."))
     }
 
     @Test
@@ -129,12 +188,12 @@
         data: {"candidates": [{"content": {"parts": [{"text": "Ahoy matey!"}], "role": "model"}, "finishReason": "STOP", "index": 0}]}
 
         """
-      nonisolated(unsafe) var receivedSystemInstruction: Content?
+      let receivedSystemInstruction = Mutex<Content?>(nil)
       MockHTTPURLProtocol.setHandler(for: expectedURL) { request, proto in
         if let body = request.httpBodyData,
           let decoded = try? JSONDecoder().decode(GenerateContentRequest.self, from: body)
         {
-          receivedSystemInstruction = decoded.systemInstruction
+          receivedSystemInstruction.withLock { $0 = decoded.systemInstruction }
         }
         proto.client?.urlProtocol(proto, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
         proto.client?.urlProtocol(proto, didLoad: Data(ssePayload.utf8))
@@ -146,7 +205,8 @@
       let response = try await session.respond(to: "Hello")
 
       #expect(response.content == "Ahoy matey!")
-      #expect(receivedSystemInstruction?.parts?.first?.data == .text("Respond like a pirate."))
+      let instruction = receivedSystemInstruction.withLock { $0 }
+      #expect(instruction?.parts?.first?.data == .text("Respond like a pirate."))
     }
 
     @Test
@@ -211,7 +271,7 @@
       do {
         _ = try await session.respond(to: "Hello")
         Issue.record("Expected rateLimited error")
-      } catch let LanguageModelError.rateLimited(rateLimited) {
+      } catch LanguageModelError.rateLimited(let rateLimited) {
         #expect(rateLimited.debugDescription.contains("Resource has been exhausted"))
       } catch {
         Issue.record("Unexpected error thrown: \(error)")
@@ -243,7 +303,7 @@
       do {
         _ = try await session.respond(to: "Harmful prompt")
         Issue.record("Expected guardrailViolation error")
-      } catch let LanguageModelError.guardrailViolation(violation) {
+      } catch LanguageModelError.guardrailViolation(let violation) {
         #expect(violation.debugDescription.contains("Filtered for safety reasons"))
       } catch {
         Issue.record("Unexpected error thrown: \(error)")

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GeminiRequestTranslatorTests.swift
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GeminiRequestTranslatorTests.swift
@@ -1,0 +1,149 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(FoundationModels) && compiler(>=6.4)
+  import Foundation
+  import FoundationModels
+  import GeminiAPIDataModels
+  import GeminiTestUtilities
+  import Testing
+
+  @testable import GeminiLanguageModel
+
+  @Suite("GeminiRequestTranslator Tests", .requireFoundationModels)
+  struct GeminiRequestTranslatorTests {
+    @Generable(description: "A simple user profile")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct UserProfile {
+      var username: String
+      var score: Int
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesRequestWithoutSchema() throws {
+      let promptEntry = Transcript.Entry.prompt(
+        Transcript.Prompt(
+          id: "prompt-1",
+          segments: [.text(Transcript.TextSegment(content: "Hello"))]
+        )
+      )
+      let transcript = Transcript(entries: [promptEntry])
+      let request = LanguageModelExecutorGenerationRequest(
+        id: UUID(),
+        transcript: transcript,
+        enabledTools: [],
+        schema: nil,
+        generationOptions: GenerationOptions(),
+        contextOptions: ContextOptions(),
+        metadata: [:]
+      )
+
+      let result = try GeminiRequestTranslator.translate(request)
+
+      #expect(result.systemInstruction == nil)
+      #expect(result.contents.count == 1)
+      #expect(result.contents.first?.parts?.first?.data == Part.PartData.text("Hello"))
+      #expect(result.generationConfig == nil)
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesRequestWithSchema() throws {
+      let promptEntry = Transcript.Entry.prompt(
+        Transcript.Prompt(
+          id: "prompt-1",
+          segments: [.text(Transcript.TextSegment(content: "Generate a profile"))]
+        )
+      )
+      let transcript = Transcript(entries: [promptEntry])
+      let schema = UserProfile.generationSchema
+      let request = LanguageModelExecutorGenerationRequest(
+        id: UUID(),
+        transcript: transcript,
+        enabledTools: [],
+        schema: schema,
+        generationOptions: GenerationOptions(),
+        contextOptions: ContextOptions(),
+        metadata: [:]
+      )
+
+      let result = try GeminiRequestTranslator.translate(request)
+
+      #expect(result.contents.count == 1)
+      let generationConfig = try #require(result.generationConfig)
+      let responseFormat = try #require(generationConfig.responseFormat)
+      let textFormat = try #require(responseFormat.text)
+      #expect(textFormat.mimeType == TextResponseFormat.MimeType.applicationJson)
+      guard case .object(let schemaObject) = textFormat.schema else {
+        Issue.record("Expected schema to be a JSON object.")
+        return
+      }
+      #expect(schemaObject["x-order"] == nil)
+      let ordering = try #require(schemaObject["propertyOrdering"])
+      #expect(ordering == JSONValue.array([.string("username"), .string("score")]))
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesGenerationConfigWithNilSchemaReturnsNil() throws {
+      let config = try GeminiRequestTranslator.translateGenerationConfig(schema: nil)
+
+      #expect(config == nil)
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesGenerationConfigWithSchemaReturnsConfig() throws {
+      let schema = UserProfile.generationSchema
+
+      let config = try GeminiRequestTranslator.translateGenerationConfig(schema: schema)
+
+      let generationConfig = try #require(config)
+      let responseFormat = try #require(generationConfig.responseFormat)
+      let textFormat = try #require(responseFormat.text)
+      #expect(textFormat.mimeType == TextResponseFormat.MimeType.applicationJson)
+      guard case .object(let schemaObject) = textFormat.schema else {
+        Issue.record("Expected schema to be a JSON object.")
+        return
+      }
+      #expect(schemaObject["x-order"] == nil)
+      #expect(schemaObject["propertyOrdering"] != nil)
+    }
+
+    @Generable(description: "A data model with a pattern guide")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct DataModelWithPattern {
+      @Guide(description: "A postal code", .pattern(#/^\d{5}$/#))
+      var postalCode: String
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesGenerationConfigWithPatternGuideThrowsUnsupportedGenerationGuide() throws {
+      let schema = DataModelWithPattern.generationSchema
+
+      do {
+        _ = try GeminiRequestTranslator.translateGenerationConfig(schema: schema)
+        Issue.record("Expected unsupportedGenerationGuide error.")
+      } catch LanguageModelError.unsupportedGenerationGuide(let error) {
+        #expect(error.debugDescription.contains("pattern"))
+      } catch {
+        Issue.record("Unexpected error thrown: \(error)")
+      }
+    }
+  }
+#endif  // canImport(FoundationModels) && compiler(>=6.4)

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GenerationSchema+GeminiTests.swift
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GenerationSchema+GeminiTests.swift
@@ -1,0 +1,333 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(FoundationModels) && compiler(>=6.4)
+  import Foundation
+  import FoundationModels
+  import GeminiAPIDataModels
+  import GeminiTestUtilities
+  import Testing
+
+  @testable import GeminiLanguageModel
+
+  @Suite("GenerationSchema+Gemini Tests", .requireFoundationModels)
+  struct GenerationSchemaGeminiTests {
+    @Generable(description: "Basic profile information about a pet")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct PetProfile {
+      var name: String
+      var age: Int
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func convertsXOrderToPropertyOrdering() throws {
+      let stringSchema = DynamicGenerationSchema(type: String.self)
+      let intSchema = DynamicGenerationSchema(type: Int.self)
+      let rootSchema = DynamicGenerationSchema(
+        name: "CatProfile",
+        description: "Profile information about a cat",
+        properties: [
+          DynamicGenerationSchema.Property(name: "name", schema: stringSchema),
+          DynamicGenerationSchema.Property(name: "age", schema: intSchema),
+        ]
+      )
+      let schema = try GenerationSchema(root: rootSchema, dependencies: [])
+
+      let jsonSchema = try schema.toGeminiJSONSchema()
+
+      #expect(jsonSchema["x-order"] == nil)
+      let propertyOrdering = try #require(jsonSchema["propertyOrdering"])
+      #expect(propertyOrdering == .array([.string("name"), .string("age")]))
+      #expect(jsonSchema["type"] == .string("object"))
+      let properties = try #require(jsonSchema["properties"])
+      if case .object(let propDict) = properties {
+        #expect(propDict["name"] != nil)
+        #expect(propDict["age"] != nil)
+      } else {
+        Issue.record("Expected properties to be an object.")
+      }
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func convertsNestedXOrderToPropertyOrdering() throws {
+      let stringSchema = DynamicGenerationSchema(type: String.self)
+      let addressSchema = DynamicGenerationSchema(
+        name: "Address",
+        description: "A postal address",
+        properties: [
+          DynamicGenerationSchema.Property(name: "street", schema: stringSchema),
+          DynamicGenerationSchema.Property(name: "city", schema: stringSchema),
+        ]
+      )
+      let personSchema = DynamicGenerationSchema(
+        name: "Person",
+        description: "A person with an address",
+        properties: [
+          DynamicGenerationSchema.Property(name: "name", schema: stringSchema),
+          DynamicGenerationSchema.Property(name: "address", schema: addressSchema),
+        ]
+      )
+      let schema = try GenerationSchema(root: personSchema, dependencies: [])
+
+      let jsonSchema = try schema.toGeminiJSONSchema()
+
+      #expect(jsonSchema["x-order"] == nil)
+      let rootOrdering = try #require(jsonSchema["propertyOrdering"])
+      #expect(rootOrdering == .array([.string("name"), .string("address")]))
+      let defs = try #require(jsonSchema["$defs"])
+      guard case .object(let defsDict) = defs,
+        case .object(let addressDef) = try #require(defsDict["Address"])
+      else {
+        Issue.record("Expected $defs to contain Address.")
+        return
+      }
+      #expect(addressDef["x-order"] == nil)
+      let addressOrdering = try #require(addressDef["propertyOrdering"])
+      #expect(addressOrdering == .array([.string("street"), .string("city")]))
+
+      let encoder = JSONEncoder()
+      let data = try encoder.encode(jsonSchema)
+      let jsonString = try #require(String(data: data, encoding: .utf8))
+      #expect(!jsonString.contains("x-order"))
+      #expect(jsonString.contains("propertyOrdering"))
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func convertsGenerableTypeSchema() throws {
+      let schema = PetProfile.generationSchema
+
+      let jsonSchema = try schema.toGeminiJSONSchema()
+
+      #expect(jsonSchema["x-order"] == nil)
+      let propertyOrdering = try #require(jsonSchema["propertyOrdering"])
+      #expect(propertyOrdering == .array([.string("name"), .string("age")]))
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func toGeminiJSONValueWrapsObject() throws {
+      let stringSchema = DynamicGenerationSchema(type: String.self)
+      let rootSchema = DynamicGenerationSchema(
+        name: "Item",
+        description: "A simple item",
+        properties: [
+          DynamicGenerationSchema.Property(name: "title", schema: stringSchema)
+        ]
+      )
+      let schema = try GenerationSchema(root: rootSchema, dependencies: [])
+
+      let jsonValue = try schema.toGeminiJSONValue()
+
+      guard case .object(let jsonObject) = jsonValue else {
+        Issue.record("Expected .object variant from toGeminiJSONValue().")
+        return
+      }
+      #expect(jsonObject["x-order"] == nil)
+      #expect(jsonObject["type"] == .string("object"))
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func integratesWithTextResponseFormat() throws {
+      let stringSchema = DynamicGenerationSchema(type: String.self)
+      let rootSchema = DynamicGenerationSchema(
+        name: "Response",
+        description: "A structured response",
+        properties: [
+          DynamicGenerationSchema.Property(name: "message", schema: stringSchema)
+        ]
+      )
+      let schema = try GenerationSchema(root: rootSchema, dependencies: [])
+
+      let textFormat = TextResponseFormat(
+        mimeType: .applicationJson,
+        schema: try schema.toGeminiJSONValue()
+      )
+      let config = ResponseFormatConfig(text: textFormat)
+      let data = try JSONEncoder().encode(config)
+      let decoded = try JSONDecoder().decode(ResponseFormatConfig.self, from: data)
+
+      #expect(decoded.text?.mimeType == .applicationJson)
+      guard case .object(let schemaObject) = decoded.text?.schema else {
+        Issue.record("Expected decoded schema to be a JSON object.")
+        return
+      }
+      #expect(schemaObject["x-order"] == nil)
+      #expect(schemaObject["propertyOrdering"] == .array([.string("message")]))
+    }
+
+    @Generable(description: "A priority level")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    enum Priority: String {
+      case low
+      case medium
+      case high
+      case critical
+    }
+
+    @Generable(description: "A node in a tree")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct TreeNode {
+      var name: String
+      var children: [TreeNode]
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func convertsStringEnumSchema() throws {
+      let schema = Priority.generationSchema
+
+      let jsonSchema = try schema.toGeminiJSONSchema()
+
+      #expect(jsonSchema["type"] == .string("string"))
+      let enumValues = try #require(jsonSchema["enum"])
+      #expect(
+        enumValues
+          == .array([
+            .string("low"),
+            .string("medium"),
+            .string("high"),
+            .string("critical"),
+          ])
+      )
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func convertsRecursiveSchema() throws {
+      let schema = TreeNode.generationSchema
+
+      let jsonSchema = try schema.toGeminiJSONSchema()
+
+      #expect(jsonSchema["x-order"] == nil)
+      #expect(jsonSchema["propertyOrdering"] != nil)
+      let properties = try #require(jsonSchema["properties"])
+      guard case .object(let propDict) = properties else {
+        Issue.record("Expected properties to be an object.")
+        return
+      }
+      #expect(propDict["name"] != nil)
+      #expect(propDict["children"] != nil)
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func convertsArrayLengthAndNumericConstraints() throws {
+      let intSchema = DynamicGenerationSchema(
+        type: Int.self,
+        guides: [.range(1...10)]
+      )
+      let arraySchema = DynamicGenerationSchema(
+        arrayOf: intSchema,
+        minimumElements: 1,
+        maximumElements: 5
+      )
+      let rootSchema = DynamicGenerationSchema(
+        name: "Rankings",
+        description: "Rankings list",
+        properties: [
+          DynamicGenerationSchema.Property(name: "scores", schema: arraySchema)
+        ]
+      )
+      let schema = try GenerationSchema(root: rootSchema, dependencies: [])
+
+      let jsonSchema = try schema.toGeminiJSONSchema()
+
+      let properties = try #require(jsonSchema["properties"])
+      guard case .object(let propDict) = properties,
+        case .object(let scoresProp) = try #require(propDict["scores"])
+      else {
+        Issue.record("Expected properties.scores to be an object.")
+        return
+      }
+      #expect(scoresProp["type"] == .string("array"))
+      #expect(scoresProp["minItems"] == .number(1))
+      #expect(scoresProp["maxItems"] == .number(5))
+    }
+
+    @Generable(description: "A data model with a pattern guide")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct DataModelWithPattern {
+      @Guide(description: "A postal code", .pattern(#/^\d{5}$/#))
+      var postalCode: String
+    }
+
+    @Generable(description: "A data model with a property named pattern")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct DataModelWithPatternProperty {
+      var pattern: String
+    }
+
+    @Generable(description: "A data model with a property named properties and a pattern guide")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct DataModelWithPropertiesAndPatternGuide {
+      @Guide(description: "A postal code", .pattern(#/^\d{5}$/#))
+      var properties: String
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func schemaWithPatternGuideThrowsUnsupportedGenerationGuide() throws {
+      let schema = DataModelWithPattern.generationSchema
+
+      do {
+        _ = try schema.toGeminiJSONSchema()
+        Issue.record("Expected unsupportedGenerationGuide error.")
+      } catch LanguageModelError.unsupportedGenerationGuide(let error) {
+        #expect(error.debugDescription.contains("pattern"))
+      } catch {
+        Issue.record("Unexpected error thrown: \(error)")
+      }
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func schemaWithPropertiesPropertyAndPatternGuideThrows() throws {
+      let schema = DataModelWithPropertiesAndPatternGuide.generationSchema
+
+      do {
+        _ = try schema.toGeminiJSONSchema()
+        Issue.record("Expected unsupportedGenerationGuide error.")
+      } catch LanguageModelError.unsupportedGenerationGuide(let error) {
+        #expect(error.debugDescription.contains("pattern"))
+      } catch {
+        Issue.record("Unexpected error thrown: \(error)")
+      }
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func schemaWithPropertyNamedPatternEncodesSuccessfully() throws {
+      let schema = DataModelWithPatternProperty.generationSchema
+
+      let jsonSchema = try schema.toGeminiJSONSchema()
+
+      let properties = try #require(jsonSchema["properties"])
+      guard case .object(let propDict) = properties else {
+        Issue.record("Expected properties to be an object.")
+        return
+      }
+      #expect(propDict["pattern"] != nil)
+    }
+  }
+#endif  // canImport(FoundationModels) && compiler(>=6.4)

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GenerationSchema+GeminiTests.swift
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GenerationSchema+GeminiTests.swift
@@ -277,6 +277,13 @@
       var pattern: String
     }
 
+    @Generable(description: "A nested data model with a pattern property")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct NestedModelWithPatternProperty {
+      var child: DataModelWithPatternProperty
+    }
+
     @Generable(description: "A data model with a property named properties and a pattern guide")
     @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
     @available(tvOS, unavailable)
@@ -328,6 +335,24 @@
         return
       }
       #expect(propDict["pattern"] != nil)
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func schemaWithNestedPropertyNamedPatternEncodesSuccessfully() throws {
+      let schema = NestedModelWithPatternProperty.generationSchema
+
+      let jsonSchema = try schema.toGeminiJSONSchema()
+
+      let defs = try #require(jsonSchema["$defs"])
+      guard case .object(let defsDict) = defs,
+        case .object(let childDef) = try #require(defsDict["DataModelWithPatternProperty"]),
+        case .object(let childProps) = try #require(childDef["properties"])
+      else {
+        Issue.record("Expected $defs to contain DataModelWithPatternProperty.")
+        return
+      }
+      #expect(childProps["pattern"] != nil)
     }
   }
 #endif  // canImport(FoundationModels) && compiler(>=6.4)

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/IntegrationTests/GuidedGenerationIntegrationTests.swift
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/IntegrationTests/GuidedGenerationIntegrationTests.swift
@@ -1,0 +1,177 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(FoundationModels) && compiler(>=6.4)
+  import Foundation
+  import FoundationModels
+  import GeminiAPIClient
+  import GeminiTestUtilities
+  import Testing
+
+  @testable import GeminiLanguageModel
+
+  /// Integration tests for guided generation (structured output) using `GeminiLanguageModel`.
+  @Suite("Guided Generation Integration Tests", .requireFoundationModels)
+  struct GuidedGenerationIntegrationTests {
+    @Generable(description: "A summary of a city")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct CitySummary {
+      var name: String
+      var country: String
+    }
+
+    @Test(
+      .tags(.integration),
+      .requireIntegrationTestingBackend,
+      arguments: IntegrationTestingBackend.availableBackends
+    )
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func sessionRespondWithSchema(backend: IntegrationTestingBackend) async throws {
+      let model = try await backend.makeModel()
+      let session = LanguageModelSession(model: model)
+
+      let response = try await session.respond(
+        to: "Provide details for the city of Paris.",
+        generating: CitySummary.self
+      )
+
+      #expect(!response.content.name.isEmpty)
+      #expect(!response.content.country.isEmpty)
+      #expect(response.usage.totalTokenCount > 0)
+      #expect(response.usage.input.totalTokenCount > 0)
+      #expect(response.usage.output.totalTokenCount > 0)
+    }
+
+    @Test(
+      .tags(.integration),
+      .requireIntegrationTestingBackend,
+      arguments: IntegrationTestingBackend.availableBackends
+    )
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func sessionStreamResponseWithSchema(backend: IntegrationTestingBackend) async throws {
+      let model = try await backend.makeModel()
+      let session = LanguageModelSession(model: model)
+
+      let stream = session.streamResponse(
+        to: "Provide details for the city of Tokyo.",
+        generating: CitySummary.self
+      )
+      var snapshotCount = 0
+      for try await _ in stream {
+        snapshotCount += 1
+      }
+      let response = try await stream.collect()
+
+      #expect(snapshotCount > 0)
+      #expect(!response.content.name.isEmpty)
+      #expect(!response.content.country.isEmpty)
+      #expect(response.usage.totalTokenCount > 0)
+      #expect(response.usage.input.totalTokenCount > 0)
+      #expect(response.usage.output.totalTokenCount > 0)
+    }
+
+    @Generable(description: "A priority level for a support ticket")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    enum TicketPriority: String {
+      case low
+      case medium
+      case high
+      case critical
+    }
+
+    @Generable(description: "A classified support ticket")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct TicketClassification {
+      var summary: String
+      var priority: TicketPriority
+    }
+
+    @Test(
+      .tags(.integration),
+      .requireIntegrationTestingBackend,
+      arguments: IntegrationTestingBackend.availableBackends
+    )
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func sessionRespondWithEnumClassification(backend: IntegrationTestingBackend) async throws {
+      let model = try await backend.makeModel()
+      let session = LanguageModelSession(model: model)
+
+      let response = try await session.respond(
+        to: "The entire production database server is down and users cannot log in.",
+        generating: TicketClassification.self
+      )
+
+      #expect(!response.content.summary.isEmpty)
+      #expect(
+        response.content.priority == .high || response.content.priority == .critical
+      )
+      #expect(response.usage.totalTokenCount > 0)
+      #expect(response.usage.input.totalTokenCount > 0)
+      #expect(response.usage.output.totalTokenCount > 0)
+    }
+
+    @Generable(description: "An organization node in an organizational hierarchy")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct OrganizationNode {
+      var name: String
+      var headcount: Int
+      var budgetMillions: Double
+      var isActive: Bool
+      var notes: String?
+      var skills: [String]
+      var subteams: [OrganizationNode]
+    }
+
+    @Test(
+      .tags(.integration),
+      .requireIntegrationTestingBackend,
+      arguments: IntegrationTestingBackend.availableBackends
+    )
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func sessionRespondWithRecursiveHierarchy(backend: IntegrationTestingBackend) async throws {
+      let model = try await backend.makeModel()
+      let session = LanguageModelSession(model: model)
+
+      let prompt = """
+        Generate an engineering department named "Platform" with 50 people, a budget of \
+        4.5 million, active status, notes "Core infrastructure team", skills ["Swift", "Go"], \
+        and one subteam named "Networking" with 10 people, budget 1.0 million, active status, \
+        skills ["TCP", "HTTP"], and no subteams.
+        """
+      let response = try await session.respond(
+        to: prompt,
+        generating: OrganizationNode.self
+      )
+
+      #expect(!response.content.name.isEmpty)
+      #expect(response.content.headcount > 0)
+      #expect(response.content.budgetMillions > 0.0)
+      #expect(response.content.isActive)
+      #expect(!response.content.skills.isEmpty)
+      #expect(response.content.subteams.count >= 1)
+      let firstSubteam = try #require(response.content.subteams.first)
+      #expect(!firstSubteam.name.isEmpty)
+      #expect(firstSubteam.headcount > 0)
+      #expect(firstSubteam.budgetMillions > 0.0)
+      #expect(firstSubteam.isActive)
+      #expect(response.usage.totalTokenCount > 0)
+      #expect(response.usage.input.totalTokenCount > 0)
+      #expect(response.usage.output.totalTokenCount > 0)
+    }
+  }
+#endif  // canImport(FoundationModels) && compiler(>=6.4)

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/IntegrationTests/GuidedGenerationIntegrationTests.swift
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/IntegrationTests/GuidedGenerationIntegrationTests.swift
@@ -22,7 +22,11 @@
   @testable import GeminiLanguageModel
 
   /// Integration tests for guided generation (structured output) using `GeminiLanguageModel`.
-  @Suite("Guided Generation Integration Tests", .requireFoundationModels)
+  @Suite(
+    "Guided Generation Integration Tests",
+    .requireFoundationModels,
+    .tags(.integration)
+  )
   struct GuidedGenerationIntegrationTests {
     @Generable(description: "A summary of a city")
     @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
@@ -33,7 +37,6 @@
     }
 
     @Test(
-      .tags(.integration),
       .requireIntegrationTestingBackend,
       arguments: IntegrationTestingBackend.availableBackends
     )
@@ -54,11 +57,7 @@
       #expect(response.usage.output.totalTokenCount > 0)
     }
 
-    @Test(
-      .tags(.integration),
-      .requireIntegrationTestingBackend,
-      arguments: IntegrationTestingBackend.availableBackends
-    )
+    @Test(.requireIntegrationTestingBackend, arguments: IntegrationTestingBackend.availableBackends)
     @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
     func sessionStreamResponseWithSchema(backend: IntegrationTestingBackend) async throws {
       let model = try await backend.makeModel()
@@ -100,11 +99,7 @@
       var priority: TicketPriority
     }
 
-    @Test(
-      .tags(.integration),
-      .requireIntegrationTestingBackend,
-      arguments: IntegrationTestingBackend.availableBackends
-    )
+    @Test(.requireIntegrationTestingBackend, arguments: IntegrationTestingBackend.availableBackends)
     @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
     func sessionRespondWithEnumClassification(backend: IntegrationTestingBackend) async throws {
       let model = try await backend.makeModel()
@@ -137,11 +132,7 @@
       var subteams: [OrganizationNode]
     }
 
-    @Test(
-      .tags(.integration),
-      .requireIntegrationTestingBackend,
-      arguments: IntegrationTestingBackend.availableBackends
-    )
+    @Test(.requireIntegrationTestingBackend, arguments: IntegrationTestingBackend.availableBackends)
     @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
     func sessionRespondWithRecursiveHierarchy(backend: IntegrationTestingBackend) async throws {
       let model = try await backend.makeModel()

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/IntegrationTests/README.md
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/IntegrationTests/README.md
@@ -47,6 +47,10 @@ All integration tests are parameterized across
 * [`BasicContentGenerationIntegrationTests.swift`](BasicContentGenerationIntegrationTests.swift):
   Parameterized integration tests for single-turn prompt response, multi-turn
   chat sessions, and streaming chunk responses.
+* [`GuidedGenerationIntegrationTests.swift`](GuidedGenerationIntegrationTests.swift):
+  Parameterized integration tests for guided generation (structured outputs)
+  using `@Generable` types, including single-turn and streaming generation,
+  enum classification, and rich multi-type recursive hierarchies.
 * [`IntegrationTestingBackend+GeminiLanguageModel.swift`](IntegrationTestingBackend+GeminiLanguageModel.swift):
   Convenience extension providing `backend.makeModel()` to instantiate a
   pre-configured `GeminiLanguageModel`.

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/README.md
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/README.md
@@ -19,6 +19,8 @@ swift test --filter GeminiLanguageModelTests
 | Suite / File | Scope | Strategy |
 |---|---|---|
 | [`GeminiLanguageModelTests.swift`](GeminiLanguageModelTests.swift) | Protocol conformance, single/multi-turn responses, streaming | Unit (`MockHTTPURLProtocol`) |
+| [`GenerationSchema+GeminiTests.swift`](GenerationSchema+GeminiTests.swift) | JSON Schema encoding and property ordering conversion | Unit (pure transformation) |
+| [`GeminiRequestTranslatorTests.swift`](GeminiRequestTranslatorTests.swift) | Request and generation config mapping with schemas | Unit (pure transformation) |
 | [`GeminiTranscriptTranslatorTests.swift`](GeminiTranscriptTranslatorTests.swift) | Apple `Transcript` <-> Gemini payload mapping | Unit (pure transformation) |
 | [`GeminiErrorMapperTests.swift`](GeminiErrorMapperTests.swift) | HTTP and API error mapping to `LanguageModelError` | Unit (exhaustive mapping) |
 | [`IntegrationTestingBackendTests.swift`](IntegrationTestingBackendTests.swift) | Endpoint resolution and credential discovery | Unit / Infrastructure |


### PR DESCRIPTION
Added guided generation (structured output) support to `GeminiLanguageModel` conforming to Apple's `LanguageModel`.

- Extended `GenerationSchema` to translate schemas into Gemini-compatible JSON Schema definitions, remapping `x-order` to `propertyOrdering`.
- Detects regex `pattern` guides during encoding and throws
  `LanguageModelError.unsupportedGenerationGuide` since these are not supported by Gemini.
- Introduced `GeminiRequestTranslator` to map generation requests and schemas into `GenerateContentRequest` and `GenerationConfig`.
  - Note: Other `GenerationConfig` settings, like `temperature`, are not yet implemented. These are lower priority since most are deprecated for Gemini 3 models.
- Declared the `.guidedGeneration` capability on `GeminiLanguageModel`.
- Added comprehensive unit tests covering property ordering, nested definitions, enums, recursive schemas, and error throwing.
- Add parameterized integration tests for single-turn and streaming structured output generation, enum classification, and recursive hierarchies.

#no-changelog