### PR TITLE
fix(ci): remove unused .build cache in AI tests

### DIFF
--- a/.github/workflows/sdk.ai.yml
+++ b/.github/workflows/sdk.ai.yml
@@ -70,10 +70,6 @@ jobs:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         persist-credentials: false
-    - uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-      with:
-        path: .build
-        key: ${{ needs.spm.outputs.cache_key }}
     - name: Run integration tests
       run: scripts/repo.sh ${{ matrix.command }} --secrets ./scripts/secrets/AI.json --platforms ${{ matrix.target }} --xcode ${{ matrix.xcode }} ${{ matrix.test_filter_arg }} AI
     - name: Upload xcodebuild logs
@@ -98,10 +94,6 @@ jobs:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         persist-credentials: false
-    - uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-      with:
-        path: .build
-        key: ${{ needs.spm.outputs.cache_key }}
     - name: Run live integration tests
       run: scripts/repo.sh test --secrets ./scripts/secrets/AI.json --platforms iOS --xcode Xcode_26.2 --filter IntegrationTests-SPM/LiveSessionTests AI
     - name: Upload xcodebuild logs
@@ -127,10 +119,6 @@ jobs:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         persist-credentials: false
-    - uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-      with:
-        path: .build
-        key: ${{ needs.spm.outputs.cache_key }}
     - name: Run Gemini Language Model integration tests
       run: scripts/repo.sh test --secrets ./scripts/secrets/AI.json --platforms iOS --xcode Xcode_27.0 --filter IntegrationTests-SPM/GeminiLanguageModelTests AI
     - name: Upload xcodebuild logs


### PR DESCRIPTION
Removes the unused `actions/cache/restore` step for `.build` from the AI integration test jobs in `.github/workflows/sdk.ai.yml` (`testapp-integration`, `testapp-integration-live`, and `testapp-integration-gemini-language-model`).

### Why this step was unnecessary
The integration test jobs invoke `scripts/repo.sh`, which builds and executes `FirebaseAITestApp.xcodeproj` via `xcodebuild`:

1. **`xcodebuild` does not use `./.build`**: Xcode SPM resolves, clones, and compiles package dependencies into `~/Library/Caches/org.swift.swiftpm` and `<DerivedData>/SourcePackages`. It never inspects or uses the repository root's `./.build` folder generated by `swift package resolve`.
2. **`scripts/repo` does not use `./.build`**: The `repo` CLI runner executes with `--package-path scripts/repo`, maintaining its own build cache in `scripts/repo/.build`.

Restoring the root `.build` cache downloaded and extracted hundreds of megabytes of unused checkouts in each of the 4 runner jobs, taking 30–60 seconds per job without accelerating the builds. Removing this step saves roughly 2–4 minutes of total runner compute time per workflow run.

#no-changelog