### PR TITLE
test: Update Package.swift with staged artifacts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1468,6 +1468,8 @@ func abseilDependency() -> Package.Dependency {
       "https://github.com/google/abseil-cpp-binary.git",
       "1.2025051201.0" ..< "1.2025051202.0"
     )
+    // TODO: Delete following line before merging.
+    return .package(url: packageInfo.url, revision: "c473b33da325bd2cb854ae7834fc63f9a5563464")
   }
 
   return .package(url: packageInfo.url, packageInfo.range)
@@ -1482,6 +1484,8 @@ func grpcDependency() -> Package.Dependency {
     packageInfo = ("https://github.com/grpc/grpc-ios.git", "1.83.1" ..< "1.84.0")
   } else {
     packageInfo = ("https://github.com/google/grpc-binary.git", "1.83.1" ..< "1.84.0")
+    // TODO: Delete following line before merging.
+    return .package(url: packageInfo.url, revision: "913d0ec56488611e32dc7a7291e627f467299aec")
   }
 
   return .package(url: packageInfo.url, packageInfo.range)
@@ -1632,8 +1636,8 @@ func firestoreTargets() -> [Target] {
     } else {
       return .binaryTarget(
         name: "FirebaseFirestoreInternal",
-        url: "https://dl.google.com/firebase/ios/bin/firestore/12.17.0/rc0/FirebaseFirestoreInternal.zip",
-        checksum: "26a8f4b5b2b454b2caf002296da08d71f241628ec27e1610b5b5a8fd5c61feb5"
+        url: "https://dl.google.com/firebase/ios/bin/firestore/13.0.0/pre_rc0/FirebaseFirestoreInternal.zip",
+        checksum: "dfbae6d47d6a427c31928db562344204e55a6af0c036a203c5dee8562d75b7d5"
       )
     }
   }()


### PR DESCRIPTION
Depends on:
- https://github.com/google/grpc-binary/pull/24
- https://github.com/google/abseil-cpp-binary/pull/17

Artifacts:
* FirebaseFirestoreInternal
  * url: "https://dl.google.com/firebase/ios/bin/firestore/13.0.0/pre_rc0/FirebaseFirestoreInternal.zip",
  * checksum: "dfbae6d47d6a427c31928db562344204e55a6af0c036a203c5dee8562d75b7d5"
* absl
  * url: "https://dl.google.com/firebase/ios/bin/abseil/1.2025051202.0/pre_rc0/absl.zip",
  * checksum: "4c25c03e2e33306844c5cdb1278910bf048d7ffe86c7a30379d9d1448722325d"
* grpc
  * url: "https://dl.google.com/firebase/ios/bin/grpc/1.83.1/pre_rc0/grpc.zip",
  * checksum: "33d1bf4ad10e681da3c3611ae7f7c7c00960e39e055f4f8f260d7eefad7b0129"
* grpcpp
  * url: "https://dl.google.com/firebase/ios/bin/grpc/1.83.1/pre_rc0/grpcpp.zip",
  * checksum: "021f587e07cba008183dcbbc547ff3cd342aa6e9b9aa9c82225e9ba8a5c262fa"
* openssl_grpc
  * url: "https://dl.google.com/firebase/ios/bin/grpc/1.83.1/pre_rc0/openssl_grpc.zip",
  * checksum: "645757320d32c2216d8bc9cfa2142f308de10d1f58608c942659a43c20ddea33"