### PR TITLE
feat(ai): add GeminiLanguageModel tool calling

### DIFF
--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GeminiLanguageModelTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GeminiLanguageModelTests.swift
@@ -72,5 +72,55 @@
       #expect(cat.age >= 0 && cat.age <= 20)
       #expect(!cat.profile.isEmpty)
     }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+    struct GetTemperature: FoundationModels.Tool {
+      let description = "Returns the current temperature for the specified location."
+
+      @Generable
+      struct Location {
+        let city: String
+      }
+
+      @Generable
+      struct Temperature {
+        let value: Double
+      }
+
+      func call(arguments: Location) async throws -> Temperature {
+        return Temperature(value: 25.0)
+      }
+    }
+
+    @Test(arguments: InstanceConfig.defaultConfigs)
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+    func testToolCalling(_ config: InstanceConfig) async throws {
+      let ai = FirebaseAI.componentInstance(config)
+      let model = ai.geminiLanguageModel(name: ModelNames.gemini3_1_FlashLite)
+      let session = LanguageModelSession(model: model, tools: [GetTemperature()])
+
+      let response = try await session.respond(to: "What is the temperature in San Francisco?")
+      let content = response.content
+      #expect(!content.isEmpty)
+      #expect(content.contains("25"))
+    }
+
+    @Test(arguments: InstanceConfig.defaultConfigs)
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+    func testToolCallingDisallowed(_ config: InstanceConfig) async throws {
+      let ai = FirebaseAI.componentInstance(config)
+      let model = ai.geminiLanguageModel(name: ModelNames.gemini3_1_FlashLite)
+      let session = LanguageModelSession(model: model, tools: [GetTemperature()])
+
+      let response = try await session.respond(
+        to: "What is the temperature in San Francisco?",
+        options: GenerationOptions(
+          toolCallingMode: .disallowed
+        )
+      )
+      let content = response.content
+      #expect(!content.isEmpty)
+      #expect(!content.contains("25"))
+    }
   }
 #endif // compiler(>=6.4) && canImport(FoundationModels) && canImport(GeminiLanguageModel)

--- a/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiLanguageModel.swift
+++ b/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiLanguageModel.swift
@@ -56,6 +56,7 @@
       LanguageModelCapabilities([
         .guidedGeneration,
         .reasoning,
+        .toolCalling,
       ])
     }
   }

--- a/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiLanguageModelExecutor.swift
+++ b/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiLanguageModelExecutor.swift
@@ -90,6 +90,8 @@
 
         let responseEntryID = UUID().uuidString
         let reasoningEntryID = UUID().uuidString
+        let toolCallsEntryID = UUID().uuidString
+        let jsonEncoder = JSONEncoder()
 
         do {
           let stream = try await client.generateContentStream(for: generateRequest)
@@ -129,6 +131,28 @@
                       )
                     )
                   }
+                }
+
+                if case .functionCall(let call) = part.data {
+                  let callID = call.id ?? UUID().uuidString
+                  let argsString: String
+                  if let args = call.args, !args.isEmpty {
+                    let data = try jsonEncoder.encode(JSONValue.object(args))
+                    argsString = String(decoding: data, as: UTF8.self)
+                  } else {
+                    argsString = "{}"
+                  }
+
+                  await channel.send(
+                    .toolCalls(
+                      entryID: toolCallsEntryID,
+                      action: .toolCall(
+                        id: callID,
+                        name: call.name,
+                        action: .appendArguments(argsString, tokenCount: 1)
+                      )
+                    )
+                  )
                 }
               }
             }

--- a/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiRequestTranslator.swift
+++ b/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiRequestTranslator.swift
@@ -15,7 +15,6 @@
 #if canImport(FoundationModels) && compiler(>=6.4)
   import Foundation
   import FoundationModels
-
   import GeminiAPIDataModels
 
   /// Translates Foundation Models requests into Gemini API data models.
@@ -34,10 +33,16 @@
         request.transcript
       )
       let generationConfig = try translateGenerationConfig(schema: request.schema)
+      let tools = try translateTools(request.enabledToolDefinitions)
+      let toolConfig = translateToolConfig(
+        toolCallingMode: request.generationOptions.toolCallingMode
+      )
 
       return GenerateContentRequest(
         systemInstruction: systemInstruction,
         contents: contents,
+        tools: tools,
+        toolConfig: toolConfig,
         generationConfig: generationConfig
       )
     }
@@ -60,6 +65,55 @@
         schema: .object(jsonSchema)
       )
       return GenerationConfig(responseFormat: ResponseFormatConfig(text: textFormat))
+    }
+
+    /// Translates enabled tool definitions into a list of Gemini `Tool` objects.
+    ///
+    /// - Parameter enabledToolDefinitions: Tool definitions registered for the request.
+    /// - Returns: A list containing a single `Tool` with function declarations, or `nil` if empty.
+    /// - Throws: An error if schema translation fails.
+    static func translateTools(
+      _ enabledToolDefinitions: [Transcript.ToolDefinition]
+    ) throws -> [GeminiAPIDataModels.Tool]? {
+      guard !enabledToolDefinitions.isEmpty else { return nil }
+
+      let declarations = try enabledToolDefinitions.map { toolDefinition in
+        let parameters = try toolDefinition.parameters.toGeminiJSONValue()
+        return FunctionDeclaration(
+          name: toolDefinition.name,
+          description: toolDefinition.description,
+          parametersJsonSchema: parameters
+        )
+      }
+      return [GeminiAPIDataModels.Tool(functionDeclarations: declarations)]
+    }
+
+    /// Translates tool calling mode options into a Gemini `ToolConfig`.
+    ///
+    /// - Parameter toolCallingMode: The tool calling mode options from the request.
+    /// - Returns: A `ToolConfig` configured with function calling mode, or `nil` if unspecified.
+    static func translateToolConfig(
+      toolCallingMode: GenerationOptions.ToolCallingMode?
+    ) -> ToolConfig? {
+      guard let mode = toolCallingMode else { return nil }
+
+      let callingMode: FunctionCallingConfig.Mode
+      switch mode.kind {
+      case .allowed:
+        // Note: Map to .auto for standard model autonomy. Consider evaluating
+        // .validated in the future for constrained decoding against declared functions.
+        callingMode = .auto
+      case .required:
+        callingMode = .any
+      case .disallowed:
+        callingMode = .none
+      @unknown default:
+        callingMode = .auto
+      }
+
+      return ToolConfig(
+        functionCallingConfig: FunctionCallingConfig(mode: callingMode)
+      )
     }
   }
 #endif  // canImport(FoundationModels) && compiler(>=6.4)

--- a/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiTranscriptTranslator.swift
+++ b/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiTranscriptTranslator.swift
@@ -44,54 +44,121 @@
         }
       }
 
+      var pendingReasoningText: String?
+      var pendingReasoningSignature: String?
+
+      /// Flushes any buffered reasoning thoughts or signature into a model part.
+      func flushPendingReasoningIfNeeded() {
+        if let text = pendingReasoningText {
+          appendPart(
+            Part(
+              data: .text(text),
+              thought: true,
+              thoughtSignature: pendingReasoningSignature
+            ),
+            role: "model"
+          )
+        } else if let signature = pendingReasoningSignature {
+          appendPart(
+            Part(
+              data: nil,
+              thought: true,
+              thoughtSignature: signature
+            ),
+            role: "model"
+          )
+        }
+        pendingReasoningText = nil
+        pendingReasoningSignature = nil
+      }
+
       for entry in transcript {
         switch entry {
         case .instructions(let instructions):
+          flushPendingReasoningIfNeeded()
           let text = try extractText(from: instructions.segments, in: entry)
-          guard instructions.toolDefinitions.isEmpty else {
-            throw makeUnsupportedError(
-              entry,
-              description: "Tool definitions in instructions are not supported."
-            )
+          if !text.isEmpty {
+            systemInstructionParts.append(Part(data: .text(text)))
           }
-          systemInstructionParts.append(Part(data: .text(text)))
 
         case .prompt(let prompt):
+          flushPendingReasoningIfNeeded()
           let text = try extractText(from: prompt.segments, in: entry)
           appendPart(Part(data: .text(text)), role: "user")
 
         case .response(let response):
+          flushPendingReasoningIfNeeded()
           let text = try extractText(from: response.segments, in: entry)
           appendPart(Part(data: .text(text)), role: "model")
 
         case .reasoning(let reasoning):
+          let text = try extractOptionalText(from: reasoning.segments, in: entry)
           let signatureString = reasoning.signature.map {
             String(decoding: $0, as: UTF8.self)
           }
-          let text = try extractOptionalText(from: reasoning.segments, in: entry)
-          let partData: Part.PartData? = text.map { .text($0) }
-          if partData != nil || signatureString != nil {
+          if let text {
+            pendingReasoningText = (pendingReasoningText ?? "") + text
+          }
+          if let signatureString {
+            pendingReasoningSignature = signatureString
+          }
+
+        case .toolCalls(let toolCalls):
+          guard !toolCalls.isEmpty else { break }
+          if let text = pendingReasoningText {
             appendPart(
               Part(
-                data: partData,
-                thought: true,
-                thoughtSignature: signatureString
+                data: .text(text),
+                thought: true
+              ),
+              role: "model"
+            )
+          }
+          let callSignature = pendingReasoningSignature
+          pendingReasoningText = nil
+          pendingReasoningSignature = nil
+
+          for call in toolCalls {
+            let args: [String: JSONValue]?
+            if case .structure(let properties, _) = call.arguments.kind {
+              args = properties.isEmpty ? nil : properties.mapValues { jsonValue(from: $0) }
+            } else {
+              args = nil
+            }
+            let functionCall = FunctionCall(
+              id: call.id,
+              name: call.toolName,
+              args: args
+            )
+            appendPart(
+              Part(
+                data: .functionCall(functionCall),
+                thoughtSignature: callSignature
               ),
               role: "model"
             )
           }
 
-        case .toolCalls:
-          throw makeUnsupportedError(
-            entry,
-            description: "Tool calls in transcript are not supported."
-          )
-
-        case .toolOutput:
-          throw makeUnsupportedError(
-            entry,
-            description: "Tool outputs in transcript are not supported."
-          )
+        case .toolOutput(let toolOutput):
+          flushPendingReasoningIfNeeded()
+          if toolOutput.segments.isEmpty {
+            let functionResponse = FunctionResponse(
+              id: toolOutput.id,
+              name: toolOutput.toolName,
+              response: ["result": .null]
+            )
+            appendPart(Part(data: .functionResponse(functionResponse)), role: "user")
+          } else {
+            for segment in toolOutput.segments {
+              let response = try extractResponse(from: segment, in: entry)
+              let functionResponse = FunctionResponse(
+                id: toolOutput.id,
+                name: toolOutput.toolName,
+                response: response
+              )
+              appendPart(Part(data: .functionResponse(functionResponse)), role: "user")
+            }
+          }
 
         @unknown default:
           throw makeUnsupportedError(
@@ -100,6 +167,8 @@
           )
         }
       }
+
+      flushPendingReasoningIfNeeded()
 
       let contents = turns.map { Content(parts: $0.parts, role: $0.role) }
       let systemInstruction: Content? =
@@ -119,6 +188,65 @@
           debugDescription: description
         )
       )
+    }
+
+    /// Converts a `GeneratedContent` value into a corresponding `JSONValue`.
+    ///
+    /// - Parameter content: The generated content to convert.
+    /// - Returns: The mapped `JSONValue`.
+    private static func jsonValue(from content: GeneratedContent) -> JSONValue {
+      switch content.kind {
+      case .null:
+        return .null
+      case .bool(let value):
+        return .bool(value)
+      case .number(let value):
+        return .number(value)
+      case .string(let value):
+        return .string(value)
+      case .array(let values):
+        return .array(values.map { jsonValue(from: $0) })
+      case .structure(let properties, _):
+        return .object(properties.mapValues { jsonValue(from: $0) })
+      @unknown default:
+        return .null
+      }
+    }
+
+    /// Extracts a JSON object dictionary representation from a tool output segment.
+    ///
+    /// - Parameters:
+    ///   - segment: The tool output segment to extract.
+    ///   - entry: The enclosing transcript entry for error reporting.
+    /// - Returns: A dictionary of key-value pairs suitable for `FunctionResponse.response`.
+    /// - Throws: `LanguageModelError.unsupportedTranscriptContent` if unsupported segments are
+    ///   found.
+    private static func extractResponse(
+      from segment: Transcript.Segment,
+      in entry: Transcript.Entry
+    ) throws -> [String: JSONValue] {
+      switch segment {
+      case .structure(let structuredSegment):
+        let val = jsonValue(from: structuredSegment.content)
+        if case .object(let obj) = val {
+          return obj
+        } else {
+          return ["result": val]
+        }
+      case .text(let textSegment):
+        return ["result": .string(textSegment.content)]
+
+      case .attachment:
+        throw makeUnsupportedError(
+          entry,
+          description: "Attachment segments in tool output are not supported."
+        )
+      @unknown default:
+        throw makeUnsupportedError(
+          entry,
+          description: "Unsupported segment in tool output."
+        )
+      }
     }
 
     private static func extractText(

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GeminiLanguageModelTests.swift
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GeminiLanguageModelTests.swift
@@ -49,7 +49,7 @@
       #expect(model.executorConfiguration.endpointConfiguration == .geminiDeveloperAPI)
       #expect(model.capabilities.contains(.reasoning))
       #expect(model.capabilities.contains(.guidedGeneration))
-      #expect(!model.capabilities.contains(.toolCalling))
+      #expect(model.capabilities.contains(.toolCalling))
     }
 
     @Test
@@ -335,15 +335,16 @@
     @Test
     @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
     func unsupportedTranscriptContentThrows() throws {
-      let toolCall = Transcript.ToolCall(
-        id: "call-1",
-        toolName: "calculator",
-        arguments: GeneratedContent("1+1")
+      let structuredSegment = Transcript.Segment.structure(
+        Transcript.StructuredSegment(
+          id: "struct-1",
+          schemaName: "test",
+          content: GeneratedContent("test")
+        )
       )
-      let toolCallsEntry = Transcript.Entry.toolCalls(
-        Transcript.ToolCalls(id: "calls-1", [toolCall])
+      let transcript = Transcript(
+        entries: [.prompt(Transcript.Prompt(segments: [structuredSegment]))]
       )
-      let transcript = Transcript(entries: [toolCallsEntry])
 
       do {
         _ = try GeminiTranscriptTranslator.translate(transcript)
@@ -355,9 +356,139 @@
       }
     }
 
+    /// A mock weather tool for testing tool call execution.
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct MockWeatherTool: FoundationModels.Tool {
+
+      let name = "get_weather"
+      let description = "Get current weather"
+
+      @Generable
+      @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+      @available(tvOS, unavailable)
+      struct Arguments {
+        var location: String
+      }
+
+      func call(arguments: Arguments) async throws -> String {
+        "Sunny, 72°F in \(arguments.location)"
+      }
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func sessionRespondWithToolCalling() async throws {
+      defer { MockHTTPURLProtocol.reset() }
+      let model = Self.makeMockModel()
+      let expectedURL = try Self.makeExpectedStreamURL()
+      let httpResponse = try HTTPURLResponse.mock(
+        url: expectedURL,
+        headerFields: ["Content-Type": "text/event-stream"]
+      )
+      let turn1SSE = """
+        data: {"candidates": [{"content": {"parts": [{"functionCall": {"id": "call-1", "name": "get_weather", "args": {"location": "Paris"}}}], "role": "model"}, "finishReason": "STOP", "index": 0}], "usageMetadata": {"candidatesTokenCount": 5, "promptTokenCount": 10, "totalTokenCount": 15}}
+
+        """
+      let turn2SSE = """
+        data: {"candidates": [{"content": {"parts": [{"text": "The weather in Paris is sunny, 72°F."}], "role": "model"}, "finishReason": "STOP", "index": 0}], "usageMetadata": {"candidatesTokenCount": 8, "promptTokenCount": 20, "totalTokenCount": 28}}
+
+        """
+      let requestCount = Mutex(0)
+      MockHTTPURLProtocol.setHandler(for: expectedURL) { _, proto in
+        let currentCount = requestCount.withLock { count -> Int in
+          count += 1
+          return count
+        }
+        proto.client?.urlProtocol(proto, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+        let payload = currentCount == 1 ? turn1SSE : turn2SSE
+        proto.client?.urlProtocol(proto, didLoad: Data(payload.utf8))
+        proto.client?.urlProtocolDidFinishLoading(proto)
+      }
+      let session = LanguageModelSession(model: model, tools: [MockWeatherTool()])
+
+      let response = try await session.respond(to: "What is the weather in Paris?")
+
+      #expect(response.content == "The weather in Paris is sunny, 72°F.")
+      #expect(requestCount.withLock { $0 } == 2)
+    }
+
+    /// A mock time tool taking no arguments for testing empty argument tool calling.
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct MockTimeTool: FoundationModels.Tool {
+      let name = "get_current_time"
+      let description = "Get the current time"
+
+      @Generable
+      @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+      @available(tvOS, unavailable)
+      struct Arguments {}
+
+      func call(arguments: Arguments) async throws -> String {
+        "12:00 PM"
+      }
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func sessionRespondWithEmptyArgumentsToolCalling() async throws {
+      defer { MockHTTPURLProtocol.reset() }
+      let model = Self.makeMockModel()
+      let expectedURL = try Self.makeExpectedStreamURL()
+      let httpResponse = try HTTPURLResponse.mock(
+        url: expectedURL,
+        headerFields: ["Content-Type": "text/event-stream"]
+      )
+      let turn1SSE = """
+        data: {"candidates": [{"content": {"parts": [{"functionCall": {"id": "call-1", "name": "get_current_time"}}], "role": "model"}, "finishReason": "STOP", "index": 0}], "usageMetadata": {"candidatesTokenCount": 5, "promptTokenCount": 10, "totalTokenCount": 15}}
+
+        """
+      let turn2SSE = """
+        data: {"candidates": [{"content": {"parts": [{"text": "The time is 12:00 PM."}], "role": "model"}, "finishReason": "STOP", "index": 0}], "usageMetadata": {"candidatesTokenCount": 8, "promptTokenCount": 20, "totalTokenCount": 28}}
+
+        """
+      let requestCount = Mutex(0)
+      let capturedRequests = Mutex<[GenerateContentRequest]>([])
+      MockHTTPURLProtocol.setHandler(for: expectedURL) { request, proto in
+        let currentCount = requestCount.withLock { count -> Int in
+          count += 1
+          return count
+        }
+        if let body = request.httpBodyData,
+          let decoded = try? JSONDecoder().decode(GenerateContentRequest.self, from: body)
+        {
+          capturedRequests.withLock { $0.append(decoded) }
+        }
+        proto.client?.urlProtocol(proto, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+        let payload = currentCount == 1 ? turn1SSE : turn2SSE
+        proto.client?.urlProtocol(proto, didLoad: Data(payload.utf8))
+        proto.client?.urlProtocolDidFinishLoading(proto)
+      }
+      let session = LanguageModelSession(model: model, tools: [MockTimeTool()])
+
+      let response = try await session.respond(to: "What time is it?")
+
+      #expect(response.content == "The time is 12:00 PM.")
+      #expect(requestCount.withLock { $0 } == 2)
+      let requests = capturedRequests.withLock { $0 }
+      #expect(requests.count == 2)
+      let turn1Tools = try #require(requests.first?.tools)
+      #expect(turn1Tools.first?.functionDeclarations?.first?.name == "get_current_time")
+      let turn2Contents = try #require(requests.last?.contents)
+      let turn2UserTurn = try #require(turn2Contents.last)
+      guard case .functionResponse(let fr) = turn2UserTurn.parts?.first?.data else {
+        Issue.record("Expected functionResponse in turn 2")
+        return
+      }
+      #expect(fr.name == "get_current_time")
+      #expect(fr.response?["result"] == .string("12:00 PM"))
+    }
+
     // MARK: - Helper Methods
 
     @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+
     private static func makeMockModel(
       modelResource: ModelResource = .gemini38Flash,
       endpointConfiguration: EndpointConfiguration = .geminiDeveloperAPI,

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GeminiRequestTranslatorTests.swift
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GeminiRequestTranslatorTests.swift
@@ -31,8 +31,29 @@
       var score: Int
     }
 
+    @Generable(description: "A data model with a pattern guide")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct DataModelWithPattern {
+      @Guide(description: "A postal code", .pattern(#/^\d{5}$/#))
+      var postalCode: String
+    }
+
+    @Generable(description: "A city location argument")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct LocationArguments {
+      var city: String
+    }
+
+    @Generable(description: "Empty arguments")
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct EmptyArguments {}
+
     @Test
     @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+
     func translatesRequestWithoutSchema() throws {
       let promptEntry = Transcript.Entry.prompt(
         Transcript.Prompt(
@@ -123,14 +144,6 @@
       #expect(schemaObject["propertyOrdering"] != nil)
     }
 
-    @Generable(description: "A data model with a pattern guide")
-    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
-    @available(tvOS, unavailable)
-    struct DataModelWithPattern {
-      @Guide(description: "A postal code", .pattern(#/^\d{5}$/#))
-      var postalCode: String
-    }
-
     @Test
     @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
     func translatesGenerationConfigWithPatternGuideThrowsUnsupportedGenerationGuide() throws {
@@ -144,6 +157,95 @@
       } catch {
         Issue.record("Unexpected error thrown: \(error)")
       }
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesEnabledToolDefinitionsIntoFunctionDeclarations() throws {
+      let toolDefinition = Transcript.ToolDefinition(
+        name: "get_current_weather",
+        description: "Get the current weather for a city.",
+        parameters: LocationArguments.generationSchema
+      )
+
+      let tools = try GeminiRequestTranslator.translateTools([toolDefinition])
+
+      let unwrappedTools = try #require(tools)
+      #expect(unwrappedTools.count == 1)
+      let declarations = try #require(unwrappedTools[0].functionDeclarations)
+      #expect(declarations.count == 1)
+      #expect(declarations[0].name == "get_current_weather")
+      #expect(declarations[0].description == "Get the current weather for a city.")
+      let parameters = try #require(declarations[0].parametersJsonSchema)
+      guard case .object(let dict) = parameters else {
+        Issue.record("Expected .object, got \(parameters)")
+        return
+      }
+      #expect(dict["type"] == .string("object"))
+      guard case .object(let properties) = dict["properties"] else {
+        Issue.record("Expected properties object in schema")
+        return
+      }
+      guard case .object(let cityProperty) = properties["city"] else {
+        Issue.record("Expected city property in properties")
+        return
+      }
+      #expect(cityProperty["type"] == .string("string"))
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesToolWithEmptyArguments() throws {
+      let toolDefinition = Transcript.ToolDefinition(
+        name: "get_current_time",
+        description: "Get the current time.",
+        parameters: EmptyArguments.generationSchema
+      )
+
+      let tools = try GeminiRequestTranslator.translateTools([toolDefinition])
+
+      let unwrappedTools = try #require(tools)
+      #expect(unwrappedTools.count == 1)
+      let declarations = try #require(unwrappedTools[0].functionDeclarations)
+      #expect(declarations.count == 1)
+      #expect(declarations[0].name == "get_current_time")
+      #expect(declarations[0].description == "Get the current time.")
+      let parameters = try #require(declarations[0].parametersJsonSchema)
+      guard case .object(let dict) = parameters else {
+        Issue.record("Expected .object, got \(parameters)")
+        return
+      }
+      #expect(dict["type"] == .string("object"))
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func emptyEnabledToolDefinitionsResultsInNilTools() throws {
+      let tools = try GeminiRequestTranslator.translateTools([])
+
+      #expect(tools == nil)
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesToolCallingModes() {
+      let allowedConfig = GeminiRequestTranslator.translateToolConfig(
+        toolCallingMode: .allowed
+      )
+      let requiredConfig = GeminiRequestTranslator.translateToolConfig(
+        toolCallingMode: .required
+      )
+      let disallowedConfig = GeminiRequestTranslator.translateToolConfig(
+        toolCallingMode: .disallowed
+      )
+      let nilConfig = GeminiRequestTranslator.translateToolConfig(
+        toolCallingMode: nil
+      )
+
+      #expect(allowedConfig?.functionCallingConfig?.mode == .auto)
+      #expect(requiredConfig?.functionCallingConfig?.mode == .any)
+      #expect(disallowedConfig?.functionCallingConfig?.mode == FunctionCallingConfig.Mode.none)
+      #expect(nilConfig == nil)
     }
   }
 #endif  // canImport(FoundationModels) && compiler(>=6.4)

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GeminiTranscriptTranslatorTests.swift
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/GeminiTranscriptTranslatorTests.swift
@@ -160,5 +160,371 @@
       #expect(parts[0].data == .text("First instruction."))
       #expect(parts[1].data == .text("Second instruction."))
     }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesToolCallsIntoModelTurn() throws {
+      let args = try GeneratedContent(json: "{\"location\":\"Paris\"}")
+      let toolCall = Transcript.ToolCall(
+        id: "call-1",
+        toolName: "get_weather",
+        arguments: args
+      )
+      let transcript = Transcript(
+        entries: [
+          .prompt(
+            Transcript.Prompt(
+              segments: [.text(Transcript.TextSegment(content: "Weather?"))]
+            )
+          ),
+          .toolCalls(Transcript.ToolCalls(id: "calls-1", [toolCall])),
+        ]
+      )
+
+      let result = try GeminiTranscriptTranslator.translate(transcript)
+
+      #expect(result.contents.count == 2)
+      #expect(result.contents[0].role == "user")
+      #expect(result.contents[1].role == "model")
+      let modelParts = try #require(result.contents[1].parts)
+      #expect(modelParts.count == 1)
+      guard case .functionCall(let functionCall) = modelParts[0].data else {
+        Issue.record("Expected functionCall part data")
+        return
+      }
+      #expect(functionCall.id == "call-1")
+      #expect(functionCall.name == "get_weather")
+      #expect(functionCall.args?["location"] == .string("Paris"))
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesToolOutputWithTextSegmentWrappingUnderResult() throws {
+      let toolOutput = Transcript.ToolOutput(
+        id: "call-1",
+        toolName: "get_weather",
+        segments: [.text(Transcript.TextSegment(content: "Sunny, 22°C"))]
+      )
+      let transcript = Transcript(entries: [.toolOutput(toolOutput)])
+
+      let result = try GeminiTranscriptTranslator.translate(transcript)
+
+      #expect(result.contents.count == 1)
+      #expect(result.contents[0].role == "user")
+      let userParts = try #require(result.contents[0].parts)
+      #expect(userParts.count == 1)
+      guard case .functionResponse(let functionResponse) = userParts[0].data else {
+        Issue.record("Expected functionResponse part data")
+        return
+      }
+      #expect(functionResponse.id == "call-1")
+      #expect(functionResponse.name == "get_weather")
+      #expect(functionResponse.response?["result"] == .string("Sunny, 22°C"))
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesToolOutputWithJSONTextPreservingStringUnderResult() throws {
+      let jsonString = "{\"temperature\":22,\"condition\":\"sunny\"}"
+      let toolOutput = Transcript.ToolOutput(
+        id: "call-1",
+        toolName: "get_weather",
+        segments: [
+          .text(Transcript.TextSegment(content: jsonString))
+        ]
+      )
+      let transcript = Transcript(entries: [.toolOutput(toolOutput)])
+
+      let result = try GeminiTranscriptTranslator.translate(transcript)
+
+      let userParts = try #require(result.contents.first?.parts)
+      guard case .functionResponse(let functionResponse) = userParts.first?.data else {
+        Issue.record("Expected functionResponse part data")
+        return
+      }
+      #expect(functionResponse.id == "call-1")
+      #expect(functionResponse.name == "get_weather")
+      #expect(functionResponse.response?["result"] == .string(jsonString))
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+
+    func translatesToolOutputWithStructuredSegmentUnpackingDirectly() throws {
+      let content = try GeneratedContent(json: "{\"temperature\":22}")
+      let structuredSegment = Transcript.StructuredSegment(
+        id: "seg-1",
+        schemaName: "Weather",
+        content: content
+      )
+      let toolOutput = Transcript.ToolOutput(
+        id: "call-1",
+        toolName: "get_weather",
+        segments: [.structure(structuredSegment)]
+      )
+      let transcript = Transcript(entries: [.toolOutput(toolOutput)])
+
+      let result = try GeminiTranscriptTranslator.translate(transcript)
+
+      let userParts = try #require(result.contents.first?.parts)
+      guard case .functionResponse(let functionResponse) = userParts.first?.data else {
+        Issue.record("Expected functionResponse part data")
+        return
+      }
+      #expect(functionResponse.id == "call-1")
+      #expect(functionResponse.name == "get_weather")
+      #expect(functionResponse.response?["temperature"] == .number(22))
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func coalescesParallelToolCallsAndOutputs() throws {
+      let call1 = Transcript.ToolCall(
+        id: "call-1",
+        toolName: "get_weather",
+        arguments: try GeneratedContent(json: "{\"location\":\"Paris\"}")
+      )
+      let call2 = Transcript.ToolCall(
+        id: "call-2",
+        toolName: "get_time",
+        arguments: try GeneratedContent(json: "{\"location\":\"Tokyo\"}")
+      )
+      let output1 = Transcript.ToolOutput(
+        id: "call-1",
+        toolName: "get_weather",
+        segments: [.text(Transcript.TextSegment(content: "22°C"))]
+      )
+      let output2 = Transcript.ToolOutput(
+        id: "call-2",
+        toolName: "get_time",
+        segments: [.text(Transcript.TextSegment(content: "15:00"))]
+      )
+      let transcript = Transcript(
+        entries: [
+          .toolCalls(Transcript.ToolCalls(id: "calls-1", [call1, call2])),
+          .toolOutput(output1),
+          .toolOutput(output2),
+        ]
+      )
+
+      let result = try GeminiTranscriptTranslator.translate(transcript)
+
+      #expect(result.contents.count == 2)
+      #expect(result.contents[0].role == "model")
+      let modelParts = try #require(result.contents[0].parts)
+      #expect(modelParts.count == 2)
+      guard case .functionCall(let fc1) = modelParts[0].data,
+        case .functionCall(let fc2) = modelParts[1].data
+      else {
+        Issue.record("Expected two functionCall parts")
+        return
+      }
+      #expect(fc1.id == "call-1")
+      #expect(fc2.id == "call-2")
+      #expect(result.contents[1].role == "user")
+      let userParts = try #require(result.contents[1].parts)
+      #expect(userParts.count == 2)
+      guard case .functionResponse(let fr1) = userParts[0].data,
+        case .functionResponse(let fr2) = userParts[1].data
+      else {
+        Issue.record("Expected two functionResponse parts in single user turn")
+        return
+      }
+      #expect(fr1.id == "call-1")
+      #expect(fr2.id == "call-2")
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesToolCallsWithEmptyArguments() throws {
+      let call = Transcript.ToolCall(
+        id: "call-1",
+        toolName: "get_time",
+        arguments: try GeneratedContent(json: "{}")
+      )
+      let transcript = Transcript(
+        entries: [.toolCalls(Transcript.ToolCalls(id: "calls-1", [call]))]
+      )
+
+      let result = try GeminiTranscriptTranslator.translate(transcript)
+
+      let modelParts = try #require(result.contents.first?.parts)
+      #expect(modelParts.count == 1)
+      guard case .functionCall(let functionCall) = modelParts[0].data else {
+        Issue.record("Expected functionCall part")
+        return
+      }
+      #expect(functionCall.id == "call-1")
+      #expect(functionCall.name == "get_time")
+      #expect(functionCall.args == nil)
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func coalescesReasoningAndToolCallsIntoSingleModelTurn() throws {
+      let signatureData = Data("test-sig".utf8)
+      let call = Transcript.ToolCall(
+        id: "call-1",
+        toolName: "get_weather",
+        arguments: try GeneratedContent(json: "{\"location\":\"Paris\"}")
+      )
+      let transcript = Transcript(
+        entries: [
+          .prompt(Transcript.Prompt(segments: [.text(Transcript.TextSegment(content: "Hi."))])),
+          .reasoning(
+            Transcript.Reasoning(
+              segments: [.text(Transcript.TextSegment(content: "Need to check weather."))],
+              signature: signatureData
+            )
+          ),
+          .toolCalls(Transcript.ToolCalls(id: "calls-1", [call])),
+        ]
+      )
+
+      let result = try GeminiTranscriptTranslator.translate(transcript)
+
+      #expect(result.contents.count == 2)
+      #expect(result.contents[0].role == "user")
+      #expect(result.contents[1].role == "model")
+      let modelParts = try #require(result.contents[1].parts)
+      #expect(modelParts.count == 2)
+      #expect(modelParts[0].thought == true)
+      #expect(modelParts[0].thoughtSignature == nil)
+      #expect(modelParts[0].data == .text("Need to check weather."))
+      #expect(modelParts[1].thoughtSignature == "test-sig")
+      guard case .functionCall(let functionCall) = modelParts[1].data else {
+        Issue.record("Expected functionCall part")
+        return
+      }
+      #expect(functionCall.id == "call-1")
+      #expect(functionCall.name == "get_weather")
+    }
+
+    @Generable
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct City {
+      var name: String
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func instructionsWithToolDefinitionsTranslatesCleanly() throws {
+      let toolDefinition = Transcript.ToolDefinition(
+        name: "get_weather",
+        description: "Get weather",
+        parameters: City.generationSchema
+      )
+      let transcript = Transcript(
+        entries: [
+          .instructions(
+            Transcript.Instructions(
+              segments: [.text(Transcript.TextSegment(content: "Be concise."))],
+              toolDefinitions: [toolDefinition]
+            )
+          ),
+          .prompt(Transcript.Prompt(segments: [.text(Transcript.TextSegment(content: "Hello"))])),
+        ]
+      )
+
+      let result = try GeminiTranscriptTranslator.translate(transcript)
+
+      let systemInstruction = try #require(result.systemInstruction)
+      #expect(systemInstruction.parts?.first?.data == Part.PartData.text("Be concise."))
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesToolOutputWithMultipleSegmentsIntoMultipleParts() throws {
+      let toolOutput = Transcript.ToolOutput(
+        id: "call-1",
+        toolName: "get_weather",
+        segments: [
+          .text(Transcript.TextSegment(content: "Part 1")),
+          .text(Transcript.TextSegment(content: "Part 2")),
+        ]
+      )
+      let transcript = Transcript(entries: [.toolOutput(toolOutput)])
+
+      let result = try GeminiTranscriptTranslator.translate(transcript)
+
+      let userParts = try #require(result.contents.first?.parts)
+      #expect(userParts.count == 2)
+      guard case .functionResponse(let fr1) = userParts[0].data,
+        case .functionResponse(let fr2) = userParts[1].data
+      else {
+        Issue.record("Expected functionResponse part data for both segments")
+        return
+      }
+      #expect(fr1.id == "call-1")
+      #expect(fr1.name == "get_weather")
+      #expect(fr1.response?["result"] == .string("Part 1"))
+      #expect(fr2.id == "call-1")
+      #expect(fr2.name == "get_weather")
+      #expect(fr2.response?["result"] == .string("Part 2"))
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func translatesToolOutputWithAttachmentThrowsUnsupportedTranscriptContent() throws {
+      let imageAttachment = Transcript.ImageAttachment(
+        imageURL: URL(fileURLWithPath: "/tmp/test.png")
+      )
+      let attachment = Transcript.Segment.attachment(
+        Transcript.AttachmentSegment(
+          id: "att-1",
+          content: .image(imageAttachment)
+        )
+      )
+      let toolOutput = Transcript.ToolOutput(
+        id: "call-1",
+        toolName: "get_weather",
+        segments: [
+          .text(Transcript.TextSegment(content: "Here is the image:")),
+          attachment,
+        ]
+      )
+      let transcript = Transcript(entries: [.toolOutput(toolOutput)])
+
+      do {
+        _ = try GeminiTranscriptTranslator.translate(transcript)
+        Issue.record("Expected unsupportedTranscriptContent error")
+      } catch LanguageModelError.unsupportedTranscriptContent {
+        // Expected
+      } catch {
+        Issue.record("Unexpected error thrown: \(error)")
+      }
+    }
+
+    @Test
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func emptyToolCallsDoesNotDropPendingReasoningSignature() throws {
+      let signatureData = Data("test-sig".utf8)
+      let prompt = Transcript.Prompt(
+        segments: [.text(Transcript.TextSegment(content: "Hi"))]
+      )
+      let reasoning = Transcript.Reasoning(
+        segments: [.text(Transcript.TextSegment(content: "Thinking..."))],
+        signature: signatureData
+      )
+      let emptyToolCalls = Transcript.ToolCalls(id: "calls-empty", [])
+      let finalResponse = Transcript.Response(
+        segments: [.text(Transcript.TextSegment(content: "Hello!"))]
+      )
+      let transcript = Transcript(
+        entries: [
+          .prompt(prompt),
+          .reasoning(reasoning),
+          .toolCalls(emptyToolCalls),
+          .response(finalResponse),
+        ]
+      )
+
+      let result = try GeminiTranscriptTranslator.translate(transcript)
+
+      let modelTurn = try #require(result.contents.last)
+      let modelParts = try #require(modelTurn.parts)
+      #expect(modelParts.first?.thoughtSignature == "test-sig")
+    }
   }
 #endif  // canImport(FoundationModels) && compiler(>=6.4)

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/IntegrationTests/README.md
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/IntegrationTests/README.md
@@ -7,7 +7,13 @@ remote Gemini and Firebase AI Logic backends.
 
 ```bash
 # Run integration tests (using environment variables or GoogleService-Info.plist)
-swift test --filter BasicContentGenerationIntegrationTests
+swift test --filter IntegrationTests
+
+# Run a specific integration test suite
+swift test --filter ToolCallingIntegrationTests
+
+# Run all unit tests (fast, skips all integration tests)
+swift test --skip Integration
 ```
 
 ## Running Integration Tests
@@ -51,6 +57,11 @@ All integration tests are parameterized across
   Parameterized integration tests for guided generation (structured outputs)
   using `@Generable` types, including single-turn and streaming generation,
   enum classification, and rich multi-type recursive hierarchies.
+* [`ToolCallingIntegrationTests.swift`](ToolCallingIntegrationTests.swift):
+  Parameterized integration tests for tool calling (function calling) using
+  FoundationModels `Tool` definitions, covering single-turn tool calls,
+  sequential tool calls, parallel tool calls, tool calling mode configuration,
+  parameterless tools with empty arguments, and reasoning models.
 * [`IntegrationTestingBackend+GeminiLanguageModel.swift`](IntegrationTestingBackend+GeminiLanguageModel.swift):
   Convenience extension providing `backend.makeModel()` to instantiate a
   pre-configured `GeminiLanguageModel`.

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/IntegrationTests/ToolCallingIntegrationTests.swift
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/IntegrationTests/ToolCallingIntegrationTests.swift
@@ -1,0 +1,249 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(FoundationModels) && compiler(>=6.4)
+  import Foundation
+  import FoundationModels
+  import GeminiAPIClient
+  import GeminiTestUtilities
+  import Testing
+
+  @testable import GeminiLanguageModel
+
+  /// Integration tests for tool calling using `GeminiLanguageModel`.
+  @Suite("Tool Calling Integration Tests", .requireFoundationModels)
+  struct ToolCallingIntegrationTests {
+    /// A tool that provides mock weather information for a given city.
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct WeatherTool: FoundationModels.Tool {
+      let name = "getWeather"
+      let description = "Get the current weather for a city."
+
+      @Generable
+      @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+      @available(tvOS, unavailable)
+      struct Arguments {
+        @Guide(description: "The city name to look up weather for")
+        var city: String
+      }
+
+      func call(arguments: Arguments) async throws -> String {
+        "The current weather in \(arguments.city) is 72°F and sunny."
+      }
+    }
+
+    /// A tool that provides the current time and takes no arguments.
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    @available(tvOS, unavailable)
+    struct CurrentTimeTool: FoundationModels.Tool {
+      let name = "getCurrentTime"
+      let description = "Get the current time."
+
+      @Generable
+      @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+      @available(tvOS, unavailable)
+      struct Arguments {}
+
+      func call(arguments: Arguments) async throws -> String {
+        "12:00 PM UTC"
+      }
+    }
+
+    @Test(
+      .tags(.integration),
+      .requireIntegrationTestingBackend,
+      arguments: IntegrationTestingBackend.availableBackends
+    )
+
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func sessionRespondSingleToolCall(backend: IntegrationTestingBackend) async throws {
+      let model = try await backend.makeModel()
+      let session = LanguageModelSession(
+        model: model,
+        tools: [WeatherTool()]
+      )
+
+      let response = try await session.respond(
+        to: "What is the weather in Paris right now?"
+      )
+
+      #expect(!response.content.isEmpty)
+      let containsExpected =
+        response.content.localizedCaseInsensitiveContains("Paris")
+        || response.content.contains("72")
+      #expect(containsExpected)
+      let hasToolCalls = session.transcript.contains { entry in
+        if case .toolCalls = entry { return true }
+        return false
+      }
+      #expect(hasToolCalls)
+      let hasToolOutput = session.transcript.contains { entry in
+        if case .toolOutput = entry { return true }
+        return false
+      }
+      #expect(hasToolOutput)
+      #expect(response.usage.totalTokenCount > 0)
+    }
+
+    @Test(
+      .tags(.integration),
+      .requireIntegrationTestingBackend,
+      arguments: IntegrationTestingBackend.availableBackends
+    )
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func sessionRespondToolWithEmptyArguments(backend: IntegrationTestingBackend) async throws {
+      let model = try await backend.makeModel()
+      let session = LanguageModelSession(
+        model: model,
+        tools: [CurrentTimeTool()]
+      )
+
+      let response = try await session.respond(to: "What time is it right now?")
+
+      #expect(!response.content.isEmpty)
+      let containsExpected =
+        response.content.localizedCaseInsensitiveContains("12:00")
+        || response.content.localizedCaseInsensitiveContains("PM")
+      #expect(containsExpected)
+      let hasToolCalls = session.transcript.contains { entry in
+        if case .toolCalls = entry { return true }
+        return false
+      }
+      #expect(hasToolCalls)
+      let hasToolOutput = session.transcript.contains { entry in
+        if case .toolOutput = entry { return true }
+        return false
+      }
+      #expect(hasToolOutput)
+      #expect(response.usage.totalTokenCount > 0)
+    }
+
+    @Test(
+      .tags(.integration),
+      .requireIntegrationTestingBackend,
+      arguments: IntegrationTestingBackend.availableBackends
+    )
+
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func sessionRespondSequentialToolCalls(backend: IntegrationTestingBackend) async throws {
+      let model = try await backend.makeModel()
+      let session = LanguageModelSession(
+        model: model,
+        tools: [WeatherTool()]
+      )
+
+      _ = try await session.respond(to: "What is the weather in Seattle?")
+
+      let secondResponse = try await session.respond(to: "What about in Miami?")
+
+      #expect(!secondResponse.content.isEmpty)
+      let containsMiamiOrTemp =
+        secondResponse.content.localizedCaseInsensitiveContains("Miami")
+        || secondResponse.content.contains("72")
+      #expect(containsMiamiOrTemp)
+      let toolCallCount = session.transcript.filter { entry in
+        if case .toolCalls = entry { return true }
+        return false
+      }.count
+      #expect(toolCallCount >= 2)
+    }
+
+    @Test(
+      .tags(.integration),
+      .requireIntegrationTestingBackend,
+      arguments: IntegrationTestingBackend.availableBackends
+    )
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func sessionRespondParallelToolCalls(backend: IntegrationTestingBackend) async throws {
+      let model = try await backend.makeModel()
+      let session = LanguageModelSession(
+        model: model,
+        tools: [WeatherTool()]
+      )
+
+      let response = try await session.respond(
+        to: "What is the weather in Tokyo and in London right now? Compare both."
+      )
+
+      #expect(!response.content.isEmpty)
+      #expect(response.content.localizedCaseInsensitiveContains("Tokyo"))
+      #expect(response.content.localizedCaseInsensitiveContains("London"))
+      let hasToolCalls = session.transcript.contains { entry in
+        if case .toolCalls = entry { return true }
+        return false
+      }
+      #expect(hasToolCalls)
+    }
+
+    @Test(
+      .tags(.integration),
+      .requireIntegrationTestingBackend,
+      arguments: IntegrationTestingBackend.availableBackends
+    )
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func sessionRespondToolCallingModeDisallowed(
+      backend: IntegrationTestingBackend
+    ) async throws {
+      let model = try await backend.makeModel()
+      let session = LanguageModelSession(
+        model: model,
+        tools: [WeatherTool()]
+      )
+
+      let response = try await session.respond(
+        to: "What is the weather in Boston?",
+        options: GenerationOptions(toolCallingMode: .disallowed)
+      )
+
+      #expect(!response.content.isEmpty)
+      let hasToolCalls = session.transcript.contains { entry in
+        if case .toolCalls = entry { return true }
+        return false
+      }
+      #expect(!hasToolCalls)
+    }
+
+    @Test(
+      .tags(.integration),
+      .requireIntegrationTestingBackend,
+      arguments: IntegrationTestingBackend.availableBackends
+    )
+    @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
+    func sessionRespondWithReasoningAndToolCalls(
+      backend: IntegrationTestingBackend
+    ) async throws {
+      let model = try await backend.makeModel(modelID: ModelResource.gemini38FlashID)
+      let session = LanguageModelSession(
+        model: model,
+        tools: [WeatherTool()]
+      )
+
+      let response = try await session.respond(
+        to: "What is the weather in Chicago?"
+      )
+
+      #expect(!response.content.isEmpty)
+      let containsChicagoOrTemp =
+        response.content.localizedCaseInsensitiveContains("Chicago")
+        || response.content.contains("72")
+      #expect(containsChicagoOrTemp)
+      let hasToolCalls = session.transcript.contains { entry in
+        if case .toolCalls = entry { return true }
+        return false
+      }
+      #expect(hasToolCalls)
+    }
+  }
+#endif  // canImport(FoundationModels) && compiler(>=6.4)

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/IntegrationTests/ToolCallingIntegrationTests.swift
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/IntegrationTests/ToolCallingIntegrationTests.swift
@@ -22,7 +22,11 @@
   @testable import GeminiLanguageModel
 
   /// Integration tests for tool calling using `GeminiLanguageModel`.
-  @Suite("Tool Calling Integration Tests", .requireFoundationModels)
+  @Suite(
+    "Tool Calling Integration Tests",
+    .requireFoundationModels,
+    .tags(.integration)
+  )
   struct ToolCallingIntegrationTests {
     /// A tool that provides mock weather information for a given city.
     @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
@@ -62,11 +66,9 @@
     }
 
     @Test(
-      .tags(.integration),
       .requireIntegrationTestingBackend,
       arguments: IntegrationTestingBackend.availableBackends
     )
-
     @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
     func sessionRespondSingleToolCall(backend: IntegrationTestingBackend) async throws {
       let model = try await backend.makeModel()
@@ -98,7 +100,6 @@
     }
 
     @Test(
-      .tags(.integration),
       .requireIntegrationTestingBackend,
       arguments: IntegrationTestingBackend.availableBackends
     )
@@ -131,11 +132,9 @@
     }
 
     @Test(
-      .tags(.integration),
       .requireIntegrationTestingBackend,
       arguments: IntegrationTestingBackend.availableBackends
     )
-
     @available(macOS 27.0, iOS 27.0, watchOS 27.0, visionOS 27.0, *)
     func sessionRespondSequentialToolCalls(backend: IntegrationTestingBackend) async throws {
       let model = try await backend.makeModel()
@@ -161,7 +160,6 @@
     }
 
     @Test(
-      .tags(.integration),
       .requireIntegrationTestingBackend,
       arguments: IntegrationTestingBackend.availableBackends
     )
@@ -188,7 +186,6 @@
     }
 
     @Test(
-      .tags(.integration),
       .requireIntegrationTestingBackend,
       arguments: IntegrationTestingBackend.availableBackends
     )
@@ -216,7 +213,6 @@
     }
 
     @Test(
-      .tags(.integration),
       .requireIntegrationTestingBackend,
       arguments: IntegrationTestingBackend.availableBackends
     )

--- a/GeminiLanguageModel/Tests/GeminiLanguageModelTests/README.md
+++ b/GeminiLanguageModel/Tests/GeminiLanguageModelTests/README.md
@@ -18,10 +18,10 @@ swift test --filter GeminiLanguageModelTests
 
 | Suite / File | Scope | Strategy |
 |---|---|---|
-| [`GeminiLanguageModelTests.swift`](GeminiLanguageModelTests.swift) | Protocol conformance, single/multi-turn responses, streaming | Unit (`MockHTTPURLProtocol`) |
+| [`GeminiLanguageModelTests.swift`](GeminiLanguageModelTests.swift) | Protocol conformance, single/multi-turn responses, streaming, tool calling | Unit (`MockHTTPURLProtocol`) |
 | [`GenerationSchema+GeminiTests.swift`](GenerationSchema+GeminiTests.swift) | JSON Schema encoding and property ordering conversion | Unit (pure transformation) |
-| [`GeminiRequestTranslatorTests.swift`](GeminiRequestTranslatorTests.swift) | Request and generation config mapping with schemas | Unit (pure transformation) |
-| [`GeminiTranscriptTranslatorTests.swift`](GeminiTranscriptTranslatorTests.swift) | Apple `Transcript` <-> Gemini payload mapping | Unit (pure transformation) |
+| [`GeminiRequestTranslatorTests.swift`](GeminiRequestTranslatorTests.swift) | Request, generation config, tool declarations, and tool mode mapping | Unit (pure transformation) |
+| [`GeminiTranscriptTranslatorTests.swift`](GeminiTranscriptTranslatorTests.swift) | Apple `Transcript` <-> Gemini payload mapping (tools, reasoning, prompts) | Unit (pure transformation) |
 | [`GeminiErrorMapperTests.swift`](GeminiErrorMapperTests.swift) | HTTP and API error mapping to `LanguageModelError` | Unit (exhaustive mapping) |
 | [`IntegrationTestingBackendTests.swift`](IntegrationTestingBackendTests.swift) | Endpoint resolution and credential discovery | Unit / Infrastructure |
 | [`IntegrationTests/`](IntegrationTests/) | End-to-end Gemini and Firebase AI Logic integration tests | Integration (see [`IntegrationTests/README.md`](IntegrationTests/README.md)) |


### PR DESCRIPTION
Add function calling (tool calling) support to `GeminiLanguageModel` conforming to Apple's FoundationModels framework.

* Added the `.toolCalling` capability to `GeminiLanguageModel`.
* Translates the Foundation Models `ToolDefinition` into a Gemini `Tool` and `FunctionDeclaration` using `parametersJsonSchema`.
* Maps `GenerationOptions.ToolCallingMode` (`.allowed`, `.required`,
  `.disallowed`) to Gemini `FunctionCallingConfig.Mode`.
* Streams function calls in `GeminiLanguageModelExecutor`, forwarding JSON-encoded arguments or empty fallback `"{}"` (omitted by the backend on empty arguments) into channel actions.
* Translates `Transcript` tool calls and tool outputs into Gemini `Content`parts, preserving thought signatures from reasoning models and flushing buffered reasoning thoughts cleanly.
* Unpacks structured tool responses and wrap scalar text tool outputs under the result field (since Foundation Models supports primitives as tool outputs).
* Support parameterless (void) tools with empty arguments across request schema translation, model response handling, and transcript history.
* Add unit tests across `GeminiLanguageModel`, `GeminiRequestTranslator`, and `GeminiTranscriptTranslator`.
* Add end-to-end integration tests covering single-turn, sequential, parallel, disallowed, parameterless, and reasoning tool calling across all supported backends.

#no-changelog