### PR TITLE
test(ai): add GeminiLanguageModel integration test

### DIFF
--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
     - 'FirebaseAI**'
+    - 'GeminiLanguageModel**'
     - '.github/workflows/sdk.ai.yml'
     - '.github/workflows/_spm.yml'
     - '.github/workflows/_cocoapods.yml'
@@ -37,23 +38,26 @@ jobs:
       env_vars: '{"FIREBASE_APP_CHECK_BRANCH": "main"}'
 
   testapp-integration:
+    name: testapp-integration (${{ matrix.name }})
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: macos-15
+          - name: build
+            os: macos-15
             target: iOS
             xcode: Xcode_26.2
             command: build-for-testing
             test_filter_arg: ""
             log_prefix: xcodebuild-build-for-testing
-          - os: macos-26
+          - name: standard
+            os: macos-26
             target: iOS
             # TODO: Bump to 26.4 when "Unable to find a destination matching the provided destination specifier" is resolved.
             xcode: Xcode_26.2
             command: test
-            test_filter_arg: --exclude IntegrationTests-SPM/LiveSessionTests
+            test_filter_arg: --exclude IntegrationTests-SPM/LiveSessionTests --exclude IntegrationTests-SPM/GeminiLanguageModelTests
             log_prefix: xcodebuild
     runs-on: ${{ matrix.os }}
     needs: spm
@@ -105,6 +109,35 @@ jobs:
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: xcodebuild-live-iOS-macos-26-Xcode_26.2.log
+        path: xcodebuild-*.log
+        retention-days: 2
+
+  testapp-integration-gemini-language-model:
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+    runs-on: xcode-27
+    continue-on-error: true
+    needs: spm
+    env:
+      GEMINI_LANGUAGE_MODEL: 1
+      TEST_RUNNER_FIRAAppCheckDebugToken: ${{ secrets.VERTEXAI_INTEGRATION_FAC_DEBUG_TOKEN }}
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+      secrets_passphrase: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FIREBASE_APP_CHECK_BRANCH: main
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        persist-credentials: false
+    - uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      with:
+        path: .build
+        key: ${{ needs.spm.outputs.cache_key }}
+    - name: Run Gemini Language Model integration tests
+      run: scripts/repo.sh test --secrets ./scripts/secrets/AI.json --platforms iOS --xcode Xcode_27.0 --filter IntegrationTests-SPM/GeminiLanguageModelTests AI
+    - name: Upload xcodebuild logs
+      if: failure()
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: xcodebuild-gemini-language-model-iOS-xcode-27-Xcode_27.0.log
         path: xcodebuild-*.log
         retention-days: 2
 

--- a/FirebaseAI/Tests/TestApp/FirebaseAITestApp.xcodeproj/project.pbxproj
+++ b/FirebaseAI/Tests/TestApp/FirebaseAITestApp.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		86E8505B2DBAFBC3002E8D94 /* FirebaseAI in Frameworks */ = {isa = PBXBuildFile; productRef = 86E8505A2DBAFBC3002E8D94 /* FirebaseAI */; };
+		86E8505B2DBAFBC3002E8D94 /* FirebaseAILogic in Frameworks */ = {isa = PBXBuildFile; productRef = 86E8505A2DBAFBC3002E8D94 /* FirebaseAILogic */; };
 		86E8505D2DBAFBC3002E8D94 /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 86E8505C2DBAFBC3002E8D94 /* FirebaseAppCheck */; };
 		86E8505F2DBAFBC3002E8D94 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 86E8505E2DBAFBC3002E8D94 /* FirebaseAuth */; };
 		86E850612DBAFBC3002E8D94 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 86E850602DBAFBC3002E8D94 /* FirebaseStorage */; };
@@ -67,7 +67,7 @@
 				86E8505D2DBAFBC3002E8D94 /* FirebaseAppCheck in Frameworks */,
 				86E850612DBAFBC3002E8D94 /* FirebaseStorage in Frameworks */,
 				86E8505F2DBAFBC3002E8D94 /* FirebaseAuth in Frameworks */,
-				86E8505B2DBAFBC3002E8D94 /* FirebaseAI in Frameworks */,
+				86E8505B2DBAFBC3002E8D94 /* FirebaseAILogic in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -121,7 +121,7 @@
 			);
 			name = "FirebaseAITestApp-SPM";
 			packageProductDependencies = (
-				86E8505A2DBAFBC3002E8D94 /* FirebaseAI */,
+				86E8505A2DBAFBC3002E8D94 /* FirebaseAILogic */,
 				86E8505C2DBAFBC3002E8D94 /* FirebaseAppCheck */,
 				86E8505E2DBAFBC3002E8D94 /* FirebaseAuth */,
 				86E850602DBAFBC3002E8D94 /* FirebaseStorage */,
@@ -513,9 +513,9 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		86E8505A2DBAFBC3002E8D94 /* FirebaseAI */ = {
+		86E8505A2DBAFBC3002E8D94 /* FirebaseAILogic */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = FirebaseAI;
+			productName = FirebaseAILogic;
 		};
 		86E8505C2DBAFBC3002E8D94 /* FirebaseAppCheck */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GeminiLanguageModelTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GeminiLanguageModelTests.swift
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if compiler(>=6.4) && canImport(FoundationModels) && canImport(GeminiLanguageModel)
+  import FirebaseAILogic
+  import FirebaseAITestApp
+  import FirebaseCore
+  import FoundationModels
+  import Testing
+
+  @Suite(.serialized)
+  struct GeminiLanguageModelTests {
+    @Test(arguments: InstanceConfig.defaultConfigs)
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+    func testStreamResponse(_ config: InstanceConfig) async throws {
+      let ai = FirebaseAI.componentInstance(config)
+      let model = ai.geminiLanguageModel(name: ModelNames.gemini3_1_FlashLite)
+      let session = LanguageModelSession(model: model)
+
+      let stream = session.streamResponse {
+        "Tell me a story about a magic backpack."
+      }
+
+      var text = ""
+      for try await snapshot in stream {
+        #expect(snapshot.content.hasPrefix(text))
+        text = snapshot.content
+      }
+      let allText = try await stream.collect().content
+
+      #expect(!text.isEmpty)
+      #expect(text == allText)
+    }
+  }
+#endif // compiler(>=6.4) && canImport(FoundationModels) && canImport(GeminiLanguageModel)

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GeminiLanguageModelTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GeminiLanguageModelTests.swift
@@ -42,23 +42,5 @@
       #expect(!text.isEmpty)
       #expect(text == allText)
     }
-
-    @Test(arguments: InstanceConfig.defaultConfigs)
-    @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
-    func intentionallyFailingTest(_ config: InstanceConfig) async throws {
-      let ai = FirebaseAI.componentInstance(config)
-      let model = ai.geminiLanguageModel(name: ModelNames.gemini3_1_FlashLite)
-      let session = LanguageModelSession(model: model)
-
-      let stream = session.streamResponse {
-        "Hello"
-      }
-      let response = try await stream.collect().content
-
-      Issue.record("""
-      Fake issue - Intentionally failing test to verify that CI is set up correctly. Gemini did \
-      respond with "\(response)" but pretending this failed for verification purposes.
-      """)
-    }
   }
 #endif // compiler(>=6.4) && canImport(FoundationModels) && canImport(GeminiLanguageModel)

--- a/FirebaseAI/Tests/TestApp/Tests/Integration/GeminiLanguageModelTests.swift
+++ b/FirebaseAI/Tests/TestApp/Tests/Integration/GeminiLanguageModelTests.swift
@@ -42,5 +42,23 @@
       #expect(!text.isEmpty)
       #expect(text == allText)
     }
+
+    @Test(arguments: InstanceConfig.defaultConfigs)
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, *)
+    func intentionallyFailingTest(_ config: InstanceConfig) async throws {
+      let ai = FirebaseAI.componentInstance(config)
+      let model = ai.geminiLanguageModel(name: ModelNames.gemini3_1_FlashLite)
+      let session = LanguageModelSession(model: model)
+
+      let stream = session.streamResponse {
+        "Hello"
+      }
+      let response = try await stream.collect().content
+
+      Issue.record("""
+      Fake issue - Intentionally failing test to verify that CI is set up correctly. Gemini did \
+      respond with "\(response)" but pretending this failed for verification purposes.
+      """)
+    }
   }
 #endif // compiler(>=6.4) && canImport(FoundationModels) && canImport(GeminiLanguageModel)

--- a/scripts/repo/Sources/Tests/Test.swift
+++ b/scripts/repo/Sources/Tests/Test.swift
@@ -25,7 +25,7 @@ public struct Test: ParsableCommand {
     commandName: "test",
     abstract: "Run the integration tests for a given SDK.",
     usage: """
-      test [--overwrite] [--secrets <file_path>] [--xcode <version_or_path>] [--platforms <platforms> ...] [--filter <suite_or_function>] [--exclude <suite_or_function>] [<sdk>]
+      test [--overwrite] [--secrets <file_path>] [--xcode <version_or_path>] [--platforms <platforms> ...] [--filter <suite_or_function> ...] [--exclude <suite_or_function> ...] [<sdk>]
 
       test --xcode Xcode_16.4.0 --platforms iOS --platforms macOS AI
       test --xcode "/Applications/Xcode_15.0.0.app" --platforms tvOS Storage
@@ -38,19 +38,19 @@ public struct Test: ParsableCommand {
 
   @Option(
     help: """
-    Optional test target to run against.
+    Optional test target(s) to run against. Repeat this option to filter by multiple targets.
     Can be a test suite or test function identifier (eg; "IntegrationTests-SPM/LiveSessionTests" or "IntegrationTests-SPM/LiveSessionTests/realtime_functionCalling").
     """
   )
-  var filter: String? = nil
+  var filter: [String] = []
 
   @Option(
     help: """
-    Optional test target to exclude from running.
+    Optional test target(s) to exclude from running. Repeat this option to exclude multiple targets.
     Can be a test suite or test function identifier (eg; "IntegrationTests-SPM/LiveSessionTests" or "IntegrationTests-SPM/LiveSessionTests/realtime_functionCalling").
     """
   )
-  var exclude: String? = nil
+  var exclude: [String] = []
 
   static let log: Logger = .init(label: "Test")
 
@@ -59,7 +59,7 @@ public struct Test: ParsableCommand {
   public func validate() throws {
     // filter takes priority with xcodebuild, so we just don't allow them to be used in tandem
     // to avoid any edge case issues
-    if filter != nil && exclude != nil {
+    if !filter.isEmpty && !exclude.isEmpty {
       throw ValidationError(
         "Cannot supply both --filter and --exclude options, please only specify one."
       )
@@ -68,13 +68,13 @@ public struct Test: ParsableCommand {
 
   private func buildExtraArguments() -> [String] {
     var arguments: [String] = []
-    if let filter {
-      arguments.append(contentsOf: ["-only-testing", filter])
-      Self.log.info("Filtering tests", metadata: ["filter": "\(filter)"])
+    for item in filter {
+      arguments.append(contentsOf: ["-only-testing", item])
+      Self.log.info("Filtering tests", metadata: ["filter": "\(item)"])
     }
-    if let exclude {
-      arguments.append(contentsOf: ["-skip-testing", exclude])
-      Self.log.info("Excluding tests", metadata: ["exclude": "\(exclude)"])
+    for item in exclude {
+      arguments.append(contentsOf: ["-skip-testing", item])
+      Self.log.info("Excluding tests", metadata: ["exclude": "\(item)"])
     }
 
     return arguments


### PR DESCRIPTION
Added an integration test in `FirebaseAITestApp` verifying streaming responses using `GeminiLanguageModel` and Foundation Models on supported platforms. Updated the `TestApp` project to link `FirebaseAILogic` instead of `FirebaseAI`.

- Enhanced `scripts/repo` to support array options for `--filter` and `--exclude` so multiple test targets can be passed to the underlying `xcodebuild` command.
- Updated `sdk.ai.yml` to introduce a dedicated integration job running on `xcode-27` with `GEMINI_LANGUAGE_MODEL: 1` and excluding `GeminiLanguageModelTests` from the standard integration runs.
  - Also provided human-readable display names for `testapp-integration` matrix jobs.

#no-changelog