### PR TITLE
chore(ci): migrate 3 jobs to ubuntu-latest

### DIFF
--- a/.github/workflows/infra.danger.yml
+++ b/.github/workflows/infra.danger.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   danger:
     if: github.event.pull_request.head.repo.fork == false
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/sdk.firestore.yml
+++ b/.github/workflows/sdk.firestore.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.firestore_src_changes.outputs.sources == 'true' || steps.related_changes.outputs.other_changes == 'true' }}
     steps:
@@ -103,7 +103,9 @@ jobs:
     if: |
       (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') ||
       (github.event_name == 'pull_request' && needs.changes.outputs.changed == 'true')
-    runs-on: macos-26
+    runs-on: ubuntu-latest
+    env:
+      MINT_PATH: ${{ github.workspace }}/mint
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
@@ -113,11 +115,24 @@ jobs:
       with:
         python-version: 3.11
 
+    - name: Cache Mint packages
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      with:
+        path: ${{ env.MINT_PATH }}
+        key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
+        restore-keys: ${{ runner.os }}-mint-
+
     - name: Setup check
-      run: scripts/setup_check.sh
+      run: |
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        scripts/setup_check.sh
 
     - name: Run check
-      run: scripts/check.sh --test-only
+      run: |
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        # Add Homebrew clang-format to first in PATH
+        export PATH="/home/linuxbrew/.linuxbrew/opt/clang-format/bin:$PATH"
+        scripts/check.sh --test-only
 
   cmake:
     needs: [changes, check]


### PR DESCRIPTION
Migrates three CI jobs from macOS runners (`macos-15` / `macos-26`) to `ubuntu-latest`:
1. `danger` in `.github/workflows/infra.danger.yml`
2. `changes` in `.github/workflows/sdk.firestore.yml`
3. `check` in `.github/workflows/sdk.firestore.yml`

## Why These Jobs Can Run on `ubuntu-latest`

- **`infra.danger.yml` (`danger` job)**: This job executes `bundle exec danger` to evaluate the PR diff, assign labels (e.g., `api: auth`), and warn if changelog entries are missing. `Dangerfile` is pure Ruby and interacts only with Git and the GitHub REST API via Octokit. It has no dependencies on Darwin, Xcode, or Apple SDKs.
- **`sdk.firestore.yml` (`changes` job)**: This job runs `actions/checkout` and `dorny/paths-filter` to determine whether any Firestore-related files or dependencies changed. Path matching is completely platform-independent and does not require a macOS runner.
- **`sdk.firestore.yml` (`check` job)**: This job runs `scripts/setup_check.sh` and `scripts/check.sh --test-only` for formatting and linting. The global check workflow (`infra.check.yml`) already runs these identical scripts on `ubuntu-latest`. We updated Firestore's `check` job with the same environment configuration (loading Linuxbrew shell environment and caching Mint packages) to run on Linux.

## Advantages of This Change

- **Faster PR feedback**: Ubuntu runners provision in a few seconds, whereas macOS runners frequently face queue delays during peak hours. Because `infra.danger.yml` and Firestore's `changes` job trigger on every PR push, PR status checks will start and complete substantially faster.
- **Conserves expensive macOS runner minutes**: GitHub Actions repository concurrency limits for macOS runners are much tighter. Offloading tasks that don't need Xcode preserves macOS runners for actual compilation, unit tests, and simulator execution.
- **Preserves fail-fast test gating**: Firestore's heavy test jobs (`cmake`, `sanitizers`, `xcodetest_*`, `pod_lib_lint`, `spm-*`) remain gated behind `check`, preventing expensive 40-minute test jobs from launching if a style or formatting error is present, while no longer tying up a macOS runner for the gate itself.

#no-changelog