### PR TITLE
feat(ai): document and expose GeminiLanguageModel

### DIFF
--- a/FirebaseAI/CHANGELOG.md
+++ b/FirebaseAI/CHANGELOG.md
@@ -1,4 +1,8 @@
 # 12.19.0
+- [feature] **Public Preview**: Added `GeminiLanguageModel`, allowing Gemini
+  models to be used with Apple's Foundation Models framework. See the
+  [getting started guide](https://firebase.google.com/docs/ai-logic/apple-foundation-models-framework/get-started)
+  for more details.
 - [fixed] Fixed an issue with a transitive import in the logger, which could cause
   a build error in explicit module mode. (#16563)
 - [changed] In 12.5.0, the `FirebaseAI` module was renamed to

--- a/FirebaseAI/Sources/Extensions/Public/FirebaseAI+GeminiLanguageModel.swift
+++ b/FirebaseAI/Sources/Extensions/Public/FirebaseAI+GeminiLanguageModel.swift
@@ -16,10 +16,24 @@
   import GeminiLanguageModel
 
   public extension FirebaseAI {
+    /// **[Public Preview]** Creates a ``GeminiLanguageModel`` instance.
+    ///
+    /// > Warning: This API is a public preview and may be subject to change.
+    ///
+    /// The returned model conforms to Apple's
+    /// [`LanguageModel`](https://developer.apple.com/documentation/foundationmodels/languagemodel)
+    /// protocol and can be used with `LanguageModelSession` in Apple's Foundation Models
+    /// framework.
+    ///
+    /// - Parameter name: The identifier of the Gemini model to use; see
+    ///   [available model
+    /// names](https://firebase.google.com/docs/ai-logic/models#available-model-names)
+    ///   for a list of supported model names.
+    /// - Returns: A ``GeminiLanguageModel`` configured for this `FirebaseAI` instance.
     @available(iOS 27.0, macOS 27.0, watchOS 27.0, visionOS 27.0, *)
     @available(tvOS, unavailable)
     func geminiLanguageModel(name: String) -> GeminiLanguageModel {
-      return GeminiLanguageModel(name: name, firebaseAI: self)
+      GeminiLanguageModel(name: name, firebaseAI: self)
     }
   }
 #endif // compiler(>=6.4) && canImport(FoundationModels) && canImport(GeminiLanguageModel)

--- a/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiLanguageModel.swift
+++ b/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiLanguageModel.swift
@@ -31,9 +31,9 @@
   ///
   /// This model conforms to Apple's
   /// [`LanguageModel`](https://developer.apple.com/documentation/foundationmodels/languagemodel)
-  /// protocol and can be used with the Foundation Models framework when [initializing](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/init(model:tools:instructions:))
+  /// protocol and can be used with the Foundation Models framework when [initializing](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/init%28model:tools:instructions:%29)
   /// a [`LanguageModelSession`](https://developer.apple.com/documentation/foundationmodels/languagemodelsession),
-  /// or by [setting the model](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/dynamicprofile/model(_:))
+  /// or by [setting the model](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/dynamicprofile/model%28_%29)
   /// on a [`DynamicProfile`](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/dynamicprofile).
   ///
   /// For more details on using Gemini to generate content with the Foundation Models framework,

--- a/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiLanguageModel.swift
+++ b/GeminiLanguageModel/Sources/GeminiLanguageModel/GeminiLanguageModel.swift
@@ -17,11 +17,33 @@
   public import FoundationModels
   package import GeminiAPIClient
 
-  /// A Gemini language model adapter conforming to Apple's `FoundationModels.LanguageModel`
-  /// protocol.
+  /// **[Public Preview]** A Gemini language model adapter for the Foundation Models framework.
+  ///
+  /// > Warning: This API is a public preview and may be subject to change.
+  ///
+  /// To create an instance of ``GeminiLanguageModel``, use
+  /// ``FirebaseAI/geminiLanguageModel(name:)`` on a ``FirebaseAI`` instance:
+  /// ```swift
+  /// let ai = FirebaseAI.firebaseAI()
+  /// let model = ai.geminiLanguageModel(name: "gemini-model-name")
+  /// let session = LanguageModelSession(model: model)
+  /// ```
+  ///
+  /// This model conforms to Apple's
+  /// [`LanguageModel`](https://developer.apple.com/documentation/foundationmodels/languagemodel)
+  /// protocol and can be used with the Foundation Models framework when [initializing](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/init(model:tools:instructions:))
+  /// a [`LanguageModelSession`](https://developer.apple.com/documentation/foundationmodels/languagemodelsession),
+  /// or by [setting the model](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/dynamicprofile/model(_:))
+  /// on a [`DynamicProfile`](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/dynamicprofile).
+  ///
+  /// For more details on using Gemini to generate content with the Foundation Models framework,
+  /// see the getting started
+  /// [guide](https://firebase.google.com/docs/ai-logic/apple-foundation-models-framework/get-started).
   @available(iOS 27.0, macOS 27.0, watchOS 27.0, visionOS 27.0, *)
   @available(tvOS, unavailable)
   public struct GeminiLanguageModel: Sendable {
+    /// The configuration for the executor responsible for translating Foundation Models requests to
+    /// Gemini API calls.
     public let executorConfiguration: Executor.Configuration
 
     /// Initializes a new Gemini language model.

--- a/Package.swift
+++ b/Package.swift
@@ -1699,9 +1699,7 @@ func firebaseAILogicDependencies() -> [Target.Dependency] {
   ]
 
   #if compiler(>=6.4) && canImport(FoundationModels)
-    if Context.environment["GEMINI_LANGUAGE_MODEL"] != nil {
-      dependencies.append("GeminiLanguageModel")
-    }
+    dependencies.append("GeminiLanguageModel")
   #endif // compiler(>=6.4) && canImport(FoundationModels)
 
   return dependencies
@@ -1709,10 +1707,6 @@ func firebaseAILogicDependencies() -> [Target.Dependency] {
 
 #if compiler(>=6.4) && canImport(FoundationModels)
   func geminiLanguageModelTargets() -> [Target] {
-    guard Context.environment["GEMINI_LANGUAGE_MODEL"] != nil else {
-      return []
-    }
-
     let swiftSettings: [SwiftSetting] = [
       .enableUpcomingFeature("ExistentialAny"),
       .enableUpcomingFeature("InternalImportsByDefault"),


### PR DESCRIPTION
Exposes `GeminiLanguageModel` for public preview and adds developer-facing DocC documentation for using Gemini with Apple's Foundation Models framework.

* **Expose in SwiftPM**: Removed the `GEMINI_LANGUAGE_MODEL` environment variable check in `Package.swift` so targets and dependencies build unconditionally on Swift 6.4+ when `FoundationModels` is available.
* **DocC Documentation**: Added documentation comments to `GeminiLanguageModel` and `FirebaseAI.geminiLanguageModel(name:)`, including usage examples with `LanguageModelSession`, public preview callouts, and guide links.
* **CHANGELOG**: Added a public preview entry in `FirebaseAI/CHANGELOG.md`.